### PR TITLE
None for Run and Experiment names, and Flow name as default

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -16,7 +16,6 @@ from ...environment import MetaflowEnvironment
 from ...graph import DAGNode, FlowGraph
 from ...plugins.resources_decorator import ResourcesDecorator
 from .kfp_constants import (
-    DEFAULT_KFP_YAML_OUTPUT_PATH,
     INPUT_PATHS_ENV_NAME,
     PASSED_IN_SPLIT_INDEXES_ENV_NAME,
     SPLIT_INDEX_ENV_NAME,
@@ -101,9 +100,7 @@ class KubeflowPipelines(object):
         )
         return run_pipeline_result
 
-    def create_kfp_pipeline_yaml(
-        self, pipeline_file_path=DEFAULT_KFP_YAML_OUTPUT_PATH
-    ) -> str:
+    def create_kfp_pipeline_yaml(self, pipeline_file_path) -> str:
         """
         Creates a new KFP pipeline YAML using `kfp.compiler.Compiler()`.
         Note: Intermediate pipeline YAML is saved at `pipeline_file_path`
@@ -490,6 +487,7 @@ class KubeflowPipelines(object):
             dsl.get_pipeline_conf().set_parallelism(self.max_parallelism)
             dsl.get_pipeline_conf().set_timeout(self.workflow_timeout)
 
+        kfp_pipeline_from_flow.__name__ = self.name
         return kfp_pipeline_from_flow
 
 

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -15,8 +15,6 @@ from metaflow.plugins.aws.step_functions.step_functions_cli import (
 )
 from metaflow.plugins.kfp.kfp_constants import (
     BASE_IMAGE,
-    DEFAULT_EXPERIMENT_NAME,
-    DEFAULT_KFP_YAML_OUTPUT_PATH,
 )
 from metaflow.util import get_username
 
@@ -64,8 +62,9 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
 @click.option(
     "--experiment-name",
     "experiment_name",
-    default=DEFAULT_EXPERIMENT_NAME,
-    help="The associated experiment name for the run",
+    default=None,
+    help="The associated experiment name for the run. "
+    "Default of None uses KFP 'default' experiment",
     show_default=True,
 )
 @click.option(
@@ -100,7 +99,7 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
 @click.option(
     "--pipeline-path",
     "pipeline_path",
-    default=DEFAULT_KFP_YAML_OUTPUT_PATH,
+    default=None,
     help="The output path of the generated KFP pipeline yaml file",
     show_default=True,
 )
@@ -144,12 +143,12 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
 @click.pass_obj
 def run(
     obj,
-    experiment_name=DEFAULT_EXPERIMENT_NAME,
+    experiment_name=None,
     run_name=None,
     namespace=KFP_SDK_NAMESPACE,
     api_namespace=KFP_SDK_API_NAMESPACE,
     yaml_only=False,
-    pipeline_path=DEFAULT_KFP_YAML_OUTPUT_PATH,
+    pipeline_path=None,
     s3_code_package=True,
     base_image=BASE_IMAGE,
     pipeline_name=None,
@@ -164,7 +163,7 @@ def run(
     check_metadata_service_version(obj)
     flow = make_flow(
         obj,
-        pipeline_name if pipeline_path else current.flow_name,
+        pipeline_name if pipeline_path else obj.flow.name,
         namespace,
         api_namespace,
         base_image,
@@ -204,7 +203,9 @@ def run(
             KFP_RUN_URL_PREFIX, "_/pipeline/#/runs/details", run_pipeline_result.run_id
         )
 
-        obj.echo("Run link: {kfp_run_url}\n".format(kfp_run_url=kfp_run_url), fg="cyan")
+        obj.echo(
+            "*Run link:* {kfp_run_url}\n".format(kfp_run_url=kfp_run_url), fg="cyan"
+        )
 
         if wait_for_completion:
             response = flow._client.wait_for_run_completion(

--- a/metaflow/plugins/kfp/kfp_constants.py
+++ b/metaflow/plugins/kfp/kfp_constants.py
@@ -1,10 +1,6 @@
 # Constants used in run MF flow on KFP
 
 # Defaults for running MF on KFP
-DEFAULT_KFP_YAML_OUTPUT_PATH = "kfp_pipeline.yaml"
-DEFAULT_RUN_NAME = "run_mf_on_kfp"
-DEFAULT_EXPERIMENT_NAME = "mf-on-kfp-experiments"
-
 BASE_IMAGE = "hsezhiyan/metaflow-zillow:2.0"
 
 


### PR DESCRIPTION
A much cleaner MF -> KFP experiment/run/pipeline mapping:

* Use default KFP experiment `Default` if none provided.
* use Flow name as default KFP pipeline name if `pipeline_name` parameter is not specified.

![image](https://user-images.githubusercontent.com/4167032/98872886-361d8f80-242c-11eb-9873-a5415f49cd9c.png)
