### PR TITLE
Metaflow Pluginify our KFP Plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,10 @@ jobs:
     - name: Install Python 3.x dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install tox numpy
+        python3 -m pip install tox numpy black
+
+    - name: Python Code Format Check
+      run: black --target-version py27 --diff --check ./metaflow/plugins/kfp/*.py
 
     - name: Set up R 3.6
       if: matrix.lang == 'R'

--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -32,9 +32,6 @@ from .event_logger import EventLogger
 from .monitor import Monitor
 from .R import use_r, metaflow_r_version
 
-from .plugins.kfp.kfp import create_run_on_kfp, create_kfp_pipeline_yaml
-from .plugins.kfp.constants import DEFAULT_RUN_NAME, DEFAULT_EXPERIMENT_NAME, DEFAULT_FLOW_CODE_URL, DEFAULT_KFP_YAML_OUTPUT_PATH
-from metaflow.metaflow_config import KFP_RUN_URL_PREFIX, KFP_SDK_NAMESPACE, KFP_SDK_API_NAMESPACE, METAFLOW_USER
 
 ERASE_TO_EOL = '\033[K'
 HIGHLIGHT = 'red'
@@ -630,73 +627,6 @@ def run(obj,
     runtime.persist_parameters()
     runtime.execute()
 
-
-@cli.command(help='Create a run on KF pipelines. This method converts the MF flow to a KFP run and outputs a link to the KFP run. '
-                  'Note: This command will not work as expected if your local environment is not configured to '
-                   'connect to a KFP cluster')
-@click.option('--code-url',
-              'code_url',
-              default=DEFAULT_FLOW_CODE_URL,
-              help="the code URL of the flow to be executed on KFP")
-@click.option('--experiment-name',
-              'experiment_name',
-              default=DEFAULT_EXPERIMENT_NAME,
-              help="the associated experiment name for the run"
-              )
-@click.option('--run-name',
-              'run_name',
-              default=DEFAULT_RUN_NAME,
-              help="name assigned to the new KFP run"
-              )
-@click.option('--namespace',
-              'namespace',
-              default=KFP_SDK_NAMESPACE,
-              help="namespace of your run in KFP."
-              )
-@click.option('--api-namespace',
-              'api_namespace',
-              default=KFP_SDK_API_NAMESPACE,
-              help="namespace where the API service is run."
-              )
-@click.option('--userid',
-              'userid',
-              default=METAFLOW_USER,
-              help="your user ID (your email)."
-              )
-@click.pass_obj
-def run_on_kfp(obj,
-        code_url=DEFAULT_FLOW_CODE_URL,
-        experiment_name=DEFAULT_EXPERIMENT_NAME,
-        run_name=DEFAULT_RUN_NAME,
-        namespace=KFP_SDK_NAMESPACE,
-        api_namespace=KFP_SDK_API_NAMESPACE,
-        userid=METAFLOW_USER
-        ):
-
-    if namespace is None or userid is None:
-        raise Exception("Both namespace and userid must be defined, either through the CLI or as environment variables.")
-    
-    run_pipeline_result = create_run_on_kfp(obj.graph, code_url, experiment_name, run_name, namespace, api_namespace, userid)
-    echo("\nRun created successfully!\n")
-    echo("Run link: {0}".format(posixpath.join(KFP_RUN_URL_PREFIX, "_/pipeline/#/runs/details", run_pipeline_result.run_id)))
-
-
-@cli.command(help='Generate the KFP YAML which is used to run the workflow on Kubeflow Pipelines.')
-@click.option('--output-path',
-              'output_path',
-              default=DEFAULT_KFP_YAML_OUTPUT_PATH,
-              help="the output path (or filename) of the generated KFP pipeline yaml file")
-@click.option('--code-url',
-              'code_url',
-              default=DEFAULT_FLOW_CODE_URL,
-              help="the code URL of the flow to be executed on KFP")
-@click.pass_obj
-def generate_kfp_yaml(obj,
-                     output_path=DEFAULT_KFP_YAML_OUTPUT_PATH,
-                     code_url=DEFAULT_FLOW_CODE_URL,
-                     ):
-    pipeline_path = create_kfp_pipeline_yaml(obj.graph, code_url, output_path)
-    echo("\nDone converting to KFP YAML. Upload the file `{0}` to the KFP UI to run!".format(pipeline_path))
 
 def write_run_id(run_id_file, run_id):
     if run_id_file is not None:

--- a/metaflow/environment.py
+++ b/metaflow/environment.py
@@ -87,8 +87,8 @@ class MetaflowEnvironment(object):
                 "mkdir .metaflow", # mute local datastore creation log
                 "i=0; while [ $i -le 5 ]; do "
                     "echo \'Downloading code package.\'; "
-                    "%s -m awscli s3 cp %s job.tar >/dev/null && "
-                    "echo \'Code package downloaded.\' && break; "
+                    "%s -m awscli s3 cp %s job.tar >/dev/null && \
+                        echo \'Code package downloaded.\' && break; "
                     "sleep 10; i=$((i+1)); "
                 "done" % (self._python(), code_package_url),
                 "if [ $i -gt 5 ]; then "

--- a/metaflow/environment.py
+++ b/metaflow/environment.py
@@ -87,8 +87,8 @@ class MetaflowEnvironment(object):
                 "mkdir .metaflow", # mute local datastore creation log
                 "i=0; while [ $i -le 5 ]; do "
                     "echo \'Downloading code package.\'; "
-                    "%s -m awscli s3 cp %s job.tar >/dev/null && \
-                        echo \'Code package downloaded.\' && break; "
+                    "%s -m awscli s3 cp %s job.tar >/dev/null && "
+                    "echo \'Code package downloaded.\' && break; "
                     "sleep 10; i=$((i+1)); "
                 "done" % (self._python(), code_package_url),
                 "if [ $i -gt 5 ]; then "

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -44,12 +44,12 @@ def from_conf(name, default=None):
 ###
 DEFAULT_DATASTORE = from_conf('METAFLOW_DEFAULT_DATASTORE', 'local')
 DEFAULT_METADATA = from_conf('METAFLOW_DEFAULT_METADATA', 'local')
+METAFLOW_USER = from_conf('METAFLOW_USER')
 
 ##
 # KFP configuration
 ###
 KFP_SDK_NAMESPACE = from_conf('KFP_SDK_NAMESPACE', 'kubeflow')
-METAFLOW_USER = from_conf('METAFLOW_USER')
 KFP_SDK_API_NAMESPACE = from_conf('KFP_SDK_API_NAMESPACE', 'kubeflow')
 
 ###

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -173,8 +173,6 @@ if AWS_SANDBOX_ENABLED:
 # being read from old tasks.
 MAX_ATTEMPTS = 6
 
-METAFLOW_AWS_ARN = from_conf('METAFLOW_AWS_ARN')
-METAFLOW_AWS_S3_REGION = from_conf('METAFLOW_AWS_S3_REGION')
 
 # Note: `KFP_RUN_URL_PREFIX` is the URL prefix for KFP runs on your KFP cluster. The prefix includes
 # all parts of the URL except the run_id at the end which we append once the run is created.

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -9,10 +9,12 @@ def get_plugin_cli():
     from . import package_cli
     from .aws.batch import batch_cli
     from .aws.step_functions import step_functions_cli
+    from .kfp import kfp_cli
 
     return [package_cli.cli,
             batch_cli.cli,
-            step_functions_cli.cli]
+            step_functions_cli.cli,
+            kfp_cli.cli]
 
 # Add new decorators in this list
 from .catch_decorator import CatchDecorator
@@ -22,6 +24,7 @@ from .retry_decorator import RetryDecorator
 from .aws.batch.batch_decorator import BatchDecorator, ResourcesDecorator
 from .aws.step_functions.step_functions_decorator import StepFunctionsInternalDecorator
 from .conda.conda_step_decorator import CondaStepDecorator
+from .kfp.kfp_decorator import KfpInternalDecorator
 
 STEP_DECORATORS = [CatchDecorator,
                    TimeoutDecorator,
@@ -30,7 +33,8 @@ STEP_DECORATORS = [CatchDecorator,
                    RetryDecorator,
                    BatchDecorator,
                    StepFunctionsInternalDecorator,
-                   CondaStepDecorator]
+                   CondaStepDecorator,
+                   KfpInternalDecorator]
 
 # Add Conda environment
 from .conda.conda_environment import CondaEnvironment

--- a/metaflow/plugins/conda/conda_step_decorator.py
+++ b/metaflow/plugins/conda/conda_step_decorator.py
@@ -176,7 +176,7 @@ class CondaStepDecorator(StepDecorator):
 
     def _architecture(self, decos):
         for deco in decos:
-            if deco.name == 'batch':
+            if deco.name == 'batch' or deco.name == 'kfp_internal':
                 # force conda resolution for linux-64 architectures
                 return 'linux-64'
         bit = '32'

--- a/metaflow/plugins/kfp/constants.py
+++ b/metaflow/plugins/kfp/constants.py
@@ -1,10 +1,6 @@
 # Constants used in run MF flow on KFP
 
 # Defaults for running MF on KFP
-# TODO: remove this when we're able to automatically package code and use it on KFP. We currently need the user supplied code URL (or this default URL) in order to download the code that is to be run on KFP
-DEFAULT_FLOW_CODE_URL = "https://gist.githubusercontent.com/mon95/98d9d88571a0307a53b637d841295702/raw/df8bc1fa363f629271cfc1d34f3c2f7ca0b2e2cf/helloworld.py"
-DEFAULT_DOWNLOADED_FLOW_FILENAME = "downloaded_flow.py"
-
 DEFAULT_KFP_YAML_OUTPUT_PATH = "kfp_pipeline.yaml"
 DEFAULT_RUN_NAME = "run_mf_on_kfp"
 DEFAULT_EXPERIMENT_NAME = "mf-on-kfp-experiments"

--- a/metaflow/plugins/kfp/constants.py
+++ b/metaflow/plugins/kfp/constants.py
@@ -2,9 +2,9 @@
 
 # Defaults for running MF on KFP
 # TODO: remove this when we're able to automatically package code and use it on KFP. We currently need the user supplied code URL (or this default URL) in order to download the code that is to be run on KFP
-DEFAULT_FLOW_CODE_URL = 'https://gist.githubusercontent.com/mon95/98d9d88571a0307a53b637d841295702/raw/df8bc1fa363f629271cfc1d34f3c2f7ca0b2e2cf/helloworld.py'
-DEFAULT_DOWNLOADED_FLOW_FILENAME = 'downloaded_flow.py'
+DEFAULT_FLOW_CODE_URL = "https://gist.githubusercontent.com/mon95/98d9d88571a0307a53b637d841295702/raw/df8bc1fa363f629271cfc1d34f3c2f7ca0b2e2cf/helloworld.py"
+DEFAULT_DOWNLOADED_FLOW_FILENAME = "downloaded_flow.py"
 
-DEFAULT_KFP_YAML_OUTPUT_PATH = 'kfp_pipeline.yaml'
-DEFAULT_RUN_NAME = 'run_mf_on_kfp'
-DEFAULT_EXPERIMENT_NAME = 'mf-on-kfp-experiments'
+DEFAULT_KFP_YAML_OUTPUT_PATH = "kfp_pipeline.yaml"
+DEFAULT_RUN_NAME = "run_mf_on_kfp"
+DEFAULT_EXPERIMENT_NAME = "mf-on-kfp-experiments"

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -270,16 +270,13 @@ class KubeflowPipelines(object):
 
         if node.type == "join" and self.graph[node.split_parents[-1]].type == "foreach":
             # TODO: get from Dynamo or a kv store
-            parent_tasks_file = "".join(
-                random.choice(string.ascii_lowercase) for _ in range(10)
-            )
+            pass
             # export_parent_tasks = \
             #     'python -m ' \
             #     'metaflow.plugins.aws.step_functions.set_batch_environment ' \
             #     'parent_tasks %s && . `pwd`/%s' \
             #         % (parent_tasks_file, parent_tasks_file)
             # cmds.append(export_parent_tasks)
-            cmds.append("echo %s" % parent_tasks_file)
 
         top_level = [
             "--quiet",
@@ -320,9 +317,7 @@ class KubeflowPipelines(object):
         import kfp
         from kfp import dsl
 
-        base_image = (
-            "ssreejith3/mf_on_kfp:python-curl-git"  # TODO: environment variable
-        )
+        base_image = "ssreejith3/mf_on_kfp:python-curl-git"  # TODO: AIP-1980 and make an environment variable
         step_to_kfp_component_map = self.create_kfp_components_from_graph()
 
         # Container op that corresponds to a step defined in the Metaflow flowgraph.

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -1,36 +1,60 @@
+from collections import deque
+
 import kfp
 from kfp import dsl
 from kubernetes.client.models import V1EnvVar
 
-from .constants import DEFAULT_FLOW_CODE_URL, DEFAULT_KFP_YAML_OUTPUT_PATH, DEFAULT_DOWNLOADED_FLOW_FILENAME
-from metaflow.metaflow_config import METAFLOW_AWS_ARN, METAFLOW_AWS_S3_REGION, DATASTORE_SYSROOT_S3
+from metaflow.metaflow_config import (
+    DATASTORE_SYSROOT_S3,
+    METAFLOW_AWS_ARN,
+    METAFLOW_AWS_S3_REGION,
+)
 
-from collections import deque
+from .constants import (
+    DEFAULT_DOWNLOADED_FLOW_FILENAME,
+    DEFAULT_FLOW_CODE_URL,
+    DEFAULT_KFP_YAML_OUTPUT_PATH,
+)
 
-def step_op_func(python_cmd_template, step_name: str,
-                 code_url: str,
-                 kfp_run_id: str,
-                 ):
+
+def step_op_func(
+    python_cmd_template, step_name: str, code_url: str, kfp_run_id: str,
+):
     """
     Function used to create a KFP container op (see: `step_container_op`) that corresponds to a single step in the flow.
     """
     import subprocess
     import os
 
-    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@bug/add_namespace_to_kfp_run'
-    DEFAULT_DOWNLOADED_FLOW_FILENAME = 'downloaded_flow.py'
+    MODIFIED_METAFLOW_URL = (
+        "git+https://github.com/zillow/metaflow.git@bug/add_namespace_to_kfp_run"
+    )
+    DEFAULT_DOWNLOADED_FLOW_FILENAME = "downloaded_flow.py"
 
     print("\n----------RUNNING: CODE DOWNLOAD from URL---------")
     subprocess.call(
-        ["curl -o {downloaded_file_name} {code_url}".format(downloaded_file_name=DEFAULT_DOWNLOADED_FLOW_FILENAME,
-                                                            code_url=code_url)], shell=True)
+        [
+            "curl -o {downloaded_file_name} {code_url}".format(
+                downloaded_file_name=DEFAULT_DOWNLOADED_FLOW_FILENAME, code_url=code_url
+            )
+        ],
+        shell=True,
+    )
 
     print("\n----------RUNNING: KFP Installation---------------")
-    subprocess.call(["pip3 install kfp"], shell=True)  # TODO: Remove this once KFP is added to dependencies
+    subprocess.call(
+        ["pip3 install kfp"], shell=True
+    )  # TODO: Remove this once KFP is added to dependencies
 
     print("\n----------RUNNING: METAFLOW INSTALLATION----------")
-    subprocess.call(["pip3 install --user --upgrade {modified_metaflow_git_url}".format(
-        modified_metaflow_git_url=MODIFIED_METAFLOW_URL)], shell=True)
+    subprocess.call(
+        [
+            "pip3 install --user --upgrade {modified_metaflow_git_url}".format(
+                modified_metaflow_git_url=MODIFIED_METAFLOW_URL
+            )
+        ],
+        shell=True,
+    )
 
     print("\n----------RUNNING: MAIN STEP COMMAND--------------")
 
@@ -38,17 +62,29 @@ def step_op_func(python_cmd_template, step_name: str,
     S3_AWS_ARN = os.getenv("S3_AWS_ARN")
     S3_AWS_REGION = os.getenv("S3_AWS_REGION")
 
-    define_s3_env_vars = 'export METAFLOW_DATASTORE_SYSROOT_S3="{}" && export METAFLOW_AWS_ARN="{}" ' \
-                         '&& export METAFLOW_AWS_S3_REGION="{}"'.format(S3_BUCKET, S3_AWS_ARN, S3_AWS_REGION)
-    define_username = 'export USERNAME="kfp-user"' # TODO: Map username to KFP specific user/profile/namespace
+    define_s3_env_vars = (
+        'export METAFLOW_DATASTORE_SYSROOT_S3="{}" && export METAFLOW_AWS_ARN="{}" '
+        '&& export METAFLOW_AWS_S3_REGION="{}"'.format(
+            S3_BUCKET, S3_AWS_ARN, S3_AWS_REGION
+        )
+    )
+    define_username = 'export USERNAME="kfp-user"'  # TODO: Map username to KFP specific user/profile/namespace
     python_cmd = python_cmd_template.format(ds_root=S3_BUCKET, run_id=kfp_run_id)
 
-    final_run_cmd = "{define_username} && {define_s3_env_vars} && {python_cmd}".format(define_username=define_username,
-                                                                                       define_s3_env_vars=define_s3_env_vars,
-                                                                                       python_cmd=python_cmd)
+    final_run_cmd = "{define_username} && {define_s3_env_vars} && {python_cmd}".format(
+        define_username=define_username,
+        define_s3_env_vars=define_s3_env_vars,
+        python_cmd=python_cmd,
+    )
 
     print("RUNNING COMMAND: ", final_run_cmd)
-    proc = subprocess.run(final_run_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    proc = subprocess.run(
+        final_run_cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     proc_output = proc.stdout
     proc_error = proc.stderr
 
@@ -64,7 +100,7 @@ def step_op_func(python_cmd_template, step_name: str,
 
     print("_______________ Done _________________________________")
     # END is the final step
-    if step_name.lower() == 'end':
+    if step_name.lower() == "end":
         print("_______________ FLOW RUN COMPLETE ________________")
 
 
@@ -81,7 +117,13 @@ def start_op_func(start_command_template: str, code_url: str, kfp_run_id: str):
         """
         Helper function to run the given command and print `stderr` and `stdout`.
         """
-        proc = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        proc = subprocess.run(
+            cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
         proc_output = proc.stdout
         proc_error = proc.stderr
 
@@ -93,20 +135,35 @@ def start_op_func(start_command_template: str, code_url: str, kfp_run_id: str):
             print("______________ STDOUT:____________________________")
             print(proc_output)
 
-    MODIFIED_METAFLOW_URL = 'git+https://github.com/zillow/metaflow.git@bug/add_namespace_to_kfp_run'
-    DEFAULT_DOWNLOADED_FLOW_FILENAME = 'downloaded_flow.py'
+    MODIFIED_METAFLOW_URL = (
+        "git+https://github.com/zillow/metaflow.git@bug/add_namespace_to_kfp_run"
+    )
+    DEFAULT_DOWNLOADED_FLOW_FILENAME = "downloaded_flow.py"
 
     print("\n----------RUNNING: CODE DOWNLOAD from URL---------")
     subprocess.call(
-        ["curl -o {downloaded_file_name} {code_url}".format(downloaded_file_name=DEFAULT_DOWNLOADED_FLOW_FILENAME,
-                                                            code_url=code_url)], shell=True)
+        [
+            "curl -o {downloaded_file_name} {code_url}".format(
+                downloaded_file_name=DEFAULT_DOWNLOADED_FLOW_FILENAME, code_url=code_url
+            )
+        ],
+        shell=True,
+    )
 
     print("\n----------RUNNING: KFP Installation---------------")
-    subprocess.call(["pip3 install kfp"], shell=True)  # TODO: Remove this once KFP is added to dependencies
+    subprocess.call(
+        ["pip3 install kfp"], shell=True
+    )  # TODO: Remove this once KFP is added to dependencies
 
     print("\n----------RUNNING: METAFLOW INSTALLATION----------")
-    subprocess.call(["pip3 install --user --upgrade {modified_metaflow_git_url}".format(
-        modified_metaflow_git_url=MODIFIED_METAFLOW_URL)], shell=True)
+    subprocess.call(
+        [
+            "pip3 install --user --upgrade {modified_metaflow_git_url}".format(
+                modified_metaflow_git_url=MODIFIED_METAFLOW_URL
+            )
+        ],
+        shell=True,
+    )
 
     print("\n----------RUNNING: INIT COMMAND-------------------")
 
@@ -114,23 +171,32 @@ def start_op_func(start_command_template: str, code_url: str, kfp_run_id: str):
     S3_AWS_ARN = os.getenv("S3_AWS_ARN")
     S3_AWS_REGION = os.getenv("S3_AWS_REGION")
 
-    define_s3_env_vars = 'export METAFLOW_DATASTORE_SYSROOT_S3="{}" && export METAFLOW_AWS_ARN="{}" ' \
-                         '&& export METAFLOW_AWS_S3_REGION="{}"'.format(S3_BUCKET, S3_AWS_ARN, S3_AWS_REGION)
-    define_username = 'export USERNAME="kfp-user"' # TODO: Map username to KFP specific user/profile/namespace
-    init_cmd = 'python {0} --datastore="s3" --datastore-root="{1}" init --run-id={2} --task-id=0'.format(DEFAULT_DOWNLOADED_FLOW_FILENAME,
-                                                                                                         S3_BUCKET, kfp_run_id)
-    final_init_cmd = "{define_username} && {define_s3_env_vars} && {init_cmd}".format(define_username=define_username,
-                                                                                      define_s3_env_vars=define_s3_env_vars,
-                                                                                      init_cmd=init_cmd)
+    define_s3_env_vars = (
+        'export METAFLOW_DATASTORE_SYSROOT_S3="{}" && export METAFLOW_AWS_ARN="{}" '
+        '&& export METAFLOW_AWS_S3_REGION="{}"'.format(
+            S3_BUCKET, S3_AWS_ARN, S3_AWS_REGION
+        )
+    )
+    define_username = 'export USERNAME="kfp-user"'  # TODO: Map username to KFP specific user/profile/namespace
+    init_cmd = 'python {0} --datastore="s3" --datastore-root="{1}" init --run-id={2} --task-id=0'.format(
+        DEFAULT_DOWNLOADED_FLOW_FILENAME, S3_BUCKET, kfp_run_id
+    )
+    final_init_cmd = "{define_username} && {define_s3_env_vars} && {init_cmd}".format(
+        define_username=define_username,
+        define_s3_env_vars=define_s3_env_vars,
+        init_cmd=init_cmd,
+    )
 
     print("RUNNING COMMAND: ", final_init_cmd)
     execute(final_init_cmd)
 
     print("\n----------RUNNING: MAIN STEP COMMAND----------------")
     start_cmd = start_command_template.format(ds_root=S3_BUCKET, run_id=kfp_run_id)
-    final_run_cmd = "{define_username} && {define_s3_env_vars} && {start_cmd}".format(define_username=define_username,
-                                                                                      define_s3_env_vars=define_s3_env_vars,
-                                                                                      start_cmd=start_cmd)
+    final_run_cmd = "{define_username} && {define_s3_env_vars} && {start_cmd}".format(
+        define_username=define_username,
+        define_s3_env_vars=define_s3_env_vars,
+        start_cmd=start_cmd,
+    )
     print("RUNNING COMMAND: ", final_run_cmd)
     execute(final_run_cmd)
 
@@ -146,7 +212,9 @@ def step_container_op():
     Note: The public docker image is a copy of the internal docker image we were using (borrowed from aip-kfp-example).
     """
 
-    step_op = kfp.components.func_to_container_op(step_op_func, base_image='ssreejith3/mf_on_kfp:python-curl-git')
+    step_op = kfp.components.func_to_container_op(
+        step_op_func, base_image="ssreejith3/mf_on_kfp:python-curl-git"
+    )
     return step_op
 
 
@@ -157,7 +225,9 @@ def start_container_op():
     Note: The public docker image is a copy of the internal docker image we were using (borrowed from aip-kfp-example).
     """
 
-    start_op = kfp.components.func_to_container_op(start_op_func, base_image='ssreejith3/mf_on_kfp:python-curl-git')
+    start_op = kfp.components.func_to_container_op(
+        start_op_func, base_image="ssreejith3/mf_on_kfp:python-curl-git"
+    )
     return start_op
 
 
@@ -166,9 +236,13 @@ def add_env_variables_transformer(container_op):
     Add environment variables to the container op.
     """
 
-    container_op.add_env_variable(V1EnvVar(name="S3_BUCKET", value=DATASTORE_SYSROOT_S3))
+    container_op.add_env_variable(
+        V1EnvVar(name="S3_BUCKET", value=DATASTORE_SYSROOT_S3)
+    )
     container_op.add_env_variable(V1EnvVar(name="S3_AWS_ARN", value=METAFLOW_AWS_ARN))
-    container_op.add_env_variable(V1EnvVar(name="S3_AWS_REGION", value=METAFLOW_AWS_S3_REGION))
+    container_op.add_env_variable(
+        V1EnvVar(name="S3_AWS_REGION", value=METAFLOW_AWS_S3_REGION)
+    )
     return container_op
 
 
@@ -199,17 +273,23 @@ def create_command_templates_from_graph(graph):
                          "--input-paths {run_id}/start/1"
         """
 
-        python_cmd = "python {downloaded_file_name} --datastore s3 --datastore-root {{ds_root}} " \
-                     "step {step_name} --run-id {{run_id}} --task-id {task_id} " \
-                     "--input-paths {input_paths}".format(downloaded_file_name=DEFAULT_DOWNLOADED_FLOW_FILENAME,
-                                                            step_name=step_name, task_id=task_id, input_paths=input_paths)
+        python_cmd = (
+            "python {downloaded_file_name} --datastore s3 --datastore-root {{ds_root}} "
+            "step {step_name} --run-id {{run_id}} --task-id {task_id} "
+            "--input-paths {input_paths}".format(
+                downloaded_file_name=DEFAULT_DOWNLOADED_FLOW_FILENAME,
+                step_name=step_name,
+                task_id=task_id,
+                input_paths=input_paths,
+            )
+        )
         return python_cmd
 
-    steps_deque = deque(['start']) # deque to process the DAG in level order
+    steps_deque = deque(["start"])  # deque to process the DAG in level order
     current_task_id = 0
 
     # set of seen steps, i.e., added to the queue for processing
-    seen_steps = set(['start'])
+    seen_steps = set(["start"])
     # Mapping of steps to task ids
     step_to_task_id_map = {}
     # Mapping of steps to their command templates
@@ -226,21 +306,27 @@ def create_command_templates_from_graph(graph):
         # non-join nodes: "run-id/parent-step/parent-task-id",
         # branch-join node: "run-id/:p1/p1-task-id,p2/p2-task-id,..."
         # foreach node: TODO: foreach is not considered here
-        if current_task_id == 1: # start step
-            cur_input_path = '{run_id}/_parameters/0' # this is the standard input path for the `start` step
+        if current_task_id == 1:  # start step
+            cur_input_path = "{run_id}/_parameters/0"  # this is the standard input path for the `start` step
         else:
-            if current_node.type == 'join':
-                cur_input_path = '{run_id}/:'
+            if current_node.type == "join":
+                cur_input_path = "{run_id}/:"
                 for parent_step in current_node.in_funcs:
-                    cur_input_path += "{parent}/{parent_task_id},".format(parent=parent_step,
-                                                                          parent_task_id=str(step_to_task_id_map[parent_step]))
-                cur_input_path = cur_input_path.strip(',')
+                    cur_input_path += "{parent}/{parent_task_id},".format(
+                        parent=parent_step,
+                        parent_task_id=str(step_to_task_id_map[parent_step]),
+                    )
+                cur_input_path = cur_input_path.strip(",")
             else:
                 parent_step = current_node.in_funcs[0]
-                cur_input_path = "{{run_id}}/{parent}/{parent_task_id}".format(parent=parent_step,
-                                                                               parent_task_id=str(step_to_task_id_map[parent_step]))
+                cur_input_path = "{{run_id}}/{parent}/{parent_task_id}".format(
+                    parent=parent_step,
+                    parent_task_id=str(step_to_task_id_map[parent_step]),
+                )
 
-        step_to_command_template_map[current_step] = build_cmd_template(current_step, current_task_id, cur_input_path)
+        step_to_command_template_map[current_step] = build_cmd_template(
+            current_step, current_task_id, cur_input_path
+        )
 
         for step in current_node.out_funcs:
             if step not in seen_steps:
@@ -255,57 +341,63 @@ def create_kfp_pipeline_from_flow_graph(flow_graph, code_url=DEFAULT_FLOW_CODE_U
     step_to_command_template_map = create_command_templates_from_graph(flow_graph)
 
     @dsl.pipeline(
-        name='MF on KFP Pipeline',
-        description='Pipeline defining KFP equivalent of the Metaflow flow. Currently supports linear flows and flows '
-                    'with branch and join nodes'
+        name="MF on KFP Pipeline",
+        description="Pipeline defining KFP equivalent of the Metaflow flow. Currently supports linear flows and flows "
+        "with branch and join nodes",
     )
     def kfp_pipeline_from_flow():
-        kfp_run_id = 'kfp-' + dsl.RUN_ID_PLACEHOLDER
+        kfp_run_id = "kfp-" + dsl.RUN_ID_PLACEHOLDER
         # Start step (start is a special step as additional initialisation is done internally)
         step_to_container_op_map = {}
-        step_to_container_op_map['start'] = (start_container_op())(step_to_command_template_map['start'],
-                                                                      code_url,
-                                                                      kfp_run_id
-                                                                    ).set_display_name('start')
+        step_to_container_op_map["start"] = (start_container_op())(
+            step_to_command_template_map["start"], code_url, kfp_run_id
+        ).set_display_name("start")
 
         # Define container ops for remaining steps
         for step, cmd in step_to_command_template_map.items():
-            if step != 'start':
+            if step != "start":
                 step_to_container_op_map[step] = (step_container_op())(
-                                                    step_to_command_template_map[step],
-                                                    step,
-                                                    code_url,
-                                                    kfp_run_id
-                                                ).set_display_name(step)
+                    step_to_command_template_map[step], step, code_url, kfp_run_id
+                ).set_display_name(step)
 
         # Add environment variables to all ops
         dsl.get_pipeline_conf().add_op_transformer(add_env_variables_transformer)
 
         # Define ordering of container op execution
         for step in flow_graph.nodes.keys():
-            if step != 'start':
+            if step != "start":
                 for parent in flow_graph.nodes[step].in_funcs:
-                    step_to_container_op_map[step].after(step_to_container_op_map[parent])
+                    step_to_container_op_map[step].after(
+                        step_to_container_op_map[parent]
+                    )
 
     return kfp_pipeline_from_flow
 
 
-def create_run_on_kfp(flow_graph, code_url, experiment_name, run_name, namespace, api_namespace, userid):
+def create_run_on_kfp(
+    flow_graph, code_url, experiment_name, run_name, namespace, api_namespace, userid
+):
     """
     Creates a new run on KFP using the `kfp.Client()`. Note: Intermediate pipeline YAML is not generated as this creates
     the run directly using the pipeline function returned by `create_flow_pipeline`
     """
 
     pipeline_func = create_kfp_pipeline_from_flow_graph(flow_graph, code_url)
-    run_pipeline_result = kfp.Client(namespace=api_namespace, userid=userid).create_run_from_pipeline_func(pipeline_func,
-                                                                     arguments={},
-                                                                     experiment_name=experiment_name,
-                                                                     run_name=run_name,
-                                                                     namespace=namespace)
+    run_pipeline_result = kfp.Client(
+        namespace=api_namespace, userid=userid
+    ).create_run_from_pipeline_func(
+        pipeline_func,
+        arguments={},
+        experiment_name=experiment_name,
+        run_name=run_name,
+        namespace=namespace,
+    )
     return run_pipeline_result
 
 
-def create_kfp_pipeline_yaml(flow_graph, code_url, pipeline_file_path=DEFAULT_KFP_YAML_OUTPUT_PATH):
+def create_kfp_pipeline_yaml(
+    flow_graph, code_url, pipeline_file_path=DEFAULT_KFP_YAML_OUTPUT_PATH
+):
     """
     Creates a new KFP pipeline YAML using `kfp.compiler.Compiler()`. Note: Intermediate pipeline YAML is saved
     at `pipeline_file_path`

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -1,3 +1,4 @@
+import os
 from collections import deque
 
 import kfp
@@ -15,6 +16,223 @@ from .constants import (
     DEFAULT_FLOW_CODE_URL,
     DEFAULT_KFP_YAML_OUTPUT_PATH,
 )
+
+
+class KubeflowPipelines(object):
+    def __init__(
+        self,
+        name,
+        graph,
+        flow,
+        code_package,
+        code_package_url,
+        metadata,
+        datastore,
+        environment,
+        event_logger,
+        monitor,
+        namespace=None,
+        api_namespace=None,
+        username=None,
+    ):
+        self.name = name
+        self.graph = graph
+        self.flow = flow
+        self.code_package = code_package
+        self.code_package_url = code_package_url
+        self.metadata = metadata
+        self.datastore = datastore
+        self.environment = environment
+        self.event_logger = event_logger
+        self.monitor = monitor
+        self.namespace = namespace
+        self.username = username
+
+        self._client = kfp.Client(namespace=api_namespace, userid=username)
+        # TODO: self._cron = self._cron()
+
+    def create_command_templates_from_graph(self):
+        """
+        Create a map of steps to their corresponding command templates. These command templates help define the command
+        to be used to run that particular step with placeholders for the `run_id` and `datastore_root` (location of the datastore).
+
+        # Note:
+        # Level-order traversal is adopted to keep the task-ids in line with what happens during a local metaflow execution.
+        # It is not entirely necessary to keep this order of task-ids if we are able to point to the correct input-paths for
+        # each step. But, using this ordering does keep the organization of data in the datastore more understandable and
+        # natural (i.e., `start` gets a task id of 1, next step gets a task id of 2 and so on with 'end' step having the
+        # highest task id. So the paths in the datastore look like: {run-id}/start/1, {run-id}/next-step/2, and so on)
+        """
+
+        def build_cmd_template(step_name, task_id, input_paths):
+            """
+            Returns the python command template to be used for each step.
+
+            This method returns a string with placeholders for `datastore_root` and `run_id`
+            which get populated using the provided config and the kfp run ID respectively.
+            The rest of the command string is populated using the passed arguments which are known before the run starts.
+
+            An example constructed command template (to run a step named `hello`):
+            "python downloaded_flow.py --datastore s3 --datastore-root {ds_root} " \
+                             "step hello --run-id {run_id} --task-id 2 " \
+                             "--input-paths {run_id}/start/1"
+            """
+
+            python_cmd = (
+                "python {downloaded_file_name} --datastore s3 --datastore-root {{ds_root}} "
+                "step {step_name} --run-id {{run_id}} --task-id {task_id} "
+                "--input-paths {input_paths}".format(
+                    downloaded_file_name=DEFAULT_DOWNLOADED_FLOW_FILENAME,
+                    step_name=step_name,
+                    task_id=task_id,
+                    input_paths=input_paths,
+                )
+            )
+            return python_cmd
+
+        steps_deque = deque(["start"])  # deque to process the DAG in level order
+        current_task_id = 0
+
+        # set of seen steps, i.e., added to the queue for processing
+        seen_steps = set(["start"])
+        # Mapping of steps to task ids
+        step_to_task_id_map = {}
+        # Mapping of steps to their command templates
+        step_to_command_template_map = {}
+
+        while len(steps_deque) > 0:
+            current_step = steps_deque.popleft()
+            current_task_id += 1
+            step_to_task_id_map[current_step] = current_task_id
+            current_node = self.graph.nodes[current_step]
+
+            # Generate the correct input_path for each step. Note: input path depends on a step's parents (i.e., in_funcs)
+            # Format of the input-paths for reference:
+            # non-join nodes: "run-id/parent-step/parent-task-id",
+            # branch-join node: "run-id/:p1/p1-task-id,p2/p2-task-id,..."
+            # foreach node: TODO: foreach is not considered here
+            if current_task_id == 1:  # start step
+                cur_input_path = "{run_id}/_parameters/0"  # this is the standard input path for the `start` step
+            else:
+                if current_node.type == "join":
+                    cur_input_path = "{run_id}/:"
+                    for parent_step in current_node.in_funcs:
+                        cur_input_path += "{parent}/{parent_task_id},".format(
+                            parent=parent_step,
+                            parent_task_id=str(step_to_task_id_map[parent_step]),
+                        )
+                    cur_input_path = cur_input_path.strip(",")
+                else:
+                    parent_step = current_node.in_funcs[0]
+                    cur_input_path = "{{run_id}}/{parent}/{parent_task_id}".format(
+                        parent=parent_step,
+                        parent_task_id=str(step_to_task_id_map[parent_step]),
+                    )
+
+            step_to_command_template_map[current_step] = build_cmd_template(
+                current_step, current_task_id, cur_input_path
+            )
+
+            for step in current_node.out_funcs:
+                if step not in seen_steps:
+                    steps_deque.append(step)
+                    seen_steps.add(step)
+
+        return step_to_command_template_map
+
+    @staticmethod
+    def add_env_variables_transformer(container_op):
+        """
+        Add environment variables to the container op.
+        """
+        container_op.add_env_variable(
+            V1EnvVar(name="S3_BUCKET", value=DATASTORE_SYSROOT_S3)
+        )
+        container_op.add_env_variable(
+            V1EnvVar(name="S3_AWS_ARN", value=METAFLOW_AWS_ARN)
+        )
+        container_op.add_env_variable(
+            V1EnvVar(name="S3_AWS_REGION", value=METAFLOW_AWS_S3_REGION)
+        )
+        return container_op
+
+    def create_kfp_pipeline_from_flow_graph(self, code_url=DEFAULT_FLOW_CODE_URL):
+        base_image = "ssreejith3/mf_on_kfp:python-curl-git"  # TODO: environment variable
+        step_to_command_template_map = self.create_command_templates_from_graph()
+        # Container op that corresponds to a step defined in the Metaflow flowgraph.
+        step_op = kfp.components.func_to_container_op(
+            step_op_func, base_image=base_image
+        )
+        # Container op that corresponds to the 'start' step of Metaflow.
+        start_op = kfp.components.func_to_container_op(
+            start_op_func, base_image=base_image
+        )
+
+        @dsl.pipeline(
+            name="MF on KFP Pipeline",
+            description="Pipeline defining KFP equivalent of the Metaflow Flow."
+            "with branch and join nodes",
+        )
+        def kfp_pipeline_from_flow():
+            kfp_run_id = "kfp-" + dsl.RUN_ID_PLACEHOLDER
+            # Start step (start is a special step as additional initialisation is done internally)
+            step_to_container_op_map = {}
+            step_to_container_op_map["start"] = start_op(
+                step_to_command_template_map["start"], code_url, kfp_run_id
+            ).set_display_name("start")
+
+            # Define container ops for remaining steps
+            for step, cmd in step_to_command_template_map.items():
+                if step != "start":
+                    step_to_container_op_map[step] = step_op(
+                        step_to_command_template_map[step], step, code_url, kfp_run_id
+                    ).set_display_name(step)
+
+            # Add environment variables to all ops
+            dsl.get_pipeline_conf().add_op_transformer(
+                KubeflowPipelines.add_env_variables_transformer
+            )
+
+            # Define ordering of container op execution
+            for step in self.graph.nodes.keys():
+                if step != "start":
+                    for parent in self.graph.nodes[step].in_funcs:
+                        step_to_container_op_map[step].after(
+                            step_to_container_op_map[parent]
+                        )
+
+        return kfp_pipeline_from_flow
+
+    def create_run_on_kfp(
+        self,
+        code_url, experiment_name, run_name, namespace, api_namespace, userid
+    ):
+        """
+        Creates a new run on KFP using the `kfp.Client()`. Note: Intermediate pipeline YAML is not generated as this creates
+        the run directly using the pipeline function returned by `create_flow_pipeline`
+        """
+
+        pipeline_func = self.create_kfp_pipeline_from_flow_graph(code_url)
+        run_pipeline_result = self._client.create_run_from_pipeline_func(
+            pipeline_func,
+            arguments={},
+            experiment_name=experiment_name,
+            run_name=run_name,
+            namespace=namespace,
+        )
+        return run_pipeline_result
+
+    def create_kfp_pipeline_yaml(
+        self,
+        code_url, pipeline_file_path=DEFAULT_KFP_YAML_OUTPUT_PATH
+    ):
+        """
+        Creates a new KFP pipeline YAML using `kfp.compiler.Compiler()`. Note: Intermediate pipeline YAML is saved
+        at `pipeline_file_path`
+        """
+        pipeline_func = self.create_kfp_pipeline_from_flow_graph(code_url)
+        kfp.compiler.Compiler().compile(pipeline_func, pipeline_file_path)
+        return os.path.abspath(pipeline_file_path)
 
 
 def step_op_func(
@@ -204,205 +422,3 @@ def start_op_func(start_command_template: str, code_url: str, kfp_run_id: str):
 
     print("_______________ Done __________________________")
 
-
-def step_container_op():
-    """
-    Container op that corresponds to a step defined in the Metaflow flowgraph.
-
-    Note: The public docker image is a copy of the internal docker image we were using (borrowed from aip-kfp-example).
-    """
-
-    step_op = kfp.components.func_to_container_op(
-        step_op_func, base_image="ssreejith3/mf_on_kfp:python-curl-git"
-    )
-    return step_op
-
-
-def start_container_op():
-    """
-    Container op that corresponds to the 'start' step of Metaflow.
-
-    Note: The public docker image is a copy of the internal docker image we were using (borrowed from aip-kfp-example).
-    """
-
-    start_op = kfp.components.func_to_container_op(
-        start_op_func, base_image="ssreejith3/mf_on_kfp:python-curl-git"
-    )
-    return start_op
-
-
-def add_env_variables_transformer(container_op):
-    """
-    Add environment variables to the container op.
-    """
-
-    container_op.add_env_variable(
-        V1EnvVar(name="S3_BUCKET", value=DATASTORE_SYSROOT_S3)
-    )
-    container_op.add_env_variable(V1EnvVar(name="S3_AWS_ARN", value=METAFLOW_AWS_ARN))
-    container_op.add_env_variable(
-        V1EnvVar(name="S3_AWS_REGION", value=METAFLOW_AWS_S3_REGION)
-    )
-    return container_op
-
-
-def create_command_templates_from_graph(graph):
-    """
-    Create a map of steps to their corresponding command templates. These command templates help define the command
-    to be used to run that particular step with placeholders for the `run_id` and `datastore_root` (location of the datastore).
-
-    # Note:
-    # Level-order traversal is adopted to keep the task-ids in line with what happens during a local metaflow execution.
-    # It is not entirely necessary to keep this order of task-ids if we are able to point to the correct input-paths for
-    # each step. But, using this ordering does keep the organization of data in the datastore more understandable and
-    # natural (i.e., `start` gets a task id of 1, next step gets a task id of 2 and so on with 'end' step having the
-    # highest task id. So the paths in the datastore look like: {run-id}/start/1, {run-id}/next-step/2, and so on)
-    """
-
-    def build_cmd_template(step_name, task_id, input_paths):
-        """
-        Returns the python command template to be used for each step.
-
-        This method returns a string with placeholders for `datastore_root` and `run_id`
-        which get populated using the provided config and the kfp run ID respectively.
-        The rest of the command string is populated using the passed arguments which are known before the run starts.
-
-        An example constructed command template (to run a step named `hello`):
-        "python downloaded_flow.py --datastore s3 --datastore-root {ds_root} " \
-                         "step hello --run-id {run_id} --task-id 2 " \
-                         "--input-paths {run_id}/start/1"
-        """
-
-        python_cmd = (
-            "python {downloaded_file_name} --datastore s3 --datastore-root {{ds_root}} "
-            "step {step_name} --run-id {{run_id}} --task-id {task_id} "
-            "--input-paths {input_paths}".format(
-                downloaded_file_name=DEFAULT_DOWNLOADED_FLOW_FILENAME,
-                step_name=step_name,
-                task_id=task_id,
-                input_paths=input_paths,
-            )
-        )
-        return python_cmd
-
-    steps_deque = deque(["start"])  # deque to process the DAG in level order
-    current_task_id = 0
-
-    # set of seen steps, i.e., added to the queue for processing
-    seen_steps = set(["start"])
-    # Mapping of steps to task ids
-    step_to_task_id_map = {}
-    # Mapping of steps to their command templates
-    step_to_command_template_map = {}
-
-    while len(steps_deque) > 0:
-        current_step = steps_deque.popleft()
-        current_task_id += 1
-        step_to_task_id_map[current_step] = current_task_id
-        current_node = graph.nodes[current_step]
-
-        # Generate the correct input_path for each step. Note: input path depends on a step's parents (i.e., in_funcs)
-        # Format of the input-paths for reference:
-        # non-join nodes: "run-id/parent-step/parent-task-id",
-        # branch-join node: "run-id/:p1/p1-task-id,p2/p2-task-id,..."
-        # foreach node: TODO: foreach is not considered here
-        if current_task_id == 1:  # start step
-            cur_input_path = "{run_id}/_parameters/0"  # this is the standard input path for the `start` step
-        else:
-            if current_node.type == "join":
-                cur_input_path = "{run_id}/:"
-                for parent_step in current_node.in_funcs:
-                    cur_input_path += "{parent}/{parent_task_id},".format(
-                        parent=parent_step,
-                        parent_task_id=str(step_to_task_id_map[parent_step]),
-                    )
-                cur_input_path = cur_input_path.strip(",")
-            else:
-                parent_step = current_node.in_funcs[0]
-                cur_input_path = "{{run_id}}/{parent}/{parent_task_id}".format(
-                    parent=parent_step,
-                    parent_task_id=str(step_to_task_id_map[parent_step]),
-                )
-
-        step_to_command_template_map[current_step] = build_cmd_template(
-            current_step, current_task_id, cur_input_path
-        )
-
-        for step in current_node.out_funcs:
-            if step not in seen_steps:
-                steps_deque.append(step)
-                seen_steps.add(step)
-
-    return step_to_command_template_map
-
-
-def create_kfp_pipeline_from_flow_graph(flow_graph, code_url=DEFAULT_FLOW_CODE_URL):
-
-    step_to_command_template_map = create_command_templates_from_graph(flow_graph)
-
-    @dsl.pipeline(
-        name="MF on KFP Pipeline",
-        description="Pipeline defining KFP equivalent of the Metaflow flow. Currently supports linear flows and flows "
-        "with branch and join nodes",
-    )
-    def kfp_pipeline_from_flow():
-        kfp_run_id = "kfp-" + dsl.RUN_ID_PLACEHOLDER
-        # Start step (start is a special step as additional initialisation is done internally)
-        step_to_container_op_map = {}
-        step_to_container_op_map["start"] = (start_container_op())(
-            step_to_command_template_map["start"], code_url, kfp_run_id
-        ).set_display_name("start")
-
-        # Define container ops for remaining steps
-        for step, cmd in step_to_command_template_map.items():
-            if step != "start":
-                step_to_container_op_map[step] = (step_container_op())(
-                    step_to_command_template_map[step], step, code_url, kfp_run_id
-                ).set_display_name(step)
-
-        # Add environment variables to all ops
-        dsl.get_pipeline_conf().add_op_transformer(add_env_variables_transformer)
-
-        # Define ordering of container op execution
-        for step in flow_graph.nodes.keys():
-            if step != "start":
-                for parent in flow_graph.nodes[step].in_funcs:
-                    step_to_container_op_map[step].after(
-                        step_to_container_op_map[parent]
-                    )
-
-    return kfp_pipeline_from_flow
-
-
-def create_run_on_kfp(
-    flow_graph, code_url, experiment_name, run_name, namespace, api_namespace, userid
-):
-    """
-    Creates a new run on KFP using the `kfp.Client()`. Note: Intermediate pipeline YAML is not generated as this creates
-    the run directly using the pipeline function returned by `create_flow_pipeline`
-    """
-
-    pipeline_func = create_kfp_pipeline_from_flow_graph(flow_graph, code_url)
-    run_pipeline_result = kfp.Client(
-        namespace=api_namespace, userid=userid
-    ).create_run_from_pipeline_func(
-        pipeline_func,
-        arguments={},
-        experiment_name=experiment_name,
-        run_name=run_name,
-        namespace=namespace,
-    )
-    return run_pipeline_result
-
-
-def create_kfp_pipeline_yaml(
-    flow_graph, code_url, pipeline_file_path=DEFAULT_KFP_YAML_OUTPUT_PATH
-):
-    """
-    Creates a new KFP pipeline YAML using `kfp.compiler.Compiler()`. Note: Intermediate pipeline YAML is saved
-    at `pipeline_file_path`
-    """
-    pipeline_func = create_kfp_pipeline_from_flow_graph(flow_graph, code_url)
-
-    kfp.compiler.Compiler().compile(pipeline_func, pipeline_file_path)
-    return pipeline_file_path

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -85,10 +85,6 @@ class KubeflowPipelines(object):
         """
         commands = environment.get_package_commands(code_package_url)
         commands.extend(environment.bootstrap_commands(step_name))
-        commands.append(
-            "pip3 install -e "
-            "'git+https://github.com/alexlatchford/pipelines@alexla/AIP-1676#egg=kfp&subdirectory=sdk/python'"
-        )
         commands.append("echo 'Task is starting.'")
         commands.extend(step_cli)
         return " && ".join(commands)
@@ -317,7 +313,7 @@ class KubeflowPipelines(object):
         import kfp
         from kfp import dsl
 
-        base_image = "ssreejith3/mf_on_kfp:python-curl-git"  # TODO: AIP-1980 and make an environment variable
+        base_image = "hsezhiyan/metaflow-zillow:1.1"  # TODO: AIP-1980 and make an environment variable
         step_to_kfp_component_map = self.create_kfp_components_from_graph()
 
         # Container op that corresponds to a step defined in the Metaflow flowgraph.

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -1,0 +1,176 @@
+import posixpath
+from distutils.version import LooseVersion
+
+import click
+
+from metaflow import current, decorators
+from metaflow.datastore.datastore import TransformableObject
+from metaflow.exception import MetaflowException
+from metaflow.metaflow_config import (
+    KFP_SDK_API_NAMESPACE,
+    KFP_SDK_NAMESPACE,
+    KFP_RUN_URL_PREFIX,
+)
+from metaflow.package import MetaflowPackage
+from metaflow.plugins.kfp.constants import (
+    DEFAULT_EXPERIMENT_NAME,
+    DEFAULT_FLOW_CODE_URL,
+    DEFAULT_RUN_NAME,
+    DEFAULT_KFP_YAML_OUTPUT_PATH,
+)
+from metaflow.plugins.kfp.kfp import KubeflowPipelines
+from metaflow.plugins.kfp.kfp_decorator import KfpInternalDecorator
+from metaflow.util import get_username
+
+
+class IncorrectMetadataServiceVersion(MetaflowException):
+    headline = "Incorrect version for metaflow service"
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.group(name="kfp", help="Commands related to Kubeflow Pipelines.")
+@click.pass_obj
+def kubeflow_pipelines(obj):
+    obj.check(obj.graph, obj.flow, obj.environment, pylint=obj.pylint)
+
+
+@kubeflow_pipelines.command(help="Deploy a new version of this workflow to Kubeflow Pipelines.")
+@click.option(
+    "--code-url",
+    "code_url",
+    default=DEFAULT_FLOW_CODE_URL,
+    help="the code URL of the flow to be executed on KFP",
+)
+@click.option(
+    "--experiment-name",
+    "experiment_name",
+    default=DEFAULT_EXPERIMENT_NAME,
+    help="the associated experiment name for the run",
+)
+@click.option(
+    "--run-name", "run_name", default=DEFAULT_RUN_NAME, help="name assigned to the new KFP run",
+)
+@click.option(
+    "--namespace", "namespace", default=KFP_SDK_NAMESPACE, help="namespace of your run in KFP.",
+)
+@click.option(
+    "--api-namespace",
+    "api_namespace",
+    default=KFP_SDK_API_NAMESPACE,
+    help="namespace where the API service is run.",
+)
+@click.option(
+    "--yaml-only",
+    "yaml_only",
+    is_flag=True,
+    default=False,
+    help="Generate the KFP YAML which is used to run the workflow on Kubeflow Pipelines.",
+)
+@click.option(
+    "--pipeline-path",
+    "pipeline_path",
+    default=DEFAULT_KFP_YAML_OUTPUT_PATH,
+    help="the output path (or filename) of the generated KFP pipeline yaml file",
+)
+@click.pass_obj
+def run(
+    obj,
+    code_url=DEFAULT_FLOW_CODE_URL,
+    experiment_name=DEFAULT_EXPERIMENT_NAME,
+    run_name=DEFAULT_RUN_NAME,
+    namespace=KFP_SDK_NAMESPACE,
+    api_namespace=KFP_SDK_API_NAMESPACE,
+    yaml_only=False,
+    pipeline_path=DEFAULT_KFP_YAML_OUTPUT_PATH,
+):
+    check_metadata_service_version(obj)
+    flow = make_flow(obj, current.flow_name, namespace, api_namespace)
+
+    if yaml_only:
+        pipeline_path = flow.create_kfp_pipeline_yaml(code_url, pipeline_path)
+        obj.echo(
+            "\nDone converting *{name}* to {path}".format(
+                name=current.flow_name, path=pipeline_path
+            )
+        )
+    else:
+        obj.echo("Deploying *%s* to Kubeflow Pipelines..." % current.flow_name, bold=True)
+        run_pipeline_result = flow.create_run_on_kfp(
+            code_url, experiment_name, run_name, namespace, api_namespace, get_username()
+        )
+
+        obj.echo("\nRun created successfully!\n")
+        kfp_run_url = posixpath.join(
+            KFP_RUN_URL_PREFIX, "_/pipeline/#/runs/details", run_pipeline_result.run_id
+        )
+        obj.echo("Workflow *{name}* triggered on KFP".format(name=current.flow_name), bold=True)
+        obj.echo("{kfp_run_url}".format(kfp_run_url=kfp_run_url), fg="cyan")
+
+
+def check_metadata_service_version(obj):
+    metadata = obj.metadata
+    version = metadata.version()
+    if version == "local":
+        return
+    elif version is not None and LooseVersion(version) >= LooseVersion("2.0.2"):
+        # Metaflow metadata service needs to be at least at version 2.0.2
+        return
+    else:
+        obj.echo("")
+        obj.echo(
+            "You are running a version of the metaflow service "
+            "that currently doesn't support Kubeflow Pipelines. "
+        )
+        obj.echo(
+            "For more information on how to upgrade your "
+            "service to a compatible version (>= 2.0.2), visit:"
+        )
+        obj.echo(
+            "    https://admin-docs.metaflow.org/metaflow-on-aws/operation"
+            "s-guide/metaflow-service-migration-guide",
+            fg="green",
+        )
+        obj.echo("Once you have upgraded your metadata service, please " "re-execute your command.")
+        raise IncorrectMetadataServiceVersion(
+            "Try again with a more recent " "version of metaflow service " "(>=2.0.2)."
+        )
+
+
+def make_flow(obj, name, namespace, api_namespace):
+    datastore = obj.datastore(
+        obj.flow.name,
+        mode="w",
+        metadata=obj.metadata,
+        event_logger=obj.event_logger,
+        monitor=obj.monitor,
+    )
+
+    if datastore.TYPE != "s3":
+        raise MetaflowException("Kubeflow Pipelines requires --datastore=s3.")
+
+    # Attach KFP decorator to the flow
+    decorators._attach_decorators(obj.flow, [KfpInternalDecorator.name])
+    decorators._init_decorators(obj.flow, obj.graph, obj.environment, obj.datastore, obj.logger)
+
+    obj.package = MetaflowPackage(obj.flow, obj.environment, obj.logger, obj.package_suffixes)
+    package_url = datastore.save_data(obj.package.sha, TransformableObject(obj.package.blob))
+
+    return KubeflowPipelines(
+        name,
+        obj.graph,
+        obj.flow,
+        obj.package,
+        package_url,
+        obj.metadata,
+        obj.datastore,
+        obj.environment,
+        obj.event_logger,
+        obj.monitor,
+        namespace=namespace,
+        api_namespace=api_namespace,
+        username=get_username(),
+    )

--- a/metaflow/plugins/kfp/kfp_decorator.py
+++ b/metaflow/plugins/kfp/kfp_decorator.py
@@ -1,8 +1,10 @@
+import json
 import os
 import tarfile
+import tempfile
 from urllib.parse import urlparse
 
-from metaflow import util
+from metaflow import util, current
 from metaflow.datastore import MetaflowDataStore
 from metaflow.datastore.util.s3util import get_s3_client
 from metaflow.decorators import StepDecorator
@@ -31,6 +33,14 @@ class KfpInternalDecorator(StepDecorator):
         # Register book-keeping metadata for debugging.
         metadata.register_metadata(run_id, step_name, task_id, entries)
 
+    def task_pre_step(
+        self, step_name, ds, metadata, run_id, task_id, flow, graph, retry_count, max_retries
+    ):
+        if metadata.TYPE == "local":
+            self.ds_root = ds.root
+        else:
+            self.ds_root = None
+
     def task_finished(self, step_name, flow, graph, is_task_ok, retry_count, max_user_code_retries):
         if not is_task_ok:
             # The task finished with an exception - execution won't
@@ -39,8 +49,16 @@ class KfpInternalDecorator(StepDecorator):
 
         # For foreaches, we need to dump the cardinality of the fanout
         # for the KFP parallelFor
+        out_dict = dict(step_name=step_name, task_id=current.task_id)
         if graph[step_name].type == "foreach":
-            print("_foreach_num_splits={0}".format(flow._foreach_num_splits))
+            out_dict["foreach_num_splits"] = flow._foreach_num_splits
+            next_task_id = current.task_id + 1
+            out_dict["split_indexes"] = [
+                i for i in range(next_task_id, next_task_id + flow._foreach_num_splits)
+            ]
+
+        with open(os.path.join(tempfile.gettempdir(), "kfp_metaflow_out_dict.json"), "w") as file:
+            json.dump(out_dict, file)
 
         if self.ds_root:
             # We have a local metadata service so we need to persist it to the datastore.

--- a/metaflow/plugins/kfp/kfp_decorator.py
+++ b/metaflow/plugins/kfp/kfp_decorator.py
@@ -1,0 +1,62 @@
+import os
+import tarfile
+from urllib.parse import urlparse
+
+from metaflow import util
+from metaflow.datastore import MetaflowDataStore
+from metaflow.datastore.util.s3util import get_s3_client
+from metaflow.decorators import StepDecorator
+from metaflow.metadata import MetaDatum
+from metaflow.metaflow_config import DATASTORE_LOCAL_DIR
+
+
+class KfpInternalDecorator(StepDecorator):
+    name = "kfp_internal"
+
+    def task_pre_step(
+        self,
+        step_name,
+        datastore,
+        metadata,
+        run_id,
+        task_id,
+        flow,
+        graph,
+        retry_count,
+        max_user_code_retries,
+    ):
+        # TODO: any other KFP environment variables to get and register to Metadata service?
+        meta = {"kfp-execution": os.environ["METAFLOW_RUN_ID"]}
+        entries = [MetaDatum(field=k, value=v, type=k) for k, v in meta.items()]
+        # Register book-keeping metadata for debugging.
+        metadata.register_metadata(run_id, step_name, task_id, entries)
+
+    def task_finished(self, step_name, flow, graph, is_task_ok, retry_count, max_user_code_retries):
+        if not is_task_ok:
+            # The task finished with an exception - execution won't
+            # continue so no need to do anything here.
+            return
+
+        # For foreaches, we need to dump the cardinality of the fanout
+        # for the KFP parallelFor
+        if graph[step_name].type == "foreach":
+            print("_foreach_num_splits={0}".format(flow._foreach_num_splits))
+
+        if self.ds_root:
+            # We have a local metadata service so we need to persist it to the datastore.
+            # Note that the datastore is *always* s3 (see runtime_task_created function)
+            with util.TempDir() as td:
+                tar_file_path = os.path.join(td, "metadata.tgz")
+                with tarfile.open(tar_file_path, "w:gz") as tar:
+                    # The local metadata is stored in the local datastore
+                    # which, for batch jobs, is always the DATASTORE_LOCAL_DIR
+                    tar.add(DATASTORE_LOCAL_DIR)
+                # At this point we upload what need to s3
+                s3, _ = get_s3_client()
+                with open(tar_file_path, "rb") as f:
+                    path = os.path.join(
+                        self.ds_root,
+                        MetaflowDataStore.filename_with_attempt_prefix("metadata.tgz", retry_count),
+                    )
+                    url = urlparse(path)
+                    s3.upload_fileobj(f, url.netloc, url.path.lstrip("/"))

--- a/metaflow/util.py
+++ b/metaflow/util.py
@@ -10,6 +10,7 @@ from itertools import takewhile
 import re
 
 from metaflow.exception import MetaflowUnknownUser, MetaflowInternalError
+from metaflow.metaflow_config import METAFLOW_USER
 
 try:
     # python2
@@ -137,6 +138,9 @@ def get_username():
     could not be determined.
     """
     # note: the order of the list matters
+    if METAFLOW_USER:
+        return METAFLOW_USER
+
     ENVVARS = ['METAFLOW_USER', 'SUDO_USER', 'USERNAME', 'USER']
     for var in ENVVARS:
         user = os.environ.get(var)

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,13 @@
+import os
+
 from setuptools import setup, find_packages
 
 version = '2.2.3'
 
-
-"""
-To use this version of Metaflow (which includes KFP integration), you
-must first install the compatible version of KFP:
-
-  - git clone -b alexla/AIP-1676 https://github.com/alexlatchford/pipelines
-  - cd pipelines/sdk/python
-  - pip3 install -e .
-"""
-
-
+# TODO: once this branch is merged or in pip use, remove this
+os.system(
+    "pip3 install -e 'git+https://github.com/alexlatchford/pipelines@alexla/AIP-1676#egg=kfp&subdirectory=sdk/python'"
+)
 
 setup(name='metaflow',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = '2.2.3'
 
 # TODO: once this branch is merged or in pip use, remove this
 os.system(
-    "pip3 install -e 'git+https://github.com/alexlatchford/pipelines@alexla/AIP-1676#egg=kfp&subdirectory=sdk/python'"
+    "pip3 install 'git+https://github.com/alexlatchford/pipelines@alexla/AIP-1676#egg=kfp&subdirectory=sdk/python'"
 )
 
 setup(name='metaflow',


### PR DESCRIPTION
Benefits:
1. We fit into the Metaflow click paradigm getting access to context object giving us access to
```python
        obj.graph,
        obj.flow,
        obj.package,
        obj.metadata,
        obj.datastore,
        obj.environment,
        obj.event_logger,
        obj.monitor,
```

2. We are also now packaging the Flow rather than passing around a Flow python file to curl download.
3. Tested that @conda decorator works

I've refactored how the graph is created.  A recursive DFS is the path towards binding foreach mapper subgraphs to the foreach node.

Foreach is a work in progress, this is because KFP doesn't support aggregating outputs into a join/reducer node.  Hence, we will need to save the step taskIds in a KV store.  Ideally, this is Dynamo to avoid consistency issues.  However, we could use S3 and only store step_name -> taskId, and for the foreach node we'd store step_name -> [generated mapper taskIds].  The join or reducer node will have access to the parent node/step name at compile time, but not the taskIds which are dynamic.  

As part of this is for taskIds to not be set at compile time but at runtime using KFP/Argo taskIds, except for foreach mapper split nodes which may have taskId=step_name_<index> or more robustly taskId=<parent_task_id>_step_name_<index> where the <parent_task_id> is generated by KFP/Argo).  This would only work when we have a KV store of step or node name -> taskId.  We'd persist and load that info much like the AWS Step Functions plugin does.