### PR TITLE
Adding resource decorator for KFP

### DIFF
--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -21,7 +21,8 @@ from .catch_decorator import CatchDecorator
 from .timeout_decorator import TimeoutDecorator
 from .environment_decorator import EnvironmentDecorator
 from .retry_decorator import RetryDecorator
-from .aws.batch.batch_decorator import BatchDecorator, ResourcesDecorator
+from .resources_decorator import ResourcesDecorator
+from .aws.batch.batch_decorator import BatchDecorator
 from .aws.step_functions.step_functions_decorator import StepFunctionsInternalDecorator
 from .conda.conda_step_decorator import CondaStepDecorator
 from .kfp.kfp_decorator import KfpInternalDecorator

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -19,6 +19,8 @@ from .batch import Batch, BatchException
 from metaflow.metaflow_config import ECS_S3_ACCESS_IAM_ROLE, BATCH_JOB_QUEUE, \
                     BATCH_CONTAINER_IMAGE, BATCH_CONTAINER_REGISTRY
 
+from metaflow.plugins.resources_decorator import ResourcesDecorator
+
 try:
     # python2
     from urlparse import urlparse
@@ -26,35 +28,6 @@ except:  # noqa E722
     # python3
     from urllib.parse import urlparse
 
-
-class ResourcesDecorator(StepDecorator):
-    """
-    Step decorator to specify the resources needed when executing this step.
-    This decorator passes this information along to Batch when requesting resources
-    to execute this step.
-    This decorator is ignored if the execution of the step does not happen on Batch.
-    To use, annotate your step as follows:
-    ```
-    @resources(cpu=32)
-    @step
-    def myStep(self):
-        ...
-    ```
-    Parameters
-    ----------
-    cpu : int
-        Number of CPUs required for this step. Defaults to 1
-    gpu : int
-        Number of GPUs required for this step. Defaults to 0
-    memory : int
-        Memory size (in MB) required for this step. Defaults to 4000
-    """
-    name = 'resources'
-    defaults = {
-        'cpu': '1',
-        'gpu': '0',
-        'memory': '4000',
-    }
 
 class BatchDecorator(StepDecorator):
     """

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -5,7 +5,7 @@ import string
 import sys
 from collections import deque
 from pathlib import Path
-from typing import NamedTuple
+from typing import NamedTuple, Union
 
 import kfp
 from metaflow.metaflow_config import DATASTORE_SYSROOT_S3
@@ -42,7 +42,7 @@ class KubeflowPipelines(object):
         namespace=None,
         api_namespace=None,
         username=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Analogous to step_functions_cli.py
@@ -120,18 +120,16 @@ class KubeflowPipelines(object):
     @staticmethod
     def _get_resource_requirements(node):
         """
-        Get resource request or limit for a Metaflow step (node).
-        If @resources is also present, the maximum value is used for resource request, and lowest
-        value is used for resource limit.
-
-        Eventually resource request and limits link back to kubernetes, see
-        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        Get resource request or limit for a Metaflow step (node) set by @resources decorator.
 
         Supported parameters: 'cpu', 'cpu_limit', 'gpu', 'gpu_vendor', 'memory', 'memory_limit'
         Keys with no suffix set resource request (minimum);
         keys with 'limit' suffix sets resource limit (maximum).
 
-        Default unit for memory is megabyte.
+        Eventually resource request and limits link back to kubernetes, see
+        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+        Default unit for memory is megabyte, aligning with existing resource decorator usage.
 
         Example using resource decorator:
             @resource(cpu=0.5, cpu_limit=2, gpu=1, memory=300)
@@ -139,38 +137,24 @@ class KubeflowPipelines(object):
             def my_kfp_step(): ...
         """
 
-        resource = dict()
+        def to_k8s_resource_format(resource: str, value: Union[int, float, str]):
+            value = str(value)
+
+            # Defaults memory unit to megabyte
+            if resource in ["memory", "memory_limit"] and value.isnumeric():
+                value = f"{value}M"
+            return value
+
+        resource_requirement = dict()
         for deco in node.decorators:
             if isinstance(deco, ResourcesDecorator):
-                for k, v in deco.attributes.items():
-                    my_val = resource.get(k)
+                for attr_key, attr_value in deco.attributes.items():
+                    if attr_value is not None:
+                        resource_requirement[attr_key] = to_k8s_resource_format(
+                            attr_key, attr_value
+                        )
 
-                    if v is not None:
-                        if my_val is not None:
-                            # Resource decorator should only be used once to avoid confusion
-                            # This only happens when user statically define same resource
-                            # requirement with more than one resource decorator for a single step.
-                            # Decorators attached during runtime doesn't fall into this category
-                            # for being dropped by metaflow.decorators._attach_decorators_to_step.
-                            # TODO before merging: should this print or raise error?
-                            print(
-                                f"Resource requirement {k} is set more than once. "
-                                f"The first request with value {my_val} is taken "
-                                f"over the second request with value {v}."
-                            )
-
-                        else:
-                            v = str(v)
-
-                            if k == "gpu" and v == "0":  # Ignore 0 gpu request
-                                continue
-
-                            if k in ["memory", "memory_limit"] and v.isnumeric():
-                                v += "M"  # Metaflow default unit for memory is Megabyte
-
-                            resource[k] = v
-
-        return resource
+        return resource_requirement
 
     def create_kfp_components_from_graph(self):
         """
@@ -393,6 +377,30 @@ class KubeflowPipelines(object):
 
             visited = {}
 
+            def set_resource_requirements(
+                container_op: ContainerOp, resource_requirements: dict
+            ):
+                if "memory" in resource_requirements:
+                    container_op.container.set_memory_request(
+                        resource_requirements["memory"]
+                    )
+                if "memory_limit" in resource_requirements:
+                    container_op.container.set_memory_limit(
+                        resource_requirements["memory_limit"]
+                    )
+                if "cpu" in resource_requirements:
+                    container_op.container.set_cpu_request(resource_requirements["cpu"])
+                if "cpu_limit" in resource_requirements:
+                    container_op.container.set_cpu_limit(
+                        resource_requirements["cpu_limit"]
+                    )
+                if "gpu" in resource_requirements:
+                    # TODO(yunw)(AIP-2048): Support mixture of GPU from different vendors.
+                    container_op.container.set_gpu_limit(
+                        resource_requirements["gpu"],
+                        vendor=resource_requirements["gpu_vendor"],
+                    )
+
             def build_kfp_dag(node: DAGNode, context: str, index=None):
                 kfp_component = step_to_kfp_component_map[node.name]
                 visited[node.name] = step_op(
@@ -403,20 +411,10 @@ class KubeflowPipelines(object):
                     index=index,
                 ).set_display_name(node.name)
 
-                resource = KubeflowPipelines._get_resource_requirements(node)
-                if "memory" in resource:
-                    visited[node.name].set_memory_request(resource["memory"])
-                if "memory_limit" in resource:
-                    visited[node.name].set_memory_limit(resource["memory_limit"])
-                if "cpu" in resource:
-                    visited[node.name].set_cpu_request(resource["cpu"])
-                if "cpu_limit" in resource:
-                    visited[node.name].set_cpu_limit(resource["cpu_limit"])
-                if "gpu" in resource:
-                    # TODO(yunw)(AIP-2048): Support mixture of GPU from different vendors.
-                    visited[node.name].set_gpu_limit(
-                        resource["gpu"], vendor=resource["gpu_vendor"]
-                    )
+                set_resource_requirements(
+                    visited[node.name],
+                    KubeflowPipelines._get_resource_requirements(node),
+                )
 
                 if node.type == "foreach":
                     with kfp.dsl.ParallelFor(

--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -52,11 +52,18 @@ class ResourcesDecorator(StepDecorator):
              Defaults None - relying on Kubernetes defaults.
     """
     name = 'resources'
+
+    # Actual defaults are set in .aws.batch.batch_decorator.BatchDecorator and
+    # .kfp.kfp.KubeflowPipelines._get_resource_requirements respectively.
+    # The defaults here simply lists accepted attributes.
     defaults = {
-        "cpu": "1",
+        # AWS Batch and KFP supported attributes
+        "cpu": None,
+        "gpu": None,
+        "memory": None,
+
+        # Only KFP supported attributes
         "cpu_limit": None,
-        "gpu": "0",
-        "gpu_vendor": "nvidia",
-        "memory": "4000",
+        "gpu_vendor": None,
         "memory_limit": None,
     }

--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -1,0 +1,62 @@
+from metaflow.decorators import StepDecorator
+
+
+class ResourcesDecorator(StepDecorator):
+    """
+    Step decorator to specify the resources needed when executing this step.
+    This decorator passes this information along when requesting resources
+    to execute this step.
+
+    This decorator can be used for two purpose:
+    When using with AWS Batch decorator, only 'cpu', 'gpu', and 'memory' parameters are supported.
+    When using for Kubeflow Pipeline, 'cpu', and 'memory' sets resource requests;
+        'cpu_limit', 'gpu', 'memory_limit' sets resource limit.
+        For more details please refer to
+        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    This decorator is ignored if the execution of the step does not happen on Batch.
+    To use, annotate your step as follows:
+    ```
+    @resources(cpu=32, memory="15G")
+    @step
+    def myStep(self):
+        ...
+    ```
+
+    Parameters
+    ----------
+    cpu : Union[int, float, str]
+        AWS Batch: Number of CPUs required for this step. Defaults to 1. Must be integer.
+        KFP: Number of CPUs required for this step. Defaults to 1. Can input int, float, or str.
+            Support millicpu requests using float or string ending in 'm'.
+            A request with a decimal point, like 0.1, is converted to 100m by the API,
+            and precision finer than 1m is not allowed.
+    cpu_limit : Union[int, float, str]
+        Not for AWS Batch.
+        KFP: Number of CPUs limited for this step. Defaults None - relying on Kubernetes defaults.
+    gpu : int
+        AWS Batch: Number of GPUs required for this step. Defaults to 0.
+        KFP: GPU limit for this step. Defaults to 0.
+            GPU are only supposed to be specified in limit section.
+            See https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/
+    gpu_vendor : str
+        Not for AWS Batch.
+        KFP: "nvidia" or "amd". Defaults to "nvidia".
+    memory : Union[int, str]
+        AWS Batch: Memory size (in MB) required for this step. Defaults to 4000.
+        KFP: Memory size required for this step. Default to 4000 MB. For int input, unit defaults to MB.
+            More memory units are supported, including "E", "P", "T", "G", "M", "K". (i.e. "4000M")
+    memory_limit : Union[int, str]
+        Not for AWS Batch.
+        KFP: Memory limit for this step. Default unit is MB.
+            More memory units are supported, including "E", "P", "T", "G", "M", "K". (i.e. "4000M")
+             Defaults None - relying on Kubernetes defaults.
+    """
+    name = 'resources'
+    defaults = {
+        "cpu": "1",
+        "cpu_limit": None,
+        "gpu": "0",
+        "gpu_vendor": "nvidia",
+        "memory": "4000",
+        "memory_limit": None,
+    }

--- a/metaflow/tutorials/00-helloworld/hello.py
+++ b/metaflow/tutorials/00-helloworld/hello.py
@@ -1,4 +1,4 @@
-from metaflow import FlowSpec, step
+from metaflow import FlowSpec, step, resources
 
 
 class HelloFlow(FlowSpec):
@@ -21,6 +21,7 @@ class HelloFlow(FlowSpec):
         self.x = 100
         self.next(self.hello)
 
+    @resources(cpu=0.5, memory=150)
     @step
     def hello(self):
         """
@@ -45,6 +46,7 @@ class HelloFlow(FlowSpec):
         print("END step:\n We have reached the END step!\n")
         print("HelloFlow is all done.")
         print("___________________________________________")
+
 
 if __name__ == '__main__':
     HelloFlow()

--- a/metaflow/tutorials/00-helloworld/hello.py
+++ b/metaflow/tutorials/00-helloworld/hello.py
@@ -1,4 +1,4 @@
-from metaflow import FlowSpec, step, resources
+from metaflow import FlowSpec, step
 
 
 class HelloFlow(FlowSpec):
@@ -21,7 +21,6 @@ class HelloFlow(FlowSpec):
         self.x = 100
         self.next(self.hello)
 
-    @resources(cpu=0.5, memory=150)
     @step
     def hello(self):
         """

--- a/metaflow/tutorials/09-hellokfp/resource_flow.py
+++ b/metaflow/tutorials/09-hellokfp/resource_flow.py
@@ -1,0 +1,71 @@
+from metaflow import FlowSpec, step, resources
+
+
+class ResourceFlow(FlowSpec):
+    """
+    A flow where Metaflow prints 'Hi'.
+
+    The hello step uses @resource decorator that only works when kfp plug-in is used.
+    """
+    @step
+    def start(self):
+        """
+        All flows must have a step named 'start' that is the first step in the flow.
+        """
+        print("\n\n_______________________________________")
+        print("START step:\n We are now inside the START step - Hello World!\n")
+        print("___________________________________________")
+        self.next(self.all_resource)
+
+    @resources(
+        cpu=0.5, cpu_limit=5,
+        gpu=3, gpu_vendor="amd",
+        memory=150, memory_limit="1G"
+    )
+    @step
+    def all_resource(self):
+        """
+        A step where all resource requirements keys are used.
+        """
+        print("\n\n_______________________________________")
+        print("All resource requirements are set by resource decorator.")
+        print("All resource requests and limits are expected in argo yaml.")
+        print("___________________________________________")
+        self.next(self.no_resource)
+
+    @resources
+    @step
+    def no_resource(self):
+        """
+        A step where resource decorator was used but no attribute was set
+        """
+        print("\n\n_______________________________________")
+        print("Resource decorator sets no resource requirements.")
+        print("No resource limit or request expected in argo yaml.")
+        print("___________________________________________")
+        self.next(self.no_decorator)
+
+    @step
+    def no_decorator(self):
+        """
+        A step where resource decorator was not used
+        """
+        print("\n\n_______________________________________")
+        print("No resource decorator was used.")
+        print("No resource limit or request expected in argo yaml.")
+        print("___________________________________________")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """
+        All flows must have an 'end' step, which is the last step in the flow.
+        """
+        print("\n\n_______________________________________")
+        print("END step:\n We have reached the END step!\n")
+        print("ResourceFlow is all done.")
+        print("___________________________________________")
+
+
+if __name__ == '__main__':
+    ResourceFlow()


### PR DESCRIPTION
Refactor resource decorator for KFP use case.

Changes:
* Moving and adding more parameters to `@resources` decorator for KFP use case
* Add resource requirement logics to KFP

Tests:
* Adding a `@resources` decorator to hello.py, and check output of `python 00-helloworld/hello.py kfp run --yaml-only` command. The following shows up in output yaml corresponding to this change in `hello.py`: https://github.com/zillow/metaflow/pull/20/files#diff-d410204a3c2638d1274ff12522df307eR24
```
  resources:
    requests: {memory: 150M, cpu: '0.5'}
```

Sample pipeline yaml complied from with the modified hello.py. (Feel free to change extension to `.yaml`. `.txt` is used because github doesn't support `.yaml` in PR.)
[kfp_pipeline.txt](https://github.com/zillow/metaflow/files/5284151/kfp_pipeline.txt)
