### PR TITLE
Use KFP Run ID in place of the Metaflow Run ID. Remove container op used for initial_setup

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -617,68 +617,6 @@ def run(obj,
     runtime.persist_parameters()
     runtime.execute()
 
-@parameters.add_custom_parameters
-@cli.command(help='Set up the initial part of the workflow by instantiating a local runtime and persisting parameters. '
-                  'This is to be executed before the start step and other steps of the workflow can be executed')
-@common_run_options
-@click.option('--run-id',
-              'run_id',
-              default=None,
-              help="run id to be used for this run")
-@click.option('--namespace',
-              'user_namespace',
-              default=None,
-              help="Change namespace from the default (your username) to "
-                   "the specified tag. Note that this option does not alter "
-                   "tags assigned to the objects produced by this run, just "
-                   "what existing objects are visible in the client API. You "
-                   "can enable the global namespace with an empty string."
-                   "--namespace=")
-@click.pass_obj
-def pre_start(obj,
-        tags=None,
-        max_workers=None,
-        max_num_splits=None,
-        max_log_size=None,
-        decospecs=None,
-        run_id_file=None,
-        user_namespace=None,
-        run_id=None,
-        **kwargs):
-
-    if namespace is not None:
-        namespace(user_namespace or None)
-
-    before_run(obj, tags, decospecs + obj.environment.decospecs())
-
-    runtime = NativeRuntime(obj.flow,
-                            obj.graph,
-                            obj.datastore,
-                            obj.metadata,
-                            obj.environment,
-                            obj.package,
-                            obj.logger,
-                            obj.entrypoint,
-                            obj.event_logger,
-                            obj.monitor,
-                            run_id=run_id,
-                            max_workers=max_workers,
-                            max_num_splits=max_num_splits,
-                            max_log_size=max_log_size * 1024 * 1024)
-    write_latest_run_id(obj, runtime.run_id)
-    write_run_id(run_id_file, runtime.run_id)
-
-    parameters.set_parameters(obj.flow, kwargs)
-    runtime.persist_parameters()
-
-    # NOTE: We are currently using this output to specify the necessary arguments to the next step.
-    # This can only be removed when we achieve the following:
-    # 1) transition to using s3 as a datastore,
-    # 2) Use a KFP run_id
-    # TODO: Remove once above criteria are met.
-    # OUTPUT FORMAT: ($1)datastore_root location \t ($2)run_id \t ($3)next_step_to_run \t ($4)task_id(of next step) \t ($5)current step \t ($6)task_id(of current step)
-    print("{0}\t{1}\tstart\t1\t_parameters\t0".format(obj.datastore.datastore_root, runtime.run_id))
-
 
 @cli.command(help='Create a run on KF pipelines. This method converts the MF flow to a KFP run and outputs a link to the KFP run. '
                   'Note: This command will not work as expected if your local environment is not configured to '

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -621,6 +621,10 @@ def run(obj,
 @cli.command(help='Set up the initial part of the workflow by instantiating a local runtime and persisting parameters. '
                   'This is to be executed before the start step and other steps of the workflow can be executed')
 @common_run_options
+@click.option('--run-id',
+              'run_id',
+              default=None,
+              help="run id to be used for this run")
 @click.option('--namespace',
               'user_namespace',
               default=None,
@@ -639,6 +643,7 @@ def pre_start(obj,
         decospecs=None,
         run_id_file=None,
         user_namespace=None,
+        run_id=None,
         **kwargs):
 
     if namespace is not None:
@@ -656,6 +661,7 @@ def pre_start(obj,
                             obj.entrypoint,
                             obj.event_logger,
                             obj.monitor,
+                            run_id=run_id,
                             max_workers=max_workers,
                             max_num_splits=max_num_splits,
                             max_log_size=max_log_size * 1024 * 1024)

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -9,8 +9,8 @@ from collections import deque
 
 def step_op_func(python_cmd_template, step_name: str,
                  code_url: str,
-                 run_id: str,
-               ):
+                 kfp_run_id: str,
+                 ):
     """
     Function used to create a KFP container op (see: `step_container_op`) that corresponds to a single step in the flow.
     """
@@ -33,6 +33,7 @@ def step_op_func(python_cmd_template, step_name: str,
         modified_metaflow_git_url=MODIFIED_METAFLOW_URL)], shell=True)
 
     print("\n----------RUNNING: MAIN STEP COMMAND--------------")
+    # TODO: Map username to KFP specific user/profile/namespace
     S3_BUCKET = os.getenv("S3_BUCKET")
     S3_AWS_ARN = os.getenv("S3_AWS_ARN")
     S3_AWS_REGION = os.getenv("S3_AWS_REGION")
@@ -40,9 +41,11 @@ def step_op_func(python_cmd_template, step_name: str,
     define_s3_env_vars = 'export METAFLOW_DATASTORE_SYSROOT_S3="{}" && export METAFLOW_AWS_ARN="{}" ' \
                          '&& export METAFLOW_AWS_S3_REGION="{}"'.format(S3_BUCKET, S3_AWS_ARN, S3_AWS_REGION)
     define_username = 'export USERNAME="kfp-user"'
-    python_cmd = python_cmd_template.format(ds_root=S3_BUCKET, run_id=run_id)
+    python_cmd = python_cmd_template.format(ds_root=S3_BUCKET, run_id=kfp_run_id)
 
-    final_run_cmd = f'{define_username} && {define_s3_env_vars} && {python_cmd}'
+    final_run_cmd = "{define_username} && {define_s3_env_vars} && {python_cmd}".format(define_username=define_username,
+                                                                                       define_s3_env_vars=define_s3_env_vars,
+                                                                                       python_cmd=python_cmd)
 
     print("RUNNING COMMAND: ", final_run_cmd)
     proc = subprocess.run(final_run_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
@@ -65,7 +68,7 @@ def step_op_func(python_cmd_template, step_name: str,
         print("_______________ FLOW RUN COMPLETE ________________")
 
 
-def start_op_func(start_command_template: str, code_url: str, run_id: str):
+def start_op_func(start_command_template: str, code_url: str, kfp_run_id: str):
     """
     Function used to create a KFP container op corresponding to the 'start' step of the flow.
     This function also defines the execution of an init step which is needed before the 'start' step
@@ -106,6 +109,7 @@ def start_op_func(start_command_template: str, code_url: str, run_id: str):
         modified_metaflow_git_url=MODIFIED_METAFLOW_URL)], shell=True)
 
     print("\n----------RUNNING: INIT COMMAND-------------------")
+    # TODO: Map username to KFP specific user/profile/namespace
     S3_BUCKET = os.getenv("S3_BUCKET")
     S3_AWS_ARN = os.getenv("S3_AWS_ARN")
     S3_AWS_REGION = os.getenv("S3_AWS_REGION")
@@ -114,15 +118,19 @@ def start_op_func(start_command_template: str, code_url: str, run_id: str):
                          '&& export METAFLOW_AWS_S3_REGION="{}"'.format(S3_BUCKET, S3_AWS_ARN, S3_AWS_REGION)
     define_username = 'export USERNAME="kfp-user"'
     init_cmd = 'python {0} --datastore="s3" --datastore-root="{1}" init --run-id={2} --task-id=0'.format(DEFAULT_DOWNLOADED_FLOW_FILENAME,
-                                                                                                           S3_BUCKET, run_id)
-    final_init_cmd = f'{define_username} && {define_s3_env_vars} && {init_cmd}'
+                                                                                                         S3_BUCKET, kfp_run_id)
+    final_init_cmd = "{define_username} && {define_s3_env_vars} && {init_cmd}".format(define_username=define_username,
+                                                                                      define_s3_env_vars=define_s3_env_vars,
+                                                                                      init_cmd=init_cmd)
 
     print("RUNNING COMMAND: ", final_init_cmd)
     execute(final_init_cmd)
 
     print("\n----------RUNNING: MAIN STEP COMMAND----------------")
-    start_cmd = start_command_template.format(ds_root=S3_BUCKET, run_id=run_id)
-    final_run_cmd = f'{define_username} && {define_s3_env_vars} && {start_cmd}'
+    start_cmd = start_command_template.format(ds_root=S3_BUCKET, run_id=kfp_run_id)
+    final_run_cmd = "{define_username} && {define_s3_env_vars} && {start_cmd}".format(define_username=define_username,
+                                                                                      define_s3_env_vars=define_s3_env_vars,
+                                                                                      start_cmd=start_cmd)
     print("RUNNING COMMAND: ", final_run_cmd)
     execute(final_run_cmd)
 
@@ -256,7 +264,7 @@ def create_kfp_pipeline_from_flow_graph(flow_graph, code_url=DEFAULT_FLOW_CODE_U
         step_to_container_op_map = {}
         step_to_container_op_map['start'] = (start_container_op())(step_to_command_template_map['start'],
                                                                       code_url,
-                                                                      dsl.RUN_ID_PLACEHOLDER
+                                                                      'kfp-' + dsl.RUN_ID_PLACEHOLDER
                                                                     ).set_display_name('start')
 
         # Define container ops for remaining steps
@@ -266,7 +274,7 @@ def create_kfp_pipeline_from_flow_graph(flow_graph, code_url=DEFAULT_FLOW_CODE_U
                                                     step_to_command_template_map[step],
                                                     step,
                                                     code_url,
-                                                    dsl.RUN_ID_PLACEHOLDER
+                                                    'kfp-'+dsl.RUN_ID_PLACEHOLDER
                                                 ).set_display_name(step)
 
         # Add environment variables to all ops

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -33,14 +33,14 @@ def step_op_func(python_cmd_template, step_name: str,
         modified_metaflow_git_url=MODIFIED_METAFLOW_URL)], shell=True)
 
     print("\n----------RUNNING: MAIN STEP COMMAND--------------")
-    # TODO: Map username to KFP specific user/profile/namespace
+
     S3_BUCKET = os.getenv("S3_BUCKET")
     S3_AWS_ARN = os.getenv("S3_AWS_ARN")
     S3_AWS_REGION = os.getenv("S3_AWS_REGION")
 
     define_s3_env_vars = 'export METAFLOW_DATASTORE_SYSROOT_S3="{}" && export METAFLOW_AWS_ARN="{}" ' \
                          '&& export METAFLOW_AWS_S3_REGION="{}"'.format(S3_BUCKET, S3_AWS_ARN, S3_AWS_REGION)
-    define_username = 'export USERNAME="kfp-user"'
+    define_username = 'export USERNAME="kfp-user"' # TODO: Map username to KFP specific user/profile/namespace
     python_cmd = python_cmd_template.format(ds_root=S3_BUCKET, run_id=kfp_run_id)
 
     final_run_cmd = "{define_username} && {define_s3_env_vars} && {python_cmd}".format(define_username=define_username,
@@ -109,14 +109,14 @@ def start_op_func(start_command_template: str, code_url: str, kfp_run_id: str):
         modified_metaflow_git_url=MODIFIED_METAFLOW_URL)], shell=True)
 
     print("\n----------RUNNING: INIT COMMAND-------------------")
-    # TODO: Map username to KFP specific user/profile/namespace
+
     S3_BUCKET = os.getenv("S3_BUCKET")
     S3_AWS_ARN = os.getenv("S3_AWS_ARN")
     S3_AWS_REGION = os.getenv("S3_AWS_REGION")
 
     define_s3_env_vars = 'export METAFLOW_DATASTORE_SYSROOT_S3="{}" && export METAFLOW_AWS_ARN="{}" ' \
                          '&& export METAFLOW_AWS_S3_REGION="{}"'.format(S3_BUCKET, S3_AWS_ARN, S3_AWS_REGION)
-    define_username = 'export USERNAME="kfp-user"'
+    define_username = 'export USERNAME="kfp-user"' # TODO: Map username to KFP specific user/profile/namespace
     init_cmd = 'python {0} --datastore="s3" --datastore-root="{1}" init --run-id={2} --task-id=0'.format(DEFAULT_DOWNLOADED_FLOW_FILENAME,
                                                                                                          S3_BUCKET, kfp_run_id)
     final_init_cmd = "{define_username} && {define_s3_env_vars} && {init_cmd}".format(define_username=define_username,

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -260,11 +260,12 @@ def create_kfp_pipeline_from_flow_graph(flow_graph, code_url=DEFAULT_FLOW_CODE_U
                     'with branch and join nodes'
     )
     def kfp_pipeline_from_flow():
+        kfp_run_id = 'kfp-'+dsl.RUN_ID_PLACEHOLDER
         # Start step (start is a special step as additional initialisation is done internally)
         step_to_container_op_map = {}
         step_to_container_op_map['start'] = (start_container_op())(step_to_command_template_map['start'],
                                                                       code_url,
-                                                                      'kfp-' + dsl.RUN_ID_PLACEHOLDER
+                                                                      kfp_run_id
                                                                     ).set_display_name('start')
 
         # Define container ops for remaining steps
@@ -274,7 +275,7 @@ def create_kfp_pipeline_from_flow_graph(flow_graph, code_url=DEFAULT_FLOW_CODE_U
                                                     step_to_command_template_map[step],
                                                     step,
                                                     code_url,
-                                                    'kfp-'+dsl.RUN_ID_PLACEHOLDER
+                                                    kfp_run_id
                                                 ).set_display_name(step)
 
         # Add environment variables to all ops

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -21,7 +21,7 @@ def step_op_func(python_cmd_template, step_name: str,
     import subprocess
     import os
 
-    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@branch-and-join'
+    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@kfp-run-id' # branch-and-join'
     DEFAULT_DOWNLOADED_FLOW_FILENAME = 'downloaded_flow.py'
 
     print("\n----------RUNNING: CODE DOWNLOAD from URL---------")
@@ -75,7 +75,7 @@ def step_op_func(python_cmd_template, step_name: str,
     print("_______________ Done _________________________________")
 
 
-def initial_setup_op_func(code_url: str)  -> StepOutput:
+def initial_setup_op_func(code_url: str, kfp_run_id: str)  -> StepOutput:
     """
     Function used to create a KFP container op (see `initial_setup_container_op`)that corresponds to the `pre-start` step of metaflow
     """
@@ -83,7 +83,7 @@ def initial_setup_op_func(code_url: str)  -> StepOutput:
     import os
     from collections import namedtuple
 
-    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@branch-and-join'
+    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@kfp-run-id' # branch-and-join'
     DEFAULT_DOWNLOADED_FLOW_FILENAME = 'downloaded_flow.py'
 
     print("\n----------RUNNING: CODE DOWNLOAD from URL---------")
@@ -107,8 +107,8 @@ def initial_setup_op_func(code_url: str)  -> StepOutput:
     define_s3_env_vars = 'export METAFLOW_DATASTORE_SYSROOT_S3="{}" && export METAFLOW_AWS_ARN="{}" ' \
                          '&& export METAFLOW_AWS_S3_REGION="{}"'.format(S3_BUCKET, S3_AWS_ARN, S3_AWS_REGION)
     define_username = 'export USERNAME="kfp-user"'
-    python_cmd = 'python {0} --datastore="s3" --datastore-root="{1}" pre-start'.format(DEFAULT_DOWNLOADED_FLOW_FILENAME,
-                                                                                       S3_BUCKET)
+    python_cmd = 'python {0} --datastore="s3" --datastore-root="{1}" pre-start --run-id={2}'.format(DEFAULT_DOWNLOADED_FLOW_FILENAME,
+                                                                                       S3_BUCKET, kfp_run_id)
     final_run_cmd = f'{define_username} && {define_s3_env_vars} && {python_cmd}'
 
     print("RUNNING COMMAND: ", final_run_cmd)
@@ -263,7 +263,7 @@ def create_kfp_pipeline_from_flow_graph(flow_graph, code_url=DEFAULT_FLOW_CODE_U
     )
     def kfp_pipeline_from_flow():
         # Initial setup
-        initial_setup_op = (initial_setup_container_op())(code_url).set_display_name('InitialSetup')
+        initial_setup_op = (initial_setup_container_op())(code_url, dsl.RUN_ID_PLACEHOLDER).set_display_name('InitialSetup')
         ds_root = initial_setup_op.outputs['ds_root']
         run_id = initial_setup_op.outputs['run_id']
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -260,7 +260,7 @@ def create_kfp_pipeline_from_flow_graph(flow_graph, code_url=DEFAULT_FLOW_CODE_U
                     'with branch and join nodes'
     )
     def kfp_pipeline_from_flow():
-        kfp_run_id = 'kfp-'+dsl.RUN_ID_PLACEHOLDER
+        kfp_run_id = 'kfp-' + dsl.RUN_ID_PLACEHOLDER
         # Start step (start is a special step as additional initialisation is done internally)
         step_to_container_op_map = {}
         step_to_container_op_map['start'] = (start_container_op())(step_to_command_template_map['start'],


### PR DESCRIPTION
Changes done:
1. Use KFP run IDs in place of Metaflow run id so that users only need to deal with a single unique ID. 
2. Remove the initial setup container op and perform required initialization within the `start` container op.
3. Remove the `pre_start` command that was introduced to get a metaflow run_id and perform initialization.
4. The container ops now do not need to read off of the `initial setup container op` output and therefore, we see cleaner, more understandable visualizations on the UI.

Testing done:
Run the flow on the terminal using below command:
```
export METAFLOW_AWS_ARN="arn:aws:iam::170606514770:role/dev-zestimate-role" && export METAFLOW_AWS_S3_REGION="us-west-2" && export METAFLOW_DATASTORE_SYSROOT_S3="s3://workspace-zillow-analytics-stage/aip/metaflow" && export KFP_RUN_URL_PREFIX="https://kubeflow.corp.zillow-analytics-dev.zg-int.net/pipeline/#/runs/details" && python 00-helloworld/hello.py run-on-kfp --code-url="https://raw.githubusercontent.com/zillow/metaflow/state-integ-s3/metaflow/tutorials/00-helloworld/hello.py"
```

Graph output before: 
![image](https://user-images.githubusercontent.com/5566004/89695123-e2595280-d8e0-11ea-9a0a-fefb5f111719.png)

Graph output now, with the current changes:
![image](https://user-images.githubusercontent.com/5566004/89696435-df149580-d8e5-11ea-9ab9-3653345c7a04.png)


Metaflow IDs were being used prior to these changes (image from the datastore showing the run-ids):
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/5566004/89695371-c4402200-d8e1-11ea-8ada-cfbc20768f02.png">

With current changes, KFP run ids get used:
<img width="956" alt="image" src="https://user-images.githubusercontent.com/5566004/89695300-7c20ff80-d8e1-11ea-8de1-f8a6c0c19f84.png">
