### PR TITLE
Persist sdout and stderr to S3.

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -439,10 +439,10 @@ def step_op_func(
     stderr_file.close()
 
     save_logs_cmd_template = f"python -m awscli s3 cp {{log_file}} s3://kfp-example-aip-dev/metaflow/{flow_name}/{kfp_run_id}/{task_out_dict['step_name']}/{task_out_dict['task_id']}/{{log_file}}"
-    save_logs_command = f"python -m awscli s3 cp 0.stdout.log s3://kfp-example-aip-dev/metaflow/{flow_name}/{kfp_run_id}/{task_out_dict['step_name']}/{task_out_dict['task_id']}/0.stdout.log"
-    # log_stdout_cmd = save_logs_cmd_template.format("0.stdout.log")
-    # log_stderr_cmd = save_logs_cmd_template.format("0.stderr.log")
-    # save_logs_command = f"{log_stdout_cmd} && {log_stderr_cmd}"
+    # save_logs_command = f"python -m awscli s3 cp 0.stdout.log s3://kfp-example-aip-dev/metaflow/{flow_name}/{kfp_run_id}/{task_out_dict['step_name']}/{task_out_dict['task_id']}/0.stdout.log"
+    log_stdout_cmd = save_logs_cmd_template.format(log_file="0.stdout.log")
+    log_stderr_cmd = save_logs_cmd_template.format(log_file="0.stderr.log")
+    save_logs_command = f"{log_stderr_cmd} >/dev/null && {log_stdout_cmd} >/dev/null"
 
     print("Logging command: ", save_logs_command)
     with Popen(
@@ -452,7 +452,7 @@ def step_op_func(
         stderr=STDOUT,
         universal_newlines=True
     ) as process:
-        print("Logging stdout: ", process.stdout)
+        print("Finished saving logs to S3.")
     
     StepMetaflowContext = NamedTuple(
         "context", [("task_out_dict", dict), ("split_indexes", list)]

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -425,19 +425,24 @@ def step_op_func(
         ["/bin/sh", "-c", cmd],
         stdin=PIPE,
         stdout=PIPE,
-        stderr=STDOUT,
+        stderr=PIPE,
         universal_newlines=True,
         env=dict(os.environ, USERNAME="kfp-user", METAFLOW_RUN_ID=kfp_run_id),
-    ) as process, StringIO() as stdout_buffer:
+    ) as process, StringIO() as stdout_buffer, StringIO() as stderr_buffer:
         for line in process.stdout:
             print(line, end="")
             stdout_buffer.write(line)
         stdout_output = stdout_buffer.getvalue()
+        for line in process.stderr:
+            print(line, end="")
+            stderr_buffer.write(line)
+        stderr_output = stderr_buffer.getvalue()
 
     with open("0.stdout.log", "w") as stdout_file, open(
         "0.stderr.log", "w"
     ) as stderr_file:
-        _ = stdout_file.write(stdout_output)
+        stdout_file.write(stdout_output)
+        stderr_file.write(stderr_output)
 
     save_logs_cmd_template = (
         f"python -m awscli s3 cp {{log_file}} {datastore_root}/"

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -443,14 +443,14 @@ def step_op_func(
     ) as process:
         print("Running command.")
     process.wait()
-
+    
     try:
         with open(
             os.path.join(tempfile.gettempdir(), "kfp_metaflow_out_dict.json"), "r"
         ) as file:
             task_out_dict = json.load(file)
     except FileNotFoundError:
-        print("There was an error with running the flow.")
+        raise Exception("Flow failed to execute properly.")
     print("___DONE___")
 
     StepMetaflowContext = NamedTuple(

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -439,7 +439,6 @@ def step_op_func(
     ) as stderr_file:
         _ = stdout_file.write(stdout_output)
 
-    # TODO: obtain the string `s3://kfp-example-aip-dev/metaflow/` dynamically
     save_logs_cmd_template = (
         f"python -m awscli s3 cp {{log_file}} {datastore_root}/"
         f"{flow_name}/{kfp_run_id}/{step_name}/"

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -40,7 +40,7 @@ class KubeflowPipelines(object):
         namespace=None,
         api_namespace=None,
         username=None,
-        **kwargs,
+        **kwargs
     ):
         """
         Analogous to step_functions_cli.py
@@ -367,7 +367,6 @@ class KubeflowPipelines(object):
 
             def build_kfp_dag(node: DAGNode, context: str, index=None):
                 kfp_component = step_to_kfp_component_map[node.name]
-
                 visited[node.name] = step_op(
                     datastore_root,
                     kfp_component.step_command,
@@ -438,9 +437,6 @@ def step_op_func(
     print("----")
 
     # TODO: Map username to KFP specific user/profile/namespace
-    # Note: we don't put this in a try catch block as below because
-    # Popen will not produce a error that will cause the Kubeflow step
-    # to stop
     with Popen(
         cmd,
         shell=True,
@@ -449,7 +445,6 @@ def step_op_func(
         env=dict(os.environ, USERNAME="kfp-user", METAFLOW_RUN_ID=kfp_run_id),
     ) as process:
         print("Running command.")
-    process.wait()
 
     if process.returncode != 0:
         raise Exception("Returned: %s" % process.returncode)

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -35,7 +35,7 @@ class KubeflowPipelines(object):
         namespace=None,
         api_namespace=None,
         username=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Analogous to step_functions_cli.py
@@ -190,9 +190,9 @@ class KubeflowPipelines(object):
             step_to_kfp_component_map[current_step] = (
                 build_kfp_component(
                     current_node, current_step, current_task_id, cur_input_path
-                ), 
-                current_step, 
-                current_task_id
+                ),
+                current_step,
+                current_task_id,
             )
 
             for step in current_node.out_funcs:
@@ -419,7 +419,7 @@ def step_op_func(
             print(line, end="")
             stderr_buffer.write(line)
         stderr_output = stderr_buffer.getvalue()
-    
+
     # We put a try-catch block here because if the process above fails,
     # this line will cause an error which will stop the Kubeflow step.
     # We want to catch this error so the error logs can be captured
@@ -446,7 +446,7 @@ def step_op_func(
         f"{flow_name}/{kfp_run_id}/{step_name}/"
         f"{task_id}/{{log_file}}"
     )
-    
+
     log_stdout_cmd = save_logs_cmd_template.format(log_file="0.stdout.log")
     log_stderr_cmd = save_logs_cmd_template.format(log_file="0.stderr.log")
     save_logs_cmd = f"{log_stderr_cmd} >/dev/null && {log_stdout_cmd} >/dev/null"
@@ -456,13 +456,15 @@ def step_op_func(
         stdin=PIPE,
         stdout=PIPE,
         stderr=STDOUT,
-        universal_newlines=True
+        universal_newlines=True,
     ) as _:
-        print("Finished saving logs to S3.") # we persist logs even if everything went fine
-    
+        print(
+            "Finished saving logs to S3."
+        )  # we persist logs even if everything went fine
+
     if process.returncode != 0:
         raise Exception("Returned: %s" % process.returncode)
-    
+
     StepMetaflowContext = NamedTuple(
         "context", [("task_out_dict", dict), ("split_indexes", list)]
     )

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -443,7 +443,7 @@ def step_op_func(
     ) as process:
         print("Running command.")
     process.wait()
-    
+
     try:
         with open(
             os.path.join(tempfile.gettempdir(), "kfp_metaflow_out_dict.json"), "r"


### PR DESCRIPTION
- Captures the stdout and stderr of a Python process running on KFP, stores into separate stdout.log and stderr.log files, and copies them to S3
- Requires modifications to the step_op function because we need to pass `task_id` and `step_name`. These variables are needed to obtain the S3 datastore path