### PR TITLE
Support non-linear flows containing `branch` and `join`; Use s3 as datastore to integrate and use state in running flows on KFP

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -31,7 +31,8 @@ from .event_logger import EventLogger
 from .monitor import Monitor
 
 from .plugins.kfp.kfp import create_run_on_kfp, create_kfp_pipeline_yaml
-from .plugins.kfp.constants import DEFAULT_RUN_NAME, DEFAULT_EXPERIMENT_NAME, DEFAULT_FLOW_CODE_URL, DEFAULT_KFP_YAML_OUTPUT_PATH, RUN_LINK_PREFIX
+from .plugins.kfp.constants import DEFAULT_RUN_NAME, DEFAULT_EXPERIMENT_NAME, DEFAULT_FLOW_CODE_URL, DEFAULT_KFP_YAML_OUTPUT_PATH
+from metaflow.metaflow_config import KFP_RUN_URL_PREFIX
 
 ERASE_TO_EOL = '\033[K'
 HIGHLIGHT = 'red'
@@ -698,7 +699,7 @@ def run_on_kfp(obj,
 
     run_pipeline_result = create_run_on_kfp(obj.graph, code_url, experiment_name, run_name)
     echo("\nRun created successfully!\n")
-    echo("Run link: {0}{1}".format(RUN_LINK_PREFIX, run_pipeline_result.run_id))
+    echo("Run link: {0}{1}".format(KFP_RUN_URL_PREFIX, run_pipeline_result.run_id))
 
 
 @cli.command(help='Generate the KFP YAML which is used to run the workflow on Kubeflow Pipelines.')

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -436,13 +436,6 @@ def step(obj,
 
     echo('Success', fg='green', bold=True, indent=True)
 
-    # Note: Leaving below statement as we use it to run and test the flow easily using CLI (locally) and to demo
-    # the ability to orchestrate without using the MF local orchestrator.
-    # TODO: Remove this once we've fully tested out MF on KFP
-    # FORMAT: ($1)datastore_root location \t ($2)run_id \t ($3)next_step_to_run \t ($4)task_id(of next step) \t ($5)current step \t ($6)task_id(of current step)
-    if step_name != 'end': # End is the final step
-        print(obj.datastore.datastore_root, run_id, obj.flow._graph[step_name].out_funcs[0], int(task_id)+1, step_name, task_id)
-
 @parameters.add_custom_parameters
 @cli.command(help="Internal command to initialize a run.")
 @click.option('--run-id',
@@ -618,9 +611,9 @@ def run(obj,
     write_run_id(run_id_file, runtime.run_id)
 
     parameters.set_parameters(obj.flow, kwargs)
+
     runtime.persist_parameters()
     runtime.execute()
-
 
 @parameters.add_custom_parameters
 @cli.command(help='Set up the initial part of the workflow by instantiating a local runtime and persisting parameters. '
@@ -677,6 +670,7 @@ def pre_start(obj,
     # TODO: Remove once above criteria are met.
     # OUTPUT FORMAT: ($1)datastore_root location \t ($2)run_id \t ($3)next_step_to_run \t ($4)task_id(of next step) \t ($5)current step \t ($6)task_id(of current step)
     print("{0}\t{1}\tstart\t1\t_parameters\t0".format(obj.datastore.datastore_root, runtime.run_id))
+
 
 @cli.command(help='Create a run on KF pipelines. This method converts the MF flow to a KFP run and outputs a link to the KFP run. '
                   'Note: This command will not work as expected if your local environment is not configured to '

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -403,7 +403,8 @@ def step(obj,
         raise CommandException("Function *%s* is not a step." % step_name)
     echo('Executing a step, *%s*' % step_name,
          fg='magenta',
-         bold=False)
+         bold=False,
+         err=False)
 
     obj.datastore.datastore_root = obj.datastore_root
     if obj.datastore.datastore_root is None:
@@ -434,7 +435,7 @@ def step(obj,
                       retry_count,
                       max_user_code_retries)
 
-    echo('Success', fg='green', bold=True, indent=True)
+    echo('Success', fg='green', bold=True, indent=True, err=False)
 
 @parameters.add_custom_parameters
 @cli.command(help="Internal command to initialize a run.")
@@ -611,7 +612,6 @@ def run(obj,
     write_run_id(run_id_file, runtime.run_id)
 
     parameters.set_parameters(obj.flow, kwargs)
-
     runtime.persist_parameters()
     runtime.execute()
 
@@ -834,9 +834,9 @@ def start(ctx,
 
     ctx.obj.version = metaflow_version.get_version()
 
-    echo('Metaflow %s' % ctx.obj.version, fg='magenta', bold=True, nl=False)
-    echo(" executing *%s*" % ctx.obj.flow.name, fg='magenta', nl=False)
-    echo(" for *%s*" % resolve_identity(), fg='magenta')
+    echo('Metaflow %s' % ctx.obj.version, fg='magenta', bold=True, nl=False, err=False)
+    echo(" executing *%s*" % ctx.obj.flow.name, fg='magenta', nl=False, err=False)
+    echo(" for *%s*" % resolve_identity(), fg='magenta', err=False)
 
     if decospecs:
         decorators._attach_decorators(ctx.obj.flow, decospecs)
@@ -876,8 +876,8 @@ def start(ctx,
     ctx.obj.datastore = DATASTORES[datastore]
     ctx.obj.datastore_root = datastore_root
 
-    echo("Datastore: {0}".format(ctx.obj.datastore))
-    echo("DatastoreRoot: {0}".format(ctx.obj.datastore_root))
+    echo("Datastore: {0}".format(ctx.obj.datastore), err=False)
+    echo("DatastoreRoot: {0}".format(ctx.obj.datastore_root), err=False)
 
     current._set_env(flow_name=ctx.obj.flow.name, is_running=False)
     if ctx.invoked_subcommand not in ('run', 'resume'):

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -876,7 +876,8 @@ def start(ctx,
     ctx.obj.datastore = DATASTORES[datastore]
     ctx.obj.datastore_root = datastore_root
 
-    echo("Datastore: {0}\nDatastoreRoot:{1}".format(ctx.obj.datastore, ctx.obj.datastore_root))
+    echo("Datastore: {0}".format(ctx.obj.datastore))
+    echo("DatastoreRoot: {0}".format(ctx.obj.datastore_root))
 
     current._set_env(flow_name=ctx.obj.flow.name, is_running=False)
     if ctx.invoked_subcommand not in ('run', 'resume'):

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -678,7 +678,6 @@ def pre_start(obj,
     # OUTPUT FORMAT: ($1)datastore_root location \t ($2)run_id \t ($3)next_step_to_run \t ($4)task_id(of next step) \t ($5)current step \t ($6)task_id(of current step)
     print("{0}\t{1}\tstart\t1\t_parameters\t0".format(obj.datastore.datastore_root, runtime.run_id))
 
-
 @cli.command(help='Create a run on KF pipelines. This method converts the MF flow to a KFP run and outputs a link to the KFP run. '
                   'Note: This command will not work as expected if your local environment is not configured to '
                    'connect to a KFP cluster')
@@ -882,6 +881,8 @@ def start(ctx,
                                                   ctx.obj.monitor)
     ctx.obj.datastore = DATASTORES[datastore]
     ctx.obj.datastore_root = datastore_root
+
+    echo("Datastore: {0}\nDatastoreRoot:{1}".format(ctx.obj.datastore, ctx.obj.datastore_root))
 
     current._set_env(flow_name=ctx.obj.flow.name, is_running=False)
     if ctx.invoked_subcommand not in ('run', 'resume'):

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -4,6 +4,7 @@ import inspect
 import traceback
 from functools import wraps
 from datetime import datetime
+import posixpath
 
 import click
 
@@ -699,7 +700,7 @@ def run_on_kfp(obj,
 
     run_pipeline_result = create_run_on_kfp(obj.graph, code_url, experiment_name, run_name)
     echo("\nRun created successfully!\n")
-    echo("Run link: {0}{1}".format(KFP_RUN_URL_PREFIX, run_pipeline_result.run_id))
+    echo("Run link: {0}".format(posixpath.join(KFP_RUN_URL_PREFIX, run_pipeline_result.run_id)))
 
 
 @cli.command(help='Generate the KFP YAML which is used to run the workflow on Kubeflow Pipelines.')

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -141,8 +141,7 @@ if AWS_SANDBOX_ENABLED:
 # being read from old tasks.
 MAX_ATTEMPTS = 6
 
-METAFLOW_AWS_ARN = from_conf('METAFLOW_AWS_ARN', "arn:aws:iam::170606514770:role/dev-zestimate-role")
-
+METAFLOW_AWS_ARN = from_conf('METAFLOW_AWS_ARN')
 
 # the naughty, naughty driver.py imported by lib2to3 produces
 # spam messages to the root logger. This is what is required

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -143,6 +143,7 @@ if AWS_SANDBOX_ENABLED:
 MAX_ATTEMPTS = 6
 
 METAFLOW_AWS_ARN = from_conf('METAFLOW_AWS_ARN')
+METAFLOW_AWS_S3_REGION = from_conf('METAFLOW_AWS_S3_REGION')
 
 # the naughty, naughty driver.py imported by lib2to3 produces
 # spam messages to the root logger. This is what is required
@@ -222,7 +223,7 @@ def get_authenticated_boto3_client(module, params={}):
             time_fetcher=lambda: datetime.now(tzlocal()),
         )
 
-        session = boto3.Session(botocore_session=botocore_session, region_name="us-west-2")
+        session = boto3.Session(botocore_session=botocore_session, region_name=METAFLOW_AWS_S3_REGION)
         return session.client("s3")
 
     return boto3.client(module, **params)

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -145,6 +145,11 @@ MAX_ATTEMPTS = 6
 METAFLOW_AWS_ARN = from_conf('METAFLOW_AWS_ARN')
 METAFLOW_AWS_S3_REGION = from_conf('METAFLOW_AWS_S3_REGION')
 
+# Note: `KFP_RUN_URL_PREFIX` is the URL prefix for KFP runs on your KFP cluster. The prefix includes
+# all parts of the URL except the run_id at the end which we append once the run is created.
+# For eg, this would look like: "https://<your-kf-cluster-url>/pipeline/#/runs/details/"
+KFP_RUN_URL_PREFIX = from_conf('KFP_RUN_URL_PREFIX')
+
 # the naughty, naughty driver.py imported by lib2to3 produces
 # spam messages to the root logger. This is what is required
 # to silence it:

--- a/metaflow/plugins/kfp/constants.py
+++ b/metaflow/plugins/kfp/constants.py
@@ -3,10 +3,11 @@
 # Defaults for running MF on KFP
 # TODO: remove this when we're able to automatically package code and use it on KFP. We currently need the user supplied code URL (or this default URL) in order to download the code that is to be run on KFP
 DEFAULT_FLOW_CODE_URL = 'https://gist.githubusercontent.com/mon95/98d9d88571a0307a53b637d841295702/raw/df8bc1fa363f629271cfc1d34f3c2f7ca0b2e2cf/helloworld.py'
+DEFAULT_DOWNLOADED_FLOW_FILENAME = 'downloaded_flow.py'
+
 DEFAULT_KFP_YAML_OUTPUT_PATH = 'kfp_pipeline.yaml'
 DEFAULT_RUN_NAME = 'run_mf_on_kfp'
 DEFAULT_EXPERIMENT_NAME = 'mf-on-kfp-experiments'
 
 # TODO: This should (probably) be moved outside
 RUN_LINK_PREFIX = "https://kubeflow.corp.zillow-analytics-dev.zg-int.net/pipeline/#/runs/details/"
-

--- a/metaflow/plugins/kfp/constants.py
+++ b/metaflow/plugins/kfp/constants.py
@@ -9,3 +9,4 @@ DEFAULT_EXPERIMENT_NAME = 'mf-on-kfp-experiments'
 
 # TODO: This should (probably) be moved outside
 RUN_LINK_PREFIX = "https://kubeflow.corp.zillow-analytics-dev.zg-int.net/pipeline/#/runs/details/"
+

--- a/metaflow/plugins/kfp/constants.py
+++ b/metaflow/plugins/kfp/constants.py
@@ -11,3 +11,7 @@ DEFAULT_EXPERIMENT_NAME = 'mf-on-kfp-experiments'
 
 # TODO: This should (probably) be moved outside
 RUN_LINK_PREFIX = "https://kubeflow.corp.zillow-analytics-dev.zg-int.net/pipeline/#/runs/details/"
+
+# TODO: Switch out of using this role
+S3_BUCKET = "s3://workspace-zillow-analytics-stage/aip/metaflow"
+S3_AWS_ARN = "arn:aws:iam::170606514770:role/dev-zestimate-role"

--- a/metaflow/plugins/kfp/constants.py
+++ b/metaflow/plugins/kfp/constants.py
@@ -15,3 +15,4 @@ RUN_LINK_PREFIX = "https://kubeflow.corp.zillow-analytics-dev.zg-int.net/pipelin
 # TODO: Switch out of using this role
 S3_BUCKET = "s3://workspace-zillow-analytics-stage/aip/metaflow"
 S3_AWS_ARN = "arn:aws:iam::170606514770:role/dev-zestimate-role"
+S3_AWS_REGION = "us-west-2"

--- a/metaflow/plugins/kfp/constants.py
+++ b/metaflow/plugins/kfp/constants.py
@@ -11,8 +11,3 @@ DEFAULT_EXPERIMENT_NAME = 'mf-on-kfp-experiments'
 
 # TODO: This should (probably) be moved outside
 RUN_LINK_PREFIX = "https://kubeflow.corp.zillow-analytics-dev.zg-int.net/pipeline/#/runs/details/"
-
-# TODO: Switch out of using this role
-S3_BUCKET = "s3://workspace-zillow-analytics-stage/aip/metaflow"
-S3_AWS_ARN = "arn:aws:iam::170606514770:role/dev-zestimate-role"
-S3_AWS_REGION = "us-west-2"

--- a/metaflow/plugins/kfp/constants.py
+++ b/metaflow/plugins/kfp/constants.py
@@ -8,6 +8,3 @@ DEFAULT_DOWNLOADED_FLOW_FILENAME = 'downloaded_flow.py'
 DEFAULT_KFP_YAML_OUTPUT_PATH = 'kfp_pipeline.yaml'
 DEFAULT_RUN_NAME = 'run_mf_on_kfp'
 DEFAULT_EXPERIMENT_NAME = 'mf-on-kfp-experiments'
-
-# TODO: This should (probably) be moved outside
-RUN_LINK_PREFIX = "https://kubeflow.corp.zillow-analytics-dev.zg-int.net/pipeline/#/runs/details/"

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -22,7 +22,7 @@ def step_op_func(python_cmd_template, step_name: str,
     import subprocess
     import os
 
-    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@state-integ-s3'
+    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@branch-and-join'
     DEFAULT_DOWNLOADED_FLOW_FILENAME = 'downloaded_flow.py'
 
     print("\n----------RUNNING: CODE DOWNLOAD from URL---------")
@@ -77,16 +77,17 @@ def step_op_func(python_cmd_template, step_name: str,
 
     print("_______________ Done _________________________________")
 
-def pre_start_op_func(code_url: str)  -> StepOutput:
+
+def initial_setup_op_func(code_url: str)  -> StepOutput:
     """
-    Function used to create a KFP container op (see `pre_start_container_op`)that corresponds to the `pre-start` step of metaflow
+    Function used to create a KFP container op (see `initial_setup_container_op`)that corresponds to the `pre-start` step of metaflow
 
     """
     import subprocess
     import os
     from collections import namedtuple
 
-    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@state-integ-s3'
+    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@branch-and-join'
     DEFAULT_DOWNLOADED_FLOW_FILENAME = 'downloaded_flow.py'
 
     print("\n----------RUNNING: CODE DOWNLOAD from URL---------")
@@ -144,6 +145,7 @@ def pre_start_op_func(code_url: str)  -> StepOutput:
     print("_______________ Done __________________________")
     return StepOutput(outputs[0], outputs[1])
 
+
 def step_container_op():
     """
     Container op that corresponds to a step defined in the Metaflow flowgraph.
@@ -154,15 +156,30 @@ def step_container_op():
     step_op = kfp.components.func_to_container_op(step_op_func, base_image='ssreejith3/mf_on_kfp:python-curl-git')
     return step_op
 
-def pre_start_container_op():
+
+def initial_setup_container_op():
     """
     Container op that corresponds to the 'pre-start' step of Metaflow.
 
     Note: The public docker image is a copy of the internal docker image we were using (borrowed from aip-kfp-example).
     """
 
-    pre_start_op = kfp.components.func_to_container_op(pre_start_op_func, base_image='ssreejith3/mf_on_kfp:python-curl-git')
-    return pre_start_op
+    init_setup_op = kfp.components.func_to_container_op(initial_setup_op_func, base_image='ssreejith3/mf_on_kfp:python-curl-git')
+    return init_setup_op
+
+
+def add_env_variables(container_op):
+    """
+    Add environment variables to the container op.
+
+    """
+
+    S3_BUCKET = V1EnvVar(name="S3_BUCKET", value=S3_BUCKET_VALUE)
+    S3_AWS_ARN = V1EnvVar(name="S3_AWS_ARN", value=S3_AWS_ARN_VALUE)
+    container_op.add_env_variable(S3_BUCKET)
+    container_op.add_env_variable(S3_AWS_ARN)
+    return container_op
+
 
 def create_command_templates_from_graph(graph):
     """
@@ -172,24 +189,26 @@ def create_command_templates_from_graph(graph):
     # Note:
     # Level-order traversal is adopted to keep the task-ids in line with what happens during a local metaflow execution.
     # It is not entirely necessary to keep this order of task-ids if we are able to point to the correct input-paths for
-    # each step. But, using this ordering does keep the organization of data more understandable and natural (i.e., `start`
-    # gets a task id of 1, next step gets a task id of 2 and so on with 'end' step having the highest task id.
+    # each step. But, using this ordering does keep the organization of data in the datastore more understandable and
+    # natural (i.e., `start` gets a task id of 1, next step gets a task id of 2 and so on with 'end' step having the
+    # highest task id. So the paths in the datastore look like: {run-id}/start/1, {run-id}/next-step/2, and so on)
     """
 
-    """
-    Returns the python command template to be used for each step.
-    
-    This method returns a string with placeholders for `datastore_root` and `run_id`
-    which get populated based on the outputs of our initial setup (i.e., when these values are known) in 
-    the pipeline.
-    The rest of the command string is populated using the passed arguments which are known before the run starts.
-    
-    An example constructed command template (to run a step named `hello`):
-    "python downloaded_flow.py --datastore s3 --datastore-root {ds_root} " \
-                     "step hello --run-id {run_id} --task-id 2 " \
-                     "--input-paths {run_id}/start/1"
-    """
     def build_cmd_template(step_name, task_id, input_paths):
+        """
+        Returns the python command template to be used for each step.
+
+        This method returns a string with placeholders for `datastore_root` and `run_id`
+        which get populated based on the outputs of our initial setup (i.e., when these values are known) in
+        the pipeline.
+        The rest of the command string is populated using the passed arguments which are known before the run starts.
+
+        An example constructed command template (to run a step named `hello`):
+        "python downloaded_flow.py --datastore s3 --datastore-root {ds_root} " \
+                         "step hello --run-id {run_id} --task-id 2 " \
+                         "--input-paths {run_id}/start/1"
+        """
+
         python_cmd = "python {downloaded_file_name} --datastore s3 --datastore-root {{ds_root}} " \
                      "step {step_name} --run-id {{run_id}} --task-id {task_id} " \
                      "--input-paths {input_paths}".format(downloaded_file_name=DEFAULT_DOWNLOADED_FLOW_FILENAME,
@@ -197,54 +216,53 @@ def create_command_templates_from_graph(graph):
         return python_cmd
 
     steps_deque = deque(['start']) # deque to process the DAG in level order
-    cur_task_id = 0
+    current_task_id = 0
 
     # set of seen steps, i.e., added to the queue for processing
     seen_steps = set(['start'])
     # Mapping of steps to task ids
-    task_id_map = {}
+    step_to_task_id_map = {}
     # Mapping of steps to their command templates
-    command_template_map = {}
+    step_to_command_template_map = {}
 
     while len(steps_deque) > 0:
-        cur_step = steps_deque.popleft()
-        cur_task_id += 1
-        task_id_map[cur_step] = cur_task_id
-        cur_node = graph.nodes[cur_step]
+        current_step = steps_deque.popleft()
+        current_task_id += 1
+        step_to_task_id_map[current_step] = current_task_id
+        current_node = graph.nodes[current_step]
 
         # Generate the correct input_path for each step. Note: input path depends on a step's parents (i.e., in_funcs)
         # Format of the input-paths for reference:
         # non-join nodes: "run-id/parent-step/parent-task-id",
         # branch-join node: "run-id/:p1/p1-task-id,p2/p2-task-id,..."
         # foreach node: TODO: foreach is not considered here
-        if cur_task_id == 1: # start step
+        if current_task_id == 1: # start step
             cur_input_path = '{run_id}/_parameters/0' # this is the standard input path for the `start` step
         else:
-            if cur_node.type == 'join':
+            if current_node.type == 'join':
                 cur_input_path = '{run_id}/:'
-                for parent in cur_node.in_funcs:
-                    cur_input_path += parent + '/' + str(task_id_map[parent]) + ','
+                for parent_step in current_node.in_funcs:
+                    cur_input_path += "{parent}/{parent_task_id},".format(parent=parent_step,
+                                                                          parent_task_id=str(step_to_task_id_map[parent_step]))
                 cur_input_path = cur_input_path.strip(',')
             else:
-                parent_step = cur_node.in_funcs[0]
-                cur_input_path = '{run_id}/'+ parent_step + '/' + str(task_id_map[parent_step])
+                parent_step = current_node.in_funcs[0]
+                cur_input_path = "{{run_id}}/{parent}/{parent_task_id}".format(parent=parent_step,
+                                                                               parent_task_id=str(step_to_task_id_map[parent_step]))
 
-        command_template_map[cur_step] = build_cmd_template(cur_step, cur_task_id, cur_input_path)
+        step_to_command_template_map[current_step] = build_cmd_template(current_step, current_task_id, cur_input_path)
 
-        for step in cur_node.out_funcs:
+        for step in current_node.out_funcs:
             if step not in seen_steps:
                 steps_deque.append(step)
                 seen_steps.add(step)
 
-    return command_template_map
+    return step_to_command_template_map
 
 
-def create_flow_from_graph(flowgraph, flow_code_url=DEFAULT_FLOW_CODE_URL):
+def create_kfp_pipeline_from_flow_graph(flow_graph, code_url=DEFAULT_FLOW_CODE_URL):
 
-    graph = flowgraph
-    code_url = flow_code_url
-
-    command_template_map = create_command_templates_from_graph(graph)
+    step_to_command_template_map = create_command_templates_from_graph(flow_graph)
 
     @dsl.pipeline(
         name='MF on KFP Pipeline',
@@ -252,54 +270,51 @@ def create_flow_from_graph(flowgraph, flow_code_url=DEFAULT_FLOW_CODE_URL):
                     'with branch and join nodes'
     )
     def kfp_pipeline_from_flow():
-        S3_BUCKET = V1EnvVar(name="S3_BUCKET", value=S3_BUCKET_VALUE)
-        S3_AWS_ARN = V1EnvVar(name="S3_AWS_ARN", value=S3_AWS_ARN_VALUE)
-        pre_start_op = (pre_start_container_op())(code_url).add_env_variable(S3_BUCKET).add_env_variable(S3_AWS_ARN)
-        outputs = pre_start_op.outputs
-
-        container_op_map = {}
-        ds_root = outputs['ds_root']
-        run_id = outputs['run_id']
-
         # Initial setup
-        pre_start_op.set_display_name('InitialSetup')
-        container_op_map['start'] = (step_container_op())(
-                                        command_template_map['start'],
+        initial_setup_op = (initial_setup_container_op())(code_url).set_display_name('InitialSetup')
+        ds_root = initial_setup_op.outputs['ds_root']
+        run_id = initial_setup_op.outputs['run_id']
+
+        step_to_container_op_map = {}
+        step_to_container_op_map['start'] = (step_container_op())(
+                                        step_to_command_template_map['start'],
                                         'start',
                                         code_url,
                                         ds_root,
                                         run_id
-                                        ).add_env_variable(S3_BUCKET).add_env_variable(S3_AWS_ARN)
-        container_op_map['start'].set_display_name('start')
-        container_op_map['start'].after(pre_start_op)
+                                        ).after(initial_setup_op).set_display_name('start')
 
-        for step, cmd in command_template_map.items():
+        # Define container ops for all steps
+        for step, cmd in step_to_command_template_map.items():
             if step != 'start':
-                container_op_map[step] = (step_container_op())(
-                                            command_template_map[step],
+                step_to_container_op_map[step] = (step_container_op())(
+                                            step_to_command_template_map[step],
                                             step,
                                             code_url,
                                             ds_root,
-                                            run_id).add_env_variable(S3_BUCKET).add_env_variable(S3_AWS_ARN)
-                container_op_map[step].set_display_name(step)
+                                            run_id).set_display_name(step)
+
+        # Add environment variables to all ops
+        dsl.get_pipeline_conf().add_op_transformer(add_env_variables)
 
         # Define ordering of container op execution
-        for step in graph.nodes.keys():
+        for step in flow_graph.nodes.keys():
             if step != 'start':
-                for parent in graph.nodes[step].in_funcs:
-                    container_op_map[step].after(container_op_map[parent])
+                for parent in flow_graph.nodes[step].in_funcs:
+                    step_to_container_op_map[step].after(step_to_container_op_map[parent])
+
 
     return kfp_pipeline_from_flow
 
 
-def create_run_on_kfp(flowgraph, code_url, experiment_name, run_name):
+def create_run_on_kfp(flow_graph, code_url, experiment_name, run_name):
     """
     Creates a new run on KFP using the `kfp.Client()`. Note: Intermediate pipeline YAML is not generated as this creates
     the run directly using the pipeline function returned by `create_flow_pipeline`
 
     """
 
-    pipeline_func = create_flow_from_graph(flowgraph, code_url)
+    pipeline_func = create_kfp_pipeline_from_flow_graph(flow_graph, code_url)
     run_pipeline_result = kfp.Client().create_run_from_pipeline_func(pipeline_func,
                                                                      arguments={},
                                                                      experiment_name=experiment_name,
@@ -307,13 +322,13 @@ def create_run_on_kfp(flowgraph, code_url, experiment_name, run_name):
     return run_pipeline_result
 
 
-def create_kfp_pipeline_yaml(flowgraph, code_url, pipeline_file_path=DEFAULT_KFP_YAML_OUTPUT_PATH):
+def create_kfp_pipeline_yaml(flow_graph, code_url, pipeline_file_path=DEFAULT_KFP_YAML_OUTPUT_PATH):
     """
     Creates a new KFP pipeline YAML using `kfp.compiler.Compiler()`. Note: Intermediate pipeline YAML is saved
     at `pipeline_file_path`
 
     """
-    pipeline_func = create_flow_from_graph(flowgraph, code_url)
+    pipeline_func = create_kfp_pipeline_from_flow_graph(flow_graph, code_url)
 
     kfp.compiler.Compiler().compile(pipeline_func, pipeline_file_path)
     return pipeline_file_path

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -5,10 +5,6 @@ from kubernetes.client.models import V1EnvVar
 from .constants import DEFAULT_FLOW_CODE_URL, DEFAULT_KFP_YAML_OUTPUT_PATH, DEFAULT_DOWNLOADED_FLOW_FILENAME
 from metaflow.metaflow_config import METAFLOW_AWS_ARN, METAFLOW_AWS_S3_REGION, DATASTORE_SYSROOT_S3
 
-# from .constants import S3_AWS_ARN as S3_AWS_ARN_VALUE
-# from .constants import S3_BUCKET as S3_BUCKET_VALUE
-# from .constants import S3_AWS_REGION as S3_AWS_REGION_VALUE
-
 from typing import NamedTuple
 from collections import deque
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -3,9 +3,11 @@ from kfp import dsl
 from kubernetes.client.models import V1EnvVar
 
 from .constants import DEFAULT_FLOW_CODE_URL, DEFAULT_KFP_YAML_OUTPUT_PATH, DEFAULT_DOWNLOADED_FLOW_FILENAME
-from .constants import S3_AWS_ARN as S3_AWS_ARN_VALUE
-from .constants import S3_BUCKET as S3_BUCKET_VALUE
-from .constants import S3_AWS_REGION as S3_AWS_REGION_VALUE
+from metaflow.metaflow_config import METAFLOW_AWS_ARN, METAFLOW_AWS_S3_REGION, DATASTORE_SYSROOT_S3
+
+# from .constants import S3_AWS_ARN as S3_AWS_ARN_VALUE
+# from .constants import S3_BUCKET as S3_BUCKET_VALUE
+# from .constants import S3_AWS_REGION as S3_AWS_REGION_VALUE
 
 from typing import NamedTuple
 from collections import deque
@@ -173,12 +175,9 @@ def add_env_variables_transformer(container_op):
     Add environment variables to the container op.
     """
 
-    S3_BUCKET = V1EnvVar(name="S3_BUCKET", value=S3_BUCKET_VALUE)
-    S3_AWS_ARN = V1EnvVar(name="S3_AWS_ARN", value=S3_AWS_ARN_VALUE)
-    S3_AWS_REGION = V1EnvVar(name="S3_AWS_REGION", value=S3_AWS_REGION_VALUE)
-    container_op.add_env_variable(S3_BUCKET)
-    container_op.add_env_variable(S3_AWS_ARN)
-    container_op.add_env_variable(S3_AWS_REGION)
+    container_op.add_env_variable(V1EnvVar(name="S3_BUCKET", value=DATASTORE_SYSROOT_S3))
+    container_op.add_env_variable(V1EnvVar(name="S3_AWS_ARN", value=METAFLOW_AWS_ARN))
+    container_op.add_env_variable(V1EnvVar(name="S3_AWS_REGION", value=METAFLOW_AWS_S3_REGION))
     return container_op
 
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -1,53 +1,19 @@
 import kfp
 from kfp import dsl
 
-from .constants import DEFAULT_RUN_NAME, DEFAULT_EXPERIMENT_NAME, DEFAULT_FLOW_CODE_URL, DEFAULT_KFP_YAML_OUTPUT_PATH
+from .constants import DEFAULT_FLOW_CODE_URL, DEFAULT_KFP_YAML_OUTPUT_PATH
 from typing import NamedTuple
 
-def get_ordered_steps(graph):
-    """
-    Returns the ordered step names in the graph (FlowGraph) from start step to end step as a list of strings containing the
-    step names.
-
-    # TODO: Support other Metaflow graphs, as branching and joins are not currently supported
-    Note: All MF graphs start at the "start" step and end with the "end" step (both of which are mandatory).
-    """
-
-    ordered_steps = ['start']
-    current_node_name = 'start'
-
-    # This is not an ideal way to iterate over the graph, but it's the (easy+)right thing to do for now.
-    # This may need to change as work on improvements.
-    while current_node_name != 'end':
-        for node in graph:
-            if node.name == current_node_name:
-                if current_node_name != 'end':
-                    current_node_name = node.out_funcs[0]
-                    ordered_steps.append(current_node_name)
-                    break
-
-    return ordered_steps
-
-
-def step_op_func(step_name: str,
+def step_op_func(python_cmd_template, step_name: str,
                  code_url: str,
                  ds_root: str,
                  run_id: str,
-                 task_id: str,
-                 prev_step_name: str,
-                 prev_task_id: str) -> NamedTuple('StepOutput', [('ds_root', str),
-                                                         ('run_id', str),
-                                                         ('next_step', str),
-                                                         ('next_task_id', str),
-                                                         ('current_step', str),
-                                                         ('current_task_id', str)]
-                                                      ):
+               ):
     """
     Function used to create a KFP container op (see: `step_container_op`) that corresponds to a single step in the flow.
 
     """
     import subprocess
-    from collections import namedtuple
 
     print("\n----------RUNNING: CODE DOWNLOAD from URL---------")
     subprocess.call(["curl -o helloworld.py {}".format(code_url)], shell=True)
@@ -66,9 +32,8 @@ def step_op_func(step_name: str,
     define_s3_env_vars = 'export METAFLOW_DATASTORE_SYSROOT_S3="{}" && export METAFLOW_AWS_ARN="{}" '.format(S3_BUCKET,
                                                                                                              S3_AWS_ARN)
     define_username = 'export USERNAME="kfp-user"'
-    python_cmd = "python helloworld.py --datastore s3 --datastore-root {0} step {1} --run-id {2} " \
-                 "--task-id {3} --input-paths {2}/{4}/{5}".format(ds_root, step_name, run_id,
-                                                                  task_id, prev_step_name, prev_task_id)
+    python_cmd = python_cmd_template.format(ds_root=ds_root, run_id=run_id)
+
     final_run_cmd = f'{define_username} && {define_s3_env_vars} && {python_cmd}'
 
     print("RUNNING COMMAND: ", final_run_cmd)
@@ -76,13 +41,10 @@ def step_op_func(step_name: str,
     proc_output = proc.stdout
     proc_error = proc.stderr
 
-    step_output = namedtuple('StepOutput',
-                             ['ds_root', 'run_id', 'next_step', 'next_task_id', 'current_step', 'current_task_id'])
-
     # END is the final step and no outputs need to be returned
     if step_name.lower() == 'end':
         print("_______________ FLOW RUN COMPLETE ________________")
-        return step_output('None', 'None', 'None', 'None', 'None', 'None')
+        # return step_output('None', 'None', 'None', 'None', 'None', 'None')
 
     # TODO: Check why MF echo statements are getting redirected to stderr
     if len(proc_error) > 1:
@@ -92,10 +54,7 @@ def step_op_func(step_name: str,
     if len(proc_output) > 1:
         print("_______________STDOUT:_____________________________")
         print(proc_output)
-        # Read in the outputs (in the penultimate line) containing args needed for the next step.
-        # Note: Output format is: ['ds_root', 'run_id', 'next_step', 'next_task_id', 'current_step', 'current_task_id']
-        outputs = (proc_output.split("\n")[-2]).split()
-        print(step_output(outputs[0], outputs[1], outputs[2], outputs[3], outputs[4], outputs[5]))
+
     else:
         raise RuntimeWarning("This step did not generate the correct args for next step to run. This might disrupt "
                              "the workflow")
@@ -105,14 +64,12 @@ def step_op_func(step_name: str,
     subprocess.call(["rm -r /opt/zillow/.metaflow"], shell=True)
 
     print("_______________ Done _________________________________")
-    return step_output(outputs[0], outputs[1], outputs[2], outputs[3], outputs[4], outputs[5])
 
-def pre_start_op_func(code_url)  -> NamedTuple('StepOutput', [('ds_root', str), ('run_id', str), ('next_step', str), ('next_task_id', str), ('current_step', str), ('current_task_id', str)]):
+def pre_start_op_func(code_url)  -> NamedTuple('StepOutput', [('ds_root', str), ('run_id', str)]):
     """
     Function used to create a KFP container op (see `pre_start_container_op`)that corresponds to the `pre-start` step of metaflow
 
     """
-
     import subprocess
     from collections import namedtuple
 
@@ -142,7 +99,7 @@ def pre_start_op_func(code_url)  -> NamedTuple('StepOutput', [('ds_root', str), 
     proc_error = proc.stderr
 
     step_output = namedtuple('StepOutput',
-                             ['ds_root', 'run_id', 'next_step', 'next_task_id', 'current_step', 'current_task_id'])
+                             ['ds_root', 'run_id'])
 
     # TODO: Check why MF echo statements are getting redirected to stderr
     if len(proc_error) > 1:
@@ -152,9 +109,8 @@ def pre_start_op_func(code_url)  -> NamedTuple('StepOutput', [('ds_root', str), 
     if len(proc_output) > 1:
         print("______________ STDOUT:____________________________")
         print(proc_output)
-        # Read in the outputs (in the penultimate line) containing args needed for the next step.
-        # Note: Output format is: ['ds_root', 'run_id', 'next_step', 'next_task_id', 'current_step', 'current_task_id']
-        outputs = (proc_output.split("\n")[-2]).split() # this contains the args needed for next step to run
+        outputs = (proc_output.split("\n")[-2]).split() # this contains the args needed for next steps to run
+
     else:
         raise RuntimeWarning("This step did not generate the correct args for next step to run. This might disrupt the workflow")
 
@@ -163,7 +119,7 @@ def pre_start_op_func(code_url)  -> NamedTuple('StepOutput', [('ds_root', str), 
     subprocess.call(["rm -r /opt/zillow/.metaflow"], shell=True)
 
     print("_______________ Done __________________________")
-    return step_output(outputs[0], outputs[1], outputs[2], outputs[3], outputs[4], outputs[5])
+    return step_output(outputs[0], outputs[1])
 
 def step_container_op():
     """
@@ -172,7 +128,7 @@ def step_container_op():
     Note: The public docker image is a copy of the internal docker image we were using (borrowed from aip-kfp-example).
     """
 
-    step_op =  kfp.components.func_to_container_op(step_op_func, base_image='ssreejith3/mf_on_kfp:python-curl-git')
+    step_op = kfp.components.func_to_container_op(step_op_func, base_image='ssreejith3/mf_on_kfp:python-curl-git')
     return step_op
 
 def pre_start_container_op():
@@ -185,13 +141,90 @@ def pre_start_container_op():
     pre_start_op = kfp.components.func_to_container_op(pre_start_op_func, base_image='ssreejith3/mf_on_kfp:python-curl-git')
     return pre_start_op
 
+def create_flow_from_graph(flowgraph, flow_code_url=DEFAULT_FLOW_CODE_URL):
+    from collections import deque
+    graph = flowgraph
+    code_url = flow_code_url
 
-def create_flow_pipeline(ordered_steps, flow_code_url=DEFAULT_FLOW_CODE_URL):
+    def build_cmd_template(step_name, task_id, input_paths):
+        python_cmd = "python helloworld.py --datastore s3 --datastore-root {{ds_root}} step {step_name} --run-id {{run_id}} --task-id {task_id} --input-paths {input_paths}".format(step_name=step_name, task_id=task_id, input_paths=input_paths )
+        return python_cmd
+
+    # Note: Below, we process the graph in level order and save the command templates to be used for each step of the graph.
+    # Level-order traversal is adopted to keep the task-ids in line with what happens during a local metaflow execution.
+    # It may not be necessary to keep this order of task-ids (TODO: verify importance of task-id ordering) as long as we
+    # are able to point to the correct input-paths for each step.
+
+    dq = deque(['start']) # deque to process the DAG in level order
+    cur_task_id = 0
+    cur_input_path = '' # non-join node: run-id/parent-step/parent-task-id, branch-join: run-id/:p1/p1-task-id,p2/p2-task-id,...
+
+    # set of seen steps, i.e., added to the queue for processing
+    seen = set(['start'])
+
+    # Mapping of steps to task ids
+    task_id_map = {}
+    # Mapping of steps to their command templates
+    command_template_map = {}
+
+    while len(dq) > 0:
+        cur_step = dq.popleft()
+        cur_task_id += 1
+        task_id_map[cur_step] = cur_task_id
+
+        if cur_task_id == 1: # start step
+            cur_input_path = '{run_id}/_parameters/0' # this is the standard input path for the `start` step
+        else:
+            if graph.nodes[cur_step].type != 'join':
+                parent_step = graph.nodes[cur_step].in_funcs[0]
+                cur_input_path = '{run_id}/'+ parent_step + '/' + str(task_id_map[parent_step])
+            else:
+                cur_input_path = '{run_id}/:'
+                for parent in graph.nodes[cur_step].in_funcs:
+                    cur_input_path += parent + '/' + str(task_id_map[parent]) + ','
+                cur_input_path = cur_input_path.strip(',')
+
+        command_template_map[cur_step] = build_cmd_template(cur_step, cur_task_id, cur_input_path)
+
+        out_funcs = graph.nodes[cur_step].out_funcs
+        for step in out_funcs:
+            if step not in seen:
+                dq.append(step)
+                seen.add(step)
+
+    @dsl.pipeline(
+        name='MF on KFP Pipeline',
+        description='Pipeline defining KFP equivalent of the Metaflow flow'
+    )
+    def kfp_pipeline_from_flow():
+        pre_start_op = (pre_start_container_op())(code_url)
+        outputs = pre_start_op.outputs
+
+        container_op_map = {}
+        ds_root = outputs['ds_root']
+        run_id = outputs['run_id']
+
+        # Initial:
+        pre_start_op.set_display_name('InitialSetup')
+        container_op_map['start'] = (step_container_op())(command_template_map['start'], 'start', code_url, ds_root, run_id)
+        container_op_map['start'].set_display_name('start')
+        container_op_map['start'].after(pre_start_op)
+
+        for step, cmd in command_template_map.items():
+            if step not in container_op_map.keys():
+                container_op_map[step] = (step_container_op())(command_template_map[step], step, code_url, ds_root, run_id)
+                container_op_map[step].set_display_name(step)
+                for parent in graph.nodes[step].in_funcs:
+                    container_op_map[step].after(container_op_map[parent])
+
+    return kfp_pipeline_from_flow
+
+def create_flow_pipeline_alternate(mf_graph, flow_code_url=DEFAULT_FLOW_CODE_URL):
     """
     Function used to create the KFP flow pipeline. Return the function defining the KFP equivalent of the flow
     """
 
-    steps = ordered_steps
+    graph = mf_graph
     code_url = flow_code_url
     print("\nCreating the pipeline definition needed to run the flow on KFP...\n")
     print("\nCode URL of the flow to be converted to KFP: {0}\n".format(flow_code_url))
@@ -210,19 +243,68 @@ def create_flow_pipeline(ordered_steps, flow_code_url=DEFAULT_FLOW_CODE_URL):
         pre_start_op = (pre_start_container_op())(code_url)
         step_container_ops.append(pre_start_op)
 
-        for step in steps:
-            prev_step_outputs = step_container_ops[-1].outputs
-            step_container_ops.append(
-                (step_container_op())(step, code_url,
-                      prev_step_outputs['ds_root'],
-                      prev_step_outputs['run_id'],
-                      prev_step_outputs['next_task_id'],
-                      prev_step_outputs['current_step'],
-                      prev_step_outputs['current_task_id']
-                      )
-                )
-            step_container_ops[-1].set_display_name(step)
-            step_container_ops[-1].after(step_container_ops[-2])
+        from collections import deque
+        import ast
+        import json
+
+        dq = deque([pre_start_op])
+        seen_in_funcs = set([])
+        input_paths_join = None
+        is_branch_join = True # Ignore foreach for now
+        pre_join_tasks = []
+
+        while len(dq) > 0:
+            prev_task = dq.popleft()
+            prev_step_outputs = prev_task.outputs
+
+            out_funcs = json.loads(prev_step_outputs['next_step'])
+            next_task_ids = json.loads(prev_step_outputs['next_task_id'])
+            out_funcs = ast.literal_eval(str(out_funcs))
+
+            for i, step in enumerate(out_funcs):
+                node_type = graph.nodes[step].type
+                node_in_funcs = graph.nodes[step].in_funcs
+                if len(node_in_funcs) <= 1: # non-join nodes
+                    # create the current task
+                    # no dependencies as this is start step
+                    input_path = prev_step_outputs['ds_root'] + "/" + prev_step_outputs['current_step'] + "/" + prev_step_outputs['current_task_id']  # runid/step/taskid
+                    current_task = (step_container_op())(
+                        step,
+                        code_url,
+                        prev_step_outputs['ds_root'],
+                        prev_step_outputs['run_id'],
+                        next_task_ids[0], # there will only be one as it's the start step
+                        input_path
+                    )
+                    current_task.set_display_name(step)
+                    current_task.after(prev_task)
+                    dq.append(current_task)
+
+                else: # join
+                    if input_paths_join is None and is_branch_join:
+                        input_paths_join = prev_step_outputs['run_id'] + "/:"
+                    seen_in_funcs.add(prev_step_outputs['current_step'])
+                    input_paths_join += prev_step_outputs['current_step'] + "/" + prev_step_outputs['current_task_id']
+                    pre_join_tasks.append(prev_task)
+                    if seen_in_funcs == node_in_funcs: # then the join has all the data it needs to start execution
+                        current_task =  (step_container_op())(
+                                            step,
+                                            code_url,
+                                            prev_step_outputs['ds_root'],
+                                            prev_step_outputs['run_id'],
+                                            next_task_ids[0],  # new task id - check if this is always correct
+                                            input_paths_join
+                                        )
+                        current_task.set_display_name(step)
+                        for pre_join_task in pre_join_tasks:
+                            current_task.after(pre_join_task)
+                        # Reset to prep for the next join
+                        input_paths_join = None
+                        seen_in_funcs = set([])
+                        pre_join_tasks = []
+                    else:
+                        # There's more to come. So, add a comma
+                        input_paths_join += ','
 
     return kfp_pipeline_from_flow
 
@@ -233,7 +315,7 @@ def create_run_on_kfp(flowgraph, code_url, experiment_name, run_name):
 
     """
 
-    pipeline_func = create_flow_pipeline(get_ordered_steps(flowgraph), code_url)
+    pipeline_func = create_flow_from_graph(flowgraph, code_url)
     run_pipeline_result = kfp.Client().create_run_from_pipeline_func(pipeline_func,
                                                                      arguments={},
                                                                      experiment_name=experiment_name,
@@ -247,7 +329,7 @@ def create_kfp_pipeline_yaml(flowgraph, code_url, pipeline_file_path=DEFAULT_KFP
     at `pipeline_file_path`
 
     """
-    pipeline_func = create_flow_pipeline(get_ordered_steps(flowgraph), code_url)
+    pipeline_func = create_flow_from_graph(flowgraph, code_url)
 
     kfp.compiler.Compiler().compile(pipeline_func, pipeline_file_path)
     return pipeline_file_path

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -70,9 +70,7 @@ def step_op_func(python_cmd_template, step_name: str,
         raise RuntimeWarning("This step did not generate the correct args for next step to run. This might disrupt "
                              "the workflow")
 
-    # TODO: Metadata needed for client API to run needs to be persisted outside before this
-    print("--------------- RUNNING: CLEANUP OF TEMP DIR----------")
-    subprocess.call(["rm -r /opt/zillow/.metaflow"], shell=True)
+    # TODO: Metadata needed for client API to run needs to be persisted outside before return
 
     print("_______________ Done _________________________________")
 
@@ -136,9 +134,7 @@ def initial_setup_op_func(code_url: str)  -> StepOutput:
     else:
         raise RuntimeWarning("This step did not generate the correct args for next step to run. This might disrupt the workflow")
 
-    # TODO: Metadata needed for client API to run needs to be persisted outside before this
-    print("--------------- RUNNING: CLEANUP OF TEMP DIR----------")
-    subprocess.call(["rm -r /opt/zillow/.metaflow"], shell=True)
+    # TODO: Metadata needed for client API to run needs to be persisted outside before return
 
     print("_______________ Done __________________________")
     return StepOutput(outputs[0], outputs[1])

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -238,8 +238,8 @@ def create_flow_from_graph(flowgraph, flow_code_url=DEFAULT_FLOW_CODE_URL):
                     'with branch and join nodes'
     )
     def kfp_pipeline_from_flow():
-        S3_BUCKET = V1EnvVar(name="S3_BUCKET", value=S3_BUCKET_VALUE) # "s3://workspace-zillow-analytics-stage/aip/metaflow")
-        S3_AWS_ARN = V1EnvVar(name="S3_AWS_ARN", value=S3_AWS_ARN_VALUE) #"arn:aws:iam::170606514770:role/dev-zestimate-role")
+        S3_BUCKET = V1EnvVar(name="S3_BUCKET", value=S3_BUCKET_VALUE)
+        S3_AWS_ARN = V1EnvVar(name="S3_AWS_ARN", value=S3_AWS_ARN_VALUE)
         pre_start_op = (pre_start_container_op())(code_url).add_env_variable(S3_BUCKET).add_env_variable(S3_AWS_ARN)
         outputs = pre_start_op.outputs
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -3,6 +3,7 @@ from kfp import dsl
 
 from .constants import DEFAULT_FLOW_CODE_URL, DEFAULT_KFP_YAML_OUTPUT_PATH
 from typing import NamedTuple
+from collections import deque
 
 def step_op_func(python_cmd_template, step_name: str,
                  code_url: str,
@@ -141,37 +142,41 @@ def pre_start_container_op():
     pre_start_op = kfp.components.func_to_container_op(pre_start_op_func, base_image='ssreejith3/mf_on_kfp:python-curl-git')
     return pre_start_op
 
-def create_flow_from_graph(flowgraph, flow_code_url=DEFAULT_FLOW_CODE_URL):
-    from collections import deque
-    graph = flowgraph
-    code_url = flow_code_url
+def create_command_templates_from_graph(graph):
+    """
+    Create a map of steps to their corresponding command templates. These command templates help define the command
+    to be used to run that particular step with placeholders for the `run_id` and `datastore_root` (location of the datastore).
 
+    # Note:
+    # Level-order traversal is adopted to keep the task-ids in line with what happens during a local metaflow execution.
+    # It is not entirely necessary to keep this order of task-ids if we are able to point to the correct input-paths for
+    # each step. But, using this ordering does keep the organization of data more understandable and natural (i.e., `start`
+    # gets a task id of 1, next step gets a task id of 2 and so on with 'end' step having the highest task id.
+    """
     def build_cmd_template(step_name, task_id, input_paths):
         python_cmd = "python helloworld.py --datastore s3 --datastore-root {{ds_root}} step {step_name} --run-id {{run_id}} --task-id {task_id} --input-paths {input_paths}".format(step_name=step_name, task_id=task_id, input_paths=input_paths )
         return python_cmd
 
-    # Note: Below, we process the graph in level order and save the command templates to be used for each step of the graph.
-    # Level-order traversal is adopted to keep the task-ids in line with what happens during a local metaflow execution.
-    # It may not be necessary to keep this order of task-ids (TODO: verify importance of task-id ordering) as long as we
-    # are able to point to the correct input-paths for each step.
-
-    dq = deque(['start']) # deque to process the DAG in level order
+    steps_deque = deque(['start']) # deque to process the DAG in level order
     cur_task_id = 0
-    cur_input_path = '' # non-join node: run-id/parent-step/parent-task-id, branch-join: run-id/:p1/p1-task-id,p2/p2-task-id,...
 
     # set of seen steps, i.e., added to the queue for processing
-    seen = set(['start'])
-
+    seen_steps = set(['start'])
     # Mapping of steps to task ids
     task_id_map = {}
     # Mapping of steps to their command templates
     command_template_map = {}
 
-    while len(dq) > 0:
-        cur_step = dq.popleft()
+    while len(steps_deque) > 0:
+        cur_step = steps_deque.popleft()
         cur_task_id += 1
         task_id_map[cur_step] = cur_task_id
 
+        # Generate the correct input_path for each step. Note: input path depends on a step's parents (i.e., in_funcs)
+        # Format of the input-paths for reference:
+        # non-join nodes: run-id/parent-step/parent-task-id,
+        # branch-join node: run-id/:p1/p1-task-id,p2/p2-task-id,...
+        # foreach node: TODO: foreach is not considered here
         if cur_task_id == 1: # start step
             cur_input_path = '{run_id}/_parameters/0' # this is the standard input path for the `start` step
         else:
@@ -188,13 +193,24 @@ def create_flow_from_graph(flowgraph, flow_code_url=DEFAULT_FLOW_CODE_URL):
 
         out_funcs = graph.nodes[cur_step].out_funcs
         for step in out_funcs:
-            if step not in seen:
-                dq.append(step)
-                seen.add(step)
+            if step not in seen_steps:
+                steps_deque.append(step)
+                seen_steps.add(step)
+
+    return command_template_map
+
+
+def create_flow_from_graph(flowgraph, flow_code_url=DEFAULT_FLOW_CODE_URL):
+
+    graph = flowgraph
+    code_url = flow_code_url
+
+    command_template_map = create_command_templates_from_graph(graph)
 
     @dsl.pipeline(
         name='MF on KFP Pipeline',
-        description='Pipeline defining KFP equivalent of the Metaflow flow'
+        description='Pipeline defining KFP equivalent of the Metaflow flow. Currently supports linear flows and flows '
+                    'with branch and join nodes'
     )
     def kfp_pipeline_from_flow():
         pre_start_op = (pre_start_container_op())(code_url)
@@ -204,7 +220,7 @@ def create_flow_from_graph(flowgraph, flow_code_url=DEFAULT_FLOW_CODE_URL):
         ds_root = outputs['ds_root']
         run_id = outputs['run_id']
 
-        # Initial:
+        # Initial setup
         pre_start_op.set_display_name('InitialSetup')
         container_op_map['start'] = (step_container_op())(command_template_map['start'], 'start', code_url, ds_root, run_id)
         container_op_map['start'].set_display_name('start')
@@ -219,94 +235,6 @@ def create_flow_from_graph(flowgraph, flow_code_url=DEFAULT_FLOW_CODE_URL):
 
     return kfp_pipeline_from_flow
 
-def create_flow_pipeline_alternate(mf_graph, flow_code_url=DEFAULT_FLOW_CODE_URL):
-    """
-    Function used to create the KFP flow pipeline. Return the function defining the KFP equivalent of the flow
-    """
-
-    graph = mf_graph
-    code_url = flow_code_url
-    print("\nCreating the pipeline definition needed to run the flow on KFP...\n")
-    print("\nCode URL of the flow to be converted to KFP: {0}\n".format(flow_code_url))
-
-    @dsl.pipeline(
-        name='MF on KFP Pipeline',
-        description='Pipeline defining KFP equivalent of the Metaflow flow'
-    )
-    def kfp_pipeline_from_flow():
-        """
-        This function converts the flow steps to kfp container op equivalents
-        by invoking `step_container_op` for every step in the flow and handling the order of steps.
-        """
-
-        step_container_ops = []
-        pre_start_op = (pre_start_container_op())(code_url)
-        step_container_ops.append(pre_start_op)
-
-        from collections import deque
-        import ast
-        import json
-
-        dq = deque([pre_start_op])
-        seen_in_funcs = set([])
-        input_paths_join = None
-        is_branch_join = True # Ignore foreach for now
-        pre_join_tasks = []
-
-        while len(dq) > 0:
-            prev_task = dq.popleft()
-            prev_step_outputs = prev_task.outputs
-
-            out_funcs = json.loads(prev_step_outputs['next_step'])
-            next_task_ids = json.loads(prev_step_outputs['next_task_id'])
-            out_funcs = ast.literal_eval(str(out_funcs))
-
-            for i, step in enumerate(out_funcs):
-                node_type = graph.nodes[step].type
-                node_in_funcs = graph.nodes[step].in_funcs
-                if len(node_in_funcs) <= 1: # non-join nodes
-                    # create the current task
-                    # no dependencies as this is start step
-                    input_path = prev_step_outputs['ds_root'] + "/" + prev_step_outputs['current_step'] + "/" + prev_step_outputs['current_task_id']  # runid/step/taskid
-                    current_task = (step_container_op())(
-                        step,
-                        code_url,
-                        prev_step_outputs['ds_root'],
-                        prev_step_outputs['run_id'],
-                        next_task_ids[0], # there will only be one as it's the start step
-                        input_path
-                    )
-                    current_task.set_display_name(step)
-                    current_task.after(prev_task)
-                    dq.append(current_task)
-
-                else: # join
-                    if input_paths_join is None and is_branch_join:
-                        input_paths_join = prev_step_outputs['run_id'] + "/:"
-                    seen_in_funcs.add(prev_step_outputs['current_step'])
-                    input_paths_join += prev_step_outputs['current_step'] + "/" + prev_step_outputs['current_task_id']
-                    pre_join_tasks.append(prev_task)
-                    if seen_in_funcs == node_in_funcs: # then the join has all the data it needs to start execution
-                        current_task =  (step_container_op())(
-                                            step,
-                                            code_url,
-                                            prev_step_outputs['ds_root'],
-                                            prev_step_outputs['run_id'],
-                                            next_task_ids[0],  # new task id - check if this is always correct
-                                            input_paths_join
-                                        )
-                        current_task.set_display_name(step)
-                        for pre_join_task in pre_join_tasks:
-                            current_task.after(pre_join_task)
-                        # Reset to prep for the next join
-                        input_paths_join = None
-                        seen_in_funcs = set([])
-                        pre_join_tasks = []
-                    else:
-                        # There's more to come. So, add a comma
-                        input_paths_join += ','
-
-    return kfp_pipeline_from_flow
 
 def create_run_on_kfp(flowgraph, code_url, experiment_name, run_name):
     """

--- a/metaflow/tutorials/00-helloworld/complex_flow.py
+++ b/metaflow/tutorials/00-helloworld/complex_flow.py
@@ -1,0 +1,135 @@
+from metaflow import FlowSpec, step
+
+class ComplexFlow(FlowSpec):
+
+    @step
+    def start(self):
+        """
+        This is the 'start' step. All flows must have a step named 'start' that
+        is the first step in the flow.
+
+        """
+        print("START step:\n We are now inside the START step - Hello World!\n")
+        self.next(self.br1, self.br2)
+
+    @step
+    def br1(self):
+        """
+        A step for metaflow to introduce itself.
+
+        """
+        print("\n\n_______________________________________")
+        print(" BR1 -> BR11 and BR12 ")
+        print("\n\n_______________________________________")
+        self.next(self.br11, self.br12)
+
+    @step
+    def br2(self):
+        """
+        A step for metaflow to introduce itself.
+
+        """
+        print("\n\n_______________________________________")
+        print(" BR2 -> BR21 and BR22 ")
+        print("___________________________________________")
+        self.next(self.br21, self.br22)
+
+    @step
+    def br11(self):
+        """
+        A step for metaflow to introduce itself.
+
+        """
+        print("\n\n_______________________________________")
+        print(" BR11 -> JOIN1")
+        print("\n\n_______________________________________")
+        self.next(self.join1)
+
+    @step
+    def br12(self):
+        """
+        A step for metaflow to introduce itself.
+
+        """
+        print("\n\n_______________________________________")
+        print(" BR 12 -> JOIN1 ")
+        print("___________________________________________")
+        self.next(self.join1)
+
+    @step
+    def br21(self):
+        """
+        A step for metaflow to introduce itself.
+
+        """
+        print("\n\n_______________________________________")
+        print(" BR21 -> JOIN2")
+        print("\n\n_______________________________________")
+        self.next(self.join2)
+
+    @step
+    def br22(self):
+        """
+        A step for metaflow to introduce itself.
+
+        """
+        print("\n\n_______________________________________")
+        print(" BR22 -> JOIN2 ")
+        print("___________________________________________")
+        self.next(self.join2)
+
+    @step
+    def join1(self, br1_inp):
+        """
+        A step for metaflow to introduce itself.
+
+        """
+        print("\n\n_______________________________________")
+        print(" BR11 & BR12 -> JOIN1 ")
+        self.var1 = 200
+        print("Inside join1; var = ", self.var1)
+        print("___________________________________________")
+        self.next(self.join3)
+
+    @step
+    def join2(self, br2_inp):
+        """
+        A step for metaflow to introduce itself.
+
+        """
+        print("\n\n_______________________________________")
+        print(" BR21 & BR22 -> JOIN2 ")
+        self.var2 = 100
+        print("Inside join2; var = ", self.var2)
+        print("___________________________________________")
+        self.next(self.join3)
+
+    @step
+    def join3(self, br_inp):
+        """
+        A step for metaflow to introduce itself.
+
+        """
+        print("\n\n_______________________________________")
+        print(" JOIN1 & JOIN2 -> JOIN3")
+        print("Verifying all input paths are correct by accessing same variable from"
+              "both branches of the join...")
+        print("JOIN1 var = ", br_inp.join1.var1)
+        print("JOIN2 var = ", br_inp.join2.var2)
+        print("___________________________________________")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """
+        This is the 'end' step. All flows must have an 'end' step, which is the
+        last step in the flow.
+
+        """
+        print("\n\n_______________________________________")
+        print("END step:\n We have reached the END step!\n")
+        print("HelloFlow is all done.")
+        print("___________________________________________")
+
+if __name__ == '__main__':
+    ComplexFlow()

--- a/metaflow/tutorials/00-helloworld/hello.py
+++ b/metaflow/tutorials/00-helloworld/hello.py
@@ -18,6 +18,7 @@ class HelloFlow(FlowSpec):
         print("\n\n_______________________________________")
         print("START step:\n We are now inside the START step - Hello World!\n")
         print("___________________________________________")
+        self.x = 100
         self.next(self.hello)
 
     @step
@@ -29,6 +30,7 @@ class HelloFlow(FlowSpec):
         print("\n\n_______________________________________")
         print("HELLO step:\n We are now inside the HELLO step!\n")
         print("METAFLOW says Hi!")
+        print("Metaflow on KFP: Reading state...\nself.x = ", self.x)
         print("___________________________________________")
         self.next(self.end)
 


### PR DESCRIPTION
This PR introduces support for non-linear flows that contain `branch` and `join` steps. It also covers using s3 as a datastore to integrate and use state in running flows on KFP. 

Note: Cancelling https://github.com/zillow/metaflow/pull/4 and addressing the comments from there on this PR as there's quite a few changes to the code that come with the support for `branch` and `join`

Testing: 
All updates are tested by following a manual integration test. This is done by creating a run on KFP from the terminal using the `run-on-kfp` command listed here in the [README](https://github.com/zillow/metaflow/tree/feature/kfp/metaflow/plugins/kfp) with the required flow code. For branch-and-join, the tests were done using `complex_flow.py` in the tutorials folder