### PR TITLE
Adding TTL and timeout (AIP-2272, AIP-2273)

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -52,7 +52,6 @@ METAFLOW_USER = from_conf("METAFLOW_USER")
 ###
 KFP_SDK_NAMESPACE = from_conf("KFP_SDK_NAMESPACE", "kubeflow")
 KFP_SDK_API_NAMESPACE = from_conf("KFP_SDK_API_NAMESPACE", "kubeflow")
-ARGO_DEFAULT_TTL = from_conf("ARGO_DEFAULT_TTL", 604800)
 
 ###
 # Datastore configuration
@@ -239,22 +238,23 @@ def get_authenticated_boto3_client(module, params={}):
     try:
         import boto3
     except (NameError, ImportError):
-        raise MetaflowException("Could not import module 'boto3'. Install boto3 first.")
+        raise MetaflowException(
+            "Could not import module 'boto3'. Install boto3 first.")
 
     if AWS_SANDBOX_ENABLED:
         global cached_aws_sandbox_creds
         if cached_aws_sandbox_creds is None:
             # authenticate using STS
             url = "%s/auth/token" % AWS_SANDBOX_STS_ENDPOINT_URL
-            headers = {"x-api-key": AWS_SANDBOX_API_KEY}
+            headers = {
+                'x-api-key': AWS_SANDBOX_API_KEY
+            }
             try:
                 r = requests.get(url, headers=headers)
                 r.raise_for_status()
                 cached_aws_sandbox_creds = r.json()
             except requests.exceptions.HTTPError as e:
                 raise MetaflowException(repr(e))
-        return boto3.session.Session(**cached_aws_sandbox_creds).client(
-            module, **params
-        )
+        return boto3.session.Session(**cached_aws_sandbox_creds).client(module, **params)
 
     return boto3.client(module, **params)

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -15,19 +15,20 @@ if sys.platform == "darwin":
 
 def init_config():
     # Read configuration from $METAFLOW_HOME/config_<profile>.json.
-    home = os.environ.get('METAFLOW_HOME', '~/.metaflowconfig')
-    profile = os.environ.get('METAFLOW_PROFILE')
-    path_to_config = os.path.join(home, 'config.json')
+    home = os.environ.get("METAFLOW_HOME", "~/.metaflowconfig")
+    profile = os.environ.get("METAFLOW_PROFILE")
+    path_to_config = os.path.join(home, "config.json")
     if profile:
-        path_to_config = os.path.join(home, 'config_%s.json' % profile)
+        path_to_config = os.path.join(home, "config_%s.json" % profile)
     path_to_config = os.path.expanduser(path_to_config)
     config = {}
     if os.path.exists(path_to_config):
         with open(path_to_config) as f:
             return json.load(f)
     elif profile:
-        raise MetaflowException('Unable to locate METAFLOW_PROFILE \'%s\' in \'%s\')' %
-                                (profile, home))
+        raise MetaflowException(
+            "Unable to locate METAFLOW_PROFILE '%s' in '%s')" % (profile, home)
+        )
     return config
 
 
@@ -42,72 +43,79 @@ def from_conf(name, default=None):
 ###
 # Default configuration
 ###
-DEFAULT_DATASTORE = from_conf('METAFLOW_DEFAULT_DATASTORE', 'local')
-DEFAULT_METADATA = from_conf('METAFLOW_DEFAULT_METADATA', 'local')
-METAFLOW_USER = from_conf('METAFLOW_USER')
+DEFAULT_DATASTORE = from_conf("METAFLOW_DEFAULT_DATASTORE", "local")
+DEFAULT_METADATA = from_conf("METAFLOW_DEFAULT_METADATA", "local")
+METAFLOW_USER = from_conf("METAFLOW_USER")
 
 ##
 # KFP configuration
 ###
-KFP_SDK_NAMESPACE = from_conf('KFP_SDK_NAMESPACE', 'kubeflow')
-KFP_SDK_API_NAMESPACE = from_conf('KFP_SDK_API_NAMESPACE', 'kubeflow')
+KFP_SDK_NAMESPACE = from_conf("KFP_SDK_NAMESPACE", "kubeflow")
+KFP_SDK_API_NAMESPACE = from_conf("KFP_SDK_API_NAMESPACE", "kubeflow")
+ARGO_DEFAULT_TTL = from_conf("ARGO_DEFAULT_TTL", 604800)
 
 ###
 # Datastore configuration
 ###
 # Path to the local directory to store artifacts for 'local' datastore.
-DATASTORE_LOCAL_DIR = '.metaflow'
-DATASTORE_SYSROOT_LOCAL = from_conf('METAFLOW_DATASTORE_SYSROOT_LOCAL')
+DATASTORE_LOCAL_DIR = ".metaflow"
+DATASTORE_SYSROOT_LOCAL = from_conf("METAFLOW_DATASTORE_SYSROOT_LOCAL")
 # S3 bucket and prefix to store artifacts for 's3' datastore.
-DATASTORE_SYSROOT_S3 = from_conf('METAFLOW_DATASTORE_SYSROOT_S3')
+DATASTORE_SYSROOT_S3 = from_conf("METAFLOW_DATASTORE_SYSROOT_S3")
 # S3 datatools root location
-DATATOOLS_SUFFIX = from_conf('METAFLOW_DATATOOLS_SUFFIX', 'data')
+DATATOOLS_SUFFIX = from_conf("METAFLOW_DATATOOLS_SUFFIX", "data")
 DATATOOLS_S3ROOT = from_conf(
-    'METAFLOW_DATATOOLS_S3ROOT', 
-        '%s/%s' % (from_conf('METAFLOW_DATASTORE_SYSROOT_S3'), DATATOOLS_SUFFIX)
-            if from_conf('METAFLOW_DATASTORE_SYSROOT_S3') else None)
+    "METAFLOW_DATATOOLS_S3ROOT",
+    "%s/%s" % (from_conf("METAFLOW_DATASTORE_SYSROOT_S3"), DATATOOLS_SUFFIX)
+    if from_conf("METAFLOW_DATASTORE_SYSROOT_S3")
+    else None,
+)
 # Local datatools root location
 DATATOOLS_LOCALROOT = from_conf(
-    'METAFLOW_DATATOOLS_LOCALROOT',
-        '%s/%s' % (from_conf('METAFLOW_DATASTORE_SYSROOT_LOCAL'), DATATOOLS_SUFFIX)
-            if from_conf('METAFLOW_DATASTORE_SYSROOT_LOCAL') else None)
+    "METAFLOW_DATATOOLS_LOCALROOT",
+    "%s/%s" % (from_conf("METAFLOW_DATASTORE_SYSROOT_LOCAL"), DATATOOLS_SUFFIX)
+    if from_conf("METAFLOW_DATASTORE_SYSROOT_LOCAL")
+    else None,
+)
 
 # S3 endpoint url
-S3_ENDPOINT_URL = from_conf('METAFLOW_S3_ENDPOINT_URL', None)
-S3_VERIFY_CERTIFICATE = from_conf('METAFLOW_S3_VERIFY_CERTIFICATE', None)
+S3_ENDPOINT_URL = from_conf("METAFLOW_S3_ENDPOINT_URL", None)
+S3_VERIFY_CERTIFICATE = from_conf("METAFLOW_S3_VERIFY_CERTIFICATE", None)
 
 ###
 # Datastore local cache
 ###
 # Path to the client cache
-CLIENT_CACHE_PATH = from_conf('METAFLOW_CLIENT_CACHE_PATH', '/tmp/metaflow_client')
+CLIENT_CACHE_PATH = from_conf("METAFLOW_CLIENT_CACHE_PATH", "/tmp/metaflow_client")
 # Maximum size (in bytes) of the cache
-CLIENT_CACHE_MAX_SIZE = from_conf('METAFLOW_CLIENT_CACHE_MAX_SIZE', 10000)
+CLIENT_CACHE_MAX_SIZE = from_conf("METAFLOW_CLIENT_CACHE_MAX_SIZE", 10000)
 
 ###
 # Metadata configuration
 ###
-METADATA_SERVICE_URL = from_conf('METAFLOW_SERVICE_URL')
-METADATA_SERVICE_NUM_RETRIES = from_conf('METAFLOW_SERVICE_RETRY_COUNT', 5)
-METADATA_SERVICE_AUTH_KEY = from_conf('METAFLOW_SERVICE_AUTH_KEY')
-METADATA_SERVICE_HEADERS = json.loads(from_conf('METAFLOW_SERVICE_HEADERS', '{}'))
+METADATA_SERVICE_URL = from_conf("METAFLOW_SERVICE_URL")
+METADATA_SERVICE_NUM_RETRIES = from_conf("METAFLOW_SERVICE_RETRY_COUNT", 5)
+METADATA_SERVICE_AUTH_KEY = from_conf("METAFLOW_SERVICE_AUTH_KEY")
+METADATA_SERVICE_HEADERS = json.loads(from_conf("METAFLOW_SERVICE_HEADERS", "{}"))
 if METADATA_SERVICE_AUTH_KEY is not None:
-    METADATA_SERVICE_HEADERS['x-api-key'] = METADATA_SERVICE_AUTH_KEY
+    METADATA_SERVICE_HEADERS["x-api-key"] = METADATA_SERVICE_AUTH_KEY
 
 ###
 # AWS Batch configuration
 ###
 # IAM role for AWS Batch container with Amazon S3 access
 # (and AWS DynamoDb access for AWS StepFunctions, if enabled)
-ECS_S3_ACCESS_IAM_ROLE = from_conf('METAFLOW_ECS_S3_ACCESS_IAM_ROLE')
+ECS_S3_ACCESS_IAM_ROLE = from_conf("METAFLOW_ECS_S3_ACCESS_IAM_ROLE")
 # Job queue for AWS Batch
-BATCH_JOB_QUEUE = from_conf('METAFLOW_BATCH_JOB_QUEUE')
+BATCH_JOB_QUEUE = from_conf("METAFLOW_BATCH_JOB_QUEUE")
 # Default container image for AWS Batch
 BATCH_CONTAINER_IMAGE = from_conf("METAFLOW_BATCH_CONTAINER_IMAGE")
 # Default container registry for AWS Batch
 BATCH_CONTAINER_REGISTRY = from_conf("METAFLOW_BATCH_CONTAINER_REGISTRY")
 # Metadata service URL for AWS Batch
-BATCH_METADATA_SERVICE_URL = from_conf('METAFLOW_SERVICE_INTERNAL_URL', METADATA_SERVICE_URL)
+BATCH_METADATA_SERVICE_URL = from_conf(
+    "METAFLOW_SERVICE_INTERNAL_URL", METADATA_SERVICE_URL
+)
 BATCH_METADATA_SERVICE_HEADERS = METADATA_SERVICE_HEADERS
 
 ###
@@ -130,38 +138,43 @@ SFN_STATE_MACHINE_PREFIX = None
 ###
 # Conda package root location on S3
 CONDA_PACKAGE_S3ROOT = from_conf(
-    'METAFLOW_CONDA_PACKAGE_S3ROOT',
-        '%s/conda' % from_conf('METAFLOW_DATASTORE_SYSROOT_S3'))
+    "METAFLOW_CONDA_PACKAGE_S3ROOT",
+    "%s/conda" % from_conf("METAFLOW_DATASTORE_SYSROOT_S3"),
+)
 
 ###
 # Debug configuration
 ###
-DEBUG_OPTIONS = ['subcommand', 'sidecar', 's3client']
+DEBUG_OPTIONS = ["subcommand", "sidecar", "s3client"]
 
 for typ in DEBUG_OPTIONS:
-    vars()['METAFLOW_DEBUG_%s' % typ.upper()] = from_conf('METAFLOW_DEBUG_%s' % typ.upper())
+    vars()["METAFLOW_DEBUG_%s" % typ.upper()] = from_conf(
+        "METAFLOW_DEBUG_%s" % typ.upper()
+    )
 
 ###
 # AWS Sandbox configuration
 ###
 # Boolean flag for metaflow AWS sandbox access
-AWS_SANDBOX_ENABLED = bool(from_conf('METAFLOW_AWS_SANDBOX_ENABLED', False))
+AWS_SANDBOX_ENABLED = bool(from_conf("METAFLOW_AWS_SANDBOX_ENABLED", False))
 # Metaflow AWS sandbox auth endpoint
-AWS_SANDBOX_STS_ENDPOINT_URL = from_conf('METAFLOW_SERVICE_URL')
+AWS_SANDBOX_STS_ENDPOINT_URL = from_conf("METAFLOW_SERVICE_URL")
 # Metaflow AWS sandbox API auth key
-AWS_SANDBOX_API_KEY = from_conf('METAFLOW_AWS_SANDBOX_API_KEY')
+AWS_SANDBOX_API_KEY = from_conf("METAFLOW_AWS_SANDBOX_API_KEY")
 # Internal Metadata URL
-AWS_SANDBOX_INTERNAL_SERVICE_URL = from_conf('METAFLOW_AWS_SANDBOX_INTERNAL_SERVICE_URL')
+AWS_SANDBOX_INTERNAL_SERVICE_URL = from_conf(
+    "METAFLOW_AWS_SANDBOX_INTERNAL_SERVICE_URL"
+)
 # AWS region
-AWS_SANDBOX_REGION = from_conf('METAFLOW_AWS_SANDBOX_REGION')
+AWS_SANDBOX_REGION = from_conf("METAFLOW_AWS_SANDBOX_REGION")
 
 
 # Finalize configuration
 if AWS_SANDBOX_ENABLED:
-    os.environ['AWS_DEFAULT_REGION'] = AWS_SANDBOX_REGION
+    os.environ["AWS_DEFAULT_REGION"] = AWS_SANDBOX_REGION
     BATCH_METADATA_SERVICE_URL = AWS_SANDBOX_INTERNAL_SERVICE_URL
-    METADATA_SERVICE_HEADERS['x-api-key'] = AWS_SANDBOX_API_KEY
-    SFN_STATE_MACHINE_PREFIX = from_conf('METAFLOW_AWS_SANDBOX_STACK_NAME')
+    METADATA_SERVICE_HEADERS["x-api-key"] = AWS_SANDBOX_API_KEY
+    SFN_STATE_MACHINE_PREFIX = from_conf("METAFLOW_AWS_SANDBOX_STACK_NAME")
 
 
 # MAX_ATTEMPTS is the maximum number of attempts, including the first
@@ -177,15 +190,14 @@ MAX_ATTEMPTS = 6
 # Note: `KFP_RUN_URL_PREFIX` is the URL prefix for KFP runs on your KFP cluster. The prefix includes
 # all parts of the URL except the run_id at the end which we append once the run is created.
 # For eg, this would look like: "https://<your-kf-cluster-url>/pipeline/#/runs/details/"
-KFP_RUN_URL_PREFIX = from_conf('KFP_RUN_URL_PREFIX')
+KFP_RUN_URL_PREFIX = from_conf("KFP_RUN_URL_PREFIX")
 
 # the naughty, naughty driver.py imported by lib2to3 produces
 # spam messages to the root logger. This is what is required
 # to silence it:
 class Filter(logging.Filter):
     def filter(self, record):
-        if record.pathname.endswith('driver.py') and \
-           'grammar' in record.msg:
+        if record.pathname.endswith("driver.py") and "grammar" in record.msg:
             return False
         return True
 
@@ -203,45 +215,46 @@ def get_version(pkg):
 def get_pinned_conda_libs(python_version):
     if python_version.startswith("3.5"):
         return {
-            'click': '7.1.2',
-            'requests': '2.24.0',
-            'boto3': '1.9.88',
-            'coverage': '4.5.1'
+            "click": "7.1.2",
+            "requests": "2.24.0",
+            "boto3": "1.9.88",
+            "coverage": "4.5.1",
         }
     else:
         return {
-            'click': '7.1.2',
-            'requests': '2.24.0',
-            'boto3': '1.14.47',
-            'coverage': '4.5.4'
+            "click": "7.1.2",
+            "requests": "2.24.0",
+            "boto3": "1.14.47",
+            "coverage": "4.5.4",
         }
-        
+
+
 cached_aws_sandbox_creds = None
 
 
 def get_authenticated_boto3_client(module, params={}):
     from metaflow.exception import MetaflowException
     import requests
+
     try:
         import boto3
     except (NameError, ImportError):
-        raise MetaflowException(
-            "Could not import module 'boto3'. Install boto3 first.")
+        raise MetaflowException("Could not import module 'boto3'. Install boto3 first.")
 
     if AWS_SANDBOX_ENABLED:
         global cached_aws_sandbox_creds
         if cached_aws_sandbox_creds is None:
             # authenticate using STS
             url = "%s/auth/token" % AWS_SANDBOX_STS_ENDPOINT_URL
-            headers = {
-                'x-api-key': AWS_SANDBOX_API_KEY
-            }
+            headers = {"x-api-key": AWS_SANDBOX_API_KEY}
             try:
                 r = requests.get(url, headers=headers)
                 r.raise_for_status()
                 cached_aws_sandbox_creds = r.json()
             except requests.exceptions.HTTPError as e:
                 raise MetaflowException(repr(e))
-        return boto3.session.Session(**cached_aws_sandbox_creds).client(module, **params)
+        return boto3.session.Session(**cached_aws_sandbox_creds).client(
+            module, **params
+        )
 
     return boto3.client(module, **params)

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -51,6 +51,7 @@ METAFLOW_USER = from_conf('METAFLOW_USER')
 ###
 KFP_SDK_NAMESPACE = from_conf('KFP_SDK_NAMESPACE', 'kubeflow')
 KFP_SDK_API_NAMESPACE = from_conf('KFP_SDK_API_NAMESPACE', 'kubeflow')
+ARGO_DEFAULT_TTL = from_conf('ARGO_DEFAULT_TTL', None)
 
 ###
 # Datastore configuration

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -15,19 +15,20 @@ if sys.platform == "darwin":
 
 def init_config():
     # Read configuration from $METAFLOW_HOME/config_<profile>.json.
-    home = os.environ.get('METAFLOW_HOME', '~/.metaflowconfig')
-    profile = os.environ.get('METAFLOW_PROFILE')
-    path_to_config = os.path.join(home, 'config.json')
+    home = os.environ.get("METAFLOW_HOME", "~/.metaflowconfig")
+    profile = os.environ.get("METAFLOW_PROFILE")
+    path_to_config = os.path.join(home, "config.json")
     if profile:
-        path_to_config = os.path.join(home, 'config_%s.json' % profile)
+        path_to_config = os.path.join(home, "config_%s.json" % profile)
     path_to_config = os.path.expanduser(path_to_config)
     config = {}
     if os.path.exists(path_to_config):
         with open(path_to_config) as f:
             return json.load(f)
     elif profile:
-        raise MetaflowException('Unable to locate METAFLOW_PROFILE \'%s\' in \'%s\')' %
-                                (profile, home))
+        raise MetaflowException(
+            "Unable to locate METAFLOW_PROFILE '%s' in '%s')" % (profile, home)
+        )
     return config
 
 
@@ -42,78 +43,79 @@ def from_conf(name, default=None):
 ###
 # Default configuration
 ###
-DEFAULT_DATASTORE = from_conf('METAFLOW_DEFAULT_DATASTORE', 'local')
-DEFAULT_ENVIRONMENT = from_conf('METAFLOW_DEFAULT_ENVIRONMENT', 'local')
-DEFAULT_EVENT_LOGGER = from_conf('METAFLOW_DEFAULT_EVENT_LOGGER', 'nullSidecarLogger')
-DEFAULT_METADATA = from_conf('METAFLOW_DEFAULT_METADATA', 'local')
-DEFAULT_MONITOR = from_conf('METAFLOW_DEFAULT_MONITOR', 'nullSidecarMonitor')
-DEFAULT_PACKAGE_SUFFIXES = from_conf('METAFLOW_DEFAULT_PACKAGE_SUFFIXES', '.py,.R,.RDS')
-
-METAFLOW_USER = from_conf('METAFLOW_USER')
+DEFAULT_DATASTORE = from_conf("METAFLOW_DEFAULT_DATASTORE", "local")
+DEFAULT_METADATA = from_conf("METAFLOW_DEFAULT_METADATA", "local")
+METAFLOW_USER = from_conf("METAFLOW_USER")
 
 ##
 # KFP configuration
 ###
-KFP_SDK_NAMESPACE = from_conf('KFP_SDK_NAMESPACE', 'kubeflow')
-KFP_SDK_API_NAMESPACE = from_conf('KFP_SDK_API_NAMESPACE', 'kubeflow')
+KFP_SDK_NAMESPACE = from_conf("KFP_SDK_NAMESPACE", "kubeflow")
+KFP_SDK_API_NAMESPACE = from_conf("KFP_SDK_API_NAMESPACE", "kubeflow")
 ARGO_DEFAULT_TTL = from_conf("ARGO_DEFAULT_TTL", 604800)
 
 ###
 # Datastore configuration
 ###
 # Path to the local directory to store artifacts for 'local' datastore.
-DATASTORE_LOCAL_DIR = '.metaflow'
-DATASTORE_SYSROOT_LOCAL = from_conf('METAFLOW_DATASTORE_SYSROOT_LOCAL')
+DATASTORE_LOCAL_DIR = ".metaflow"
+DATASTORE_SYSROOT_LOCAL = from_conf("METAFLOW_DATASTORE_SYSROOT_LOCAL")
 # S3 bucket and prefix to store artifacts for 's3' datastore.
-DATASTORE_SYSROOT_S3 = from_conf('METAFLOW_DATASTORE_SYSROOT_S3')
+DATASTORE_SYSROOT_S3 = from_conf("METAFLOW_DATASTORE_SYSROOT_S3")
 # S3 datatools root location
-DATATOOLS_SUFFIX = from_conf('METAFLOW_DATATOOLS_SUFFIX', 'data')
+DATATOOLS_SUFFIX = from_conf("METAFLOW_DATATOOLS_SUFFIX", "data")
 DATATOOLS_S3ROOT = from_conf(
-    'METAFLOW_DATATOOLS_S3ROOT', 
-        '%s/%s' % (from_conf('METAFLOW_DATASTORE_SYSROOT_S3'), DATATOOLS_SUFFIX)
-            if from_conf('METAFLOW_DATASTORE_SYSROOT_S3') else None)
+    "METAFLOW_DATATOOLS_S3ROOT",
+    "%s/%s" % (from_conf("METAFLOW_DATASTORE_SYSROOT_S3"), DATATOOLS_SUFFIX)
+    if from_conf("METAFLOW_DATASTORE_SYSROOT_S3")
+    else None,
+)
 # Local datatools root location
 DATATOOLS_LOCALROOT = from_conf(
-    'METAFLOW_DATATOOLS_LOCALROOT',
-        '%s/%s' % (from_conf('METAFLOW_DATASTORE_SYSROOT_LOCAL'), DATATOOLS_SUFFIX)
-            if from_conf('METAFLOW_DATASTORE_SYSROOT_LOCAL') else None)
+    "METAFLOW_DATATOOLS_LOCALROOT",
+    "%s/%s" % (from_conf("METAFLOW_DATASTORE_SYSROOT_LOCAL"), DATATOOLS_SUFFIX)
+    if from_conf("METAFLOW_DATASTORE_SYSROOT_LOCAL")
+    else None,
+)
 
 # S3 endpoint url
-S3_ENDPOINT_URL = from_conf('METAFLOW_S3_ENDPOINT_URL', None)
-S3_VERIFY_CERTIFICATE = from_conf('METAFLOW_S3_VERIFY_CERTIFICATE', None)
+S3_ENDPOINT_URL = from_conf("METAFLOW_S3_ENDPOINT_URL", None)
+S3_VERIFY_CERTIFICATE = from_conf("METAFLOW_S3_VERIFY_CERTIFICATE", None)
 
 ###
 # Datastore local cache
 ###
 # Path to the client cache
-CLIENT_CACHE_PATH = from_conf('METAFLOW_CLIENT_CACHE_PATH', '/tmp/metaflow_client')
+CLIENT_CACHE_PATH = from_conf("METAFLOW_CLIENT_CACHE_PATH", "/tmp/metaflow_client")
 # Maximum size (in bytes) of the cache
-CLIENT_CACHE_MAX_SIZE = from_conf('METAFLOW_CLIENT_CACHE_MAX_SIZE', 10000)
+CLIENT_CACHE_MAX_SIZE = from_conf("METAFLOW_CLIENT_CACHE_MAX_SIZE", 10000)
 
 ###
 # Metadata configuration
 ###
-METADATA_SERVICE_URL = from_conf('METAFLOW_SERVICE_URL')
-METADATA_SERVICE_NUM_RETRIES = from_conf('METAFLOW_SERVICE_RETRY_COUNT', 5)
-METADATA_SERVICE_AUTH_KEY = from_conf('METAFLOW_SERVICE_AUTH_KEY')
-METADATA_SERVICE_HEADERS = json.loads(from_conf('METAFLOW_SERVICE_HEADERS', '{}'))
+METADATA_SERVICE_URL = from_conf("METAFLOW_SERVICE_URL")
+METADATA_SERVICE_NUM_RETRIES = from_conf("METAFLOW_SERVICE_RETRY_COUNT", 5)
+METADATA_SERVICE_AUTH_KEY = from_conf("METAFLOW_SERVICE_AUTH_KEY")
+METADATA_SERVICE_HEADERS = json.loads(from_conf("METAFLOW_SERVICE_HEADERS", "{}"))
 if METADATA_SERVICE_AUTH_KEY is not None:
-    METADATA_SERVICE_HEADERS['x-api-key'] = METADATA_SERVICE_AUTH_KEY
+    METADATA_SERVICE_HEADERS["x-api-key"] = METADATA_SERVICE_AUTH_KEY
 
 ###
 # AWS Batch configuration
 ###
 # IAM role for AWS Batch container with Amazon S3 access
 # (and AWS DynamoDb access for AWS StepFunctions, if enabled)
-ECS_S3_ACCESS_IAM_ROLE = from_conf('METAFLOW_ECS_S3_ACCESS_IAM_ROLE')
+ECS_S3_ACCESS_IAM_ROLE = from_conf("METAFLOW_ECS_S3_ACCESS_IAM_ROLE")
 # Job queue for AWS Batch
-BATCH_JOB_QUEUE = from_conf('METAFLOW_BATCH_JOB_QUEUE')
+BATCH_JOB_QUEUE = from_conf("METAFLOW_BATCH_JOB_QUEUE")
 # Default container image for AWS Batch
 BATCH_CONTAINER_IMAGE = from_conf("METAFLOW_BATCH_CONTAINER_IMAGE")
 # Default container registry for AWS Batch
 BATCH_CONTAINER_REGISTRY = from_conf("METAFLOW_BATCH_CONTAINER_REGISTRY")
 # Metadata service URL for AWS Batch
-BATCH_METADATA_SERVICE_URL = from_conf('METAFLOW_SERVICE_INTERNAL_URL', METADATA_SERVICE_URL)
+BATCH_METADATA_SERVICE_URL = from_conf(
+    "METAFLOW_SERVICE_INTERNAL_URL", METADATA_SERVICE_URL
+)
 BATCH_METADATA_SERVICE_HEADERS = METADATA_SERVICE_HEADERS
 
 ###
@@ -129,45 +131,50 @@ SFN_DYNAMO_DB_TABLE = from_conf("METAFLOW_SFN_DYNAMO_DB_TABLE")
 EVENTS_SFN_ACCESS_IAM_ROLE = from_conf("METAFLOW_EVENTS_SFN_ACCESS_IAM_ROLE")
 # Prefix for AWS Step Functions state machines. Set to stack name for Metaflow
 # sandbox.
-SFN_STATE_MACHINE_PREFIX = from_conf("METAFLOW_SFN_STATE_MACHINE_PREFIX")
+SFN_STATE_MACHINE_PREFIX = None
 
 ###
 # Conda configuration
 ###
 # Conda package root location on S3
 CONDA_PACKAGE_S3ROOT = from_conf(
-    'METAFLOW_CONDA_PACKAGE_S3ROOT',
-        '%s/conda' % from_conf('METAFLOW_DATASTORE_SYSROOT_S3'))
+    "METAFLOW_CONDA_PACKAGE_S3ROOT",
+    "%s/conda" % from_conf("METAFLOW_DATASTORE_SYSROOT_S3"),
+)
 
 ###
 # Debug configuration
 ###
-DEBUG_OPTIONS = ['subcommand', 'sidecar', 's3client']
+DEBUG_OPTIONS = ["subcommand", "sidecar", "s3client"]
 
 for typ in DEBUG_OPTIONS:
-    vars()['METAFLOW_DEBUG_%s' % typ.upper()] = from_conf('METAFLOW_DEBUG_%s' % typ.upper())
+    vars()["METAFLOW_DEBUG_%s" % typ.upper()] = from_conf(
+        "METAFLOW_DEBUG_%s" % typ.upper()
+    )
 
 ###
 # AWS Sandbox configuration
 ###
 # Boolean flag for metaflow AWS sandbox access
-AWS_SANDBOX_ENABLED = bool(from_conf('METAFLOW_AWS_SANDBOX_ENABLED', False))
+AWS_SANDBOX_ENABLED = bool(from_conf("METAFLOW_AWS_SANDBOX_ENABLED", False))
 # Metaflow AWS sandbox auth endpoint
-AWS_SANDBOX_STS_ENDPOINT_URL = from_conf('METAFLOW_SERVICE_URL')
+AWS_SANDBOX_STS_ENDPOINT_URL = from_conf("METAFLOW_SERVICE_URL")
 # Metaflow AWS sandbox API auth key
-AWS_SANDBOX_API_KEY = from_conf('METAFLOW_AWS_SANDBOX_API_KEY')
+AWS_SANDBOX_API_KEY = from_conf("METAFLOW_AWS_SANDBOX_API_KEY")
 # Internal Metadata URL
-AWS_SANDBOX_INTERNAL_SERVICE_URL = from_conf('METAFLOW_AWS_SANDBOX_INTERNAL_SERVICE_URL')
+AWS_SANDBOX_INTERNAL_SERVICE_URL = from_conf(
+    "METAFLOW_AWS_SANDBOX_INTERNAL_SERVICE_URL"
+)
 # AWS region
-AWS_SANDBOX_REGION = from_conf('METAFLOW_AWS_SANDBOX_REGION')
+AWS_SANDBOX_REGION = from_conf("METAFLOW_AWS_SANDBOX_REGION")
 
 
 # Finalize configuration
 if AWS_SANDBOX_ENABLED:
-    os.environ['AWS_DEFAULT_REGION'] = AWS_SANDBOX_REGION
+    os.environ["AWS_DEFAULT_REGION"] = AWS_SANDBOX_REGION
     BATCH_METADATA_SERVICE_URL = AWS_SANDBOX_INTERNAL_SERVICE_URL
-    METADATA_SERVICE_HEADERS['x-api-key'] = AWS_SANDBOX_API_KEY
-    SFN_STATE_MACHINE_PREFIX = from_conf('METAFLOW_AWS_SANDBOX_STACK_NAME')
+    METADATA_SERVICE_HEADERS["x-api-key"] = AWS_SANDBOX_API_KEY
+    SFN_STATE_MACHINE_PREFIX = from_conf("METAFLOW_AWS_SANDBOX_STACK_NAME")
 
 
 # MAX_ATTEMPTS is the maximum number of attempts, including the first
@@ -183,15 +190,14 @@ MAX_ATTEMPTS = 6
 # Note: `KFP_RUN_URL_PREFIX` is the URL prefix for KFP runs on your KFP cluster. The prefix includes
 # all parts of the URL except the run_id at the end which we append once the run is created.
 # For eg, this would look like: "https://<your-kf-cluster-url>/pipeline/#/runs/details/"
-KFP_RUN_URL_PREFIX = from_conf('KFP_RUN_URL_PREFIX')
+KFP_RUN_URL_PREFIX = from_conf("KFP_RUN_URL_PREFIX")
 
 # the naughty, naughty driver.py imported by lib2to3 produces
 # spam messages to the root logger. This is what is required
 # to silence it:
 class Filter(logging.Filter):
     def filter(self, record):
-        if record.pathname.endswith('driver.py') and \
-           'grammar' in record.msg:
+        if record.pathname.endswith("driver.py") and "grammar" in record.msg:
             return False
         return True
 
@@ -209,27 +215,46 @@ def get_version(pkg):
 def get_pinned_conda_libs(python_version):
     if python_version.startswith("3.5"):
         return {
-            'click': '7.1.2',
-            'requests': '2.24.0',
-            'boto3': '1.9.88',
-            'coverage': '4.5.1'
+            "click": "7.1.2",
+            "requests": "2.24.0",
+            "boto3": "1.9.88",
+            "coverage": "4.5.1",
         }
     else:
         return {
-            'click': '7.1.2',
-            'requests': '2.24.0',
-            'boto3': '1.14.47',
-            'coverage': '4.5.4'
+            "click": "7.1.2",
+            "requests": "2.24.0",
+            "boto3": "1.14.47",
+            "coverage": "4.5.4",
         }
 
 
-# Check if there is a an extension to Metaflow to load and override everything
-try:
-    import metaflow_custom.config.metaflow_config as extension_module
-except ImportError:
-    pass
-else:
-    # We load into globals whatever we have in extension_module
-    for n, o in extension_module.__dict__.items():
-        if not n.startswith('__'):
-            globals()[n] = o
+cached_aws_sandbox_creds = None
+
+
+def get_authenticated_boto3_client(module, params={}):
+    from metaflow.exception import MetaflowException
+    import requests
+
+    try:
+        import boto3
+    except (NameError, ImportError):
+        raise MetaflowException("Could not import module 'boto3'. Install boto3 first.")
+
+    if AWS_SANDBOX_ENABLED:
+        global cached_aws_sandbox_creds
+        if cached_aws_sandbox_creds is None:
+            # authenticate using STS
+            url = "%s/auth/token" % AWS_SANDBOX_STS_ENDPOINT_URL
+            headers = {"x-api-key": AWS_SANDBOX_API_KEY}
+            try:
+                r = requests.get(url, headers=headers)
+                r.raise_for_status()
+                cached_aws_sandbox_creds = r.json()
+            except requests.exceptions.HTTPError as e:
+                raise MetaflowException(repr(e))
+        return boto3.session.Session(**cached_aws_sandbox_creds).client(
+            module, **params
+        )
+
+    return boto3.client(module, **params)

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -15,20 +15,19 @@ if sys.platform == "darwin":
 
 def init_config():
     # Read configuration from $METAFLOW_HOME/config_<profile>.json.
-    home = os.environ.get("METAFLOW_HOME", "~/.metaflowconfig")
-    profile = os.environ.get("METAFLOW_PROFILE")
-    path_to_config = os.path.join(home, "config.json")
+    home = os.environ.get('METAFLOW_HOME', '~/.metaflowconfig')
+    profile = os.environ.get('METAFLOW_PROFILE')
+    path_to_config = os.path.join(home, 'config.json')
     if profile:
-        path_to_config = os.path.join(home, "config_%s.json" % profile)
+        path_to_config = os.path.join(home, 'config_%s.json' % profile)
     path_to_config = os.path.expanduser(path_to_config)
     config = {}
     if os.path.exists(path_to_config):
         with open(path_to_config) as f:
             return json.load(f)
     elif profile:
-        raise MetaflowException(
-            "Unable to locate METAFLOW_PROFILE '%s' in '%s')" % (profile, home)
-        )
+        raise MetaflowException('Unable to locate METAFLOW_PROFILE \'%s\' in \'%s\')' %
+                                (profile, home))
     return config
 
 
@@ -43,79 +42,78 @@ def from_conf(name, default=None):
 ###
 # Default configuration
 ###
-DEFAULT_DATASTORE = from_conf("METAFLOW_DEFAULT_DATASTORE", "local")
-DEFAULT_METADATA = from_conf("METAFLOW_DEFAULT_METADATA", "local")
-METAFLOW_USER = from_conf("METAFLOW_USER")
+DEFAULT_DATASTORE = from_conf('METAFLOW_DEFAULT_DATASTORE', 'local')
+DEFAULT_ENVIRONMENT = from_conf('METAFLOW_DEFAULT_ENVIRONMENT', 'local')
+DEFAULT_EVENT_LOGGER = from_conf('METAFLOW_DEFAULT_EVENT_LOGGER', 'nullSidecarLogger')
+DEFAULT_METADATA = from_conf('METAFLOW_DEFAULT_METADATA', 'local')
+DEFAULT_MONITOR = from_conf('METAFLOW_DEFAULT_MONITOR', 'nullSidecarMonitor')
+DEFAULT_PACKAGE_SUFFIXES = from_conf('METAFLOW_DEFAULT_PACKAGE_SUFFIXES', '.py,.R,.RDS')
+
+METAFLOW_USER = from_conf('METAFLOW_USER')
 
 ##
 # KFP configuration
 ###
-KFP_SDK_NAMESPACE = from_conf("KFP_SDK_NAMESPACE", "kubeflow")
-KFP_SDK_API_NAMESPACE = from_conf("KFP_SDK_API_NAMESPACE", "kubeflow")
+KFP_SDK_NAMESPACE = from_conf('KFP_SDK_NAMESPACE', 'kubeflow')
+KFP_SDK_API_NAMESPACE = from_conf('KFP_SDK_API_NAMESPACE', 'kubeflow')
 ARGO_DEFAULT_TTL = from_conf("ARGO_DEFAULT_TTL", 604800)
 
 ###
 # Datastore configuration
 ###
 # Path to the local directory to store artifacts for 'local' datastore.
-DATASTORE_LOCAL_DIR = ".metaflow"
-DATASTORE_SYSROOT_LOCAL = from_conf("METAFLOW_DATASTORE_SYSROOT_LOCAL")
+DATASTORE_LOCAL_DIR = '.metaflow'
+DATASTORE_SYSROOT_LOCAL = from_conf('METAFLOW_DATASTORE_SYSROOT_LOCAL')
 # S3 bucket and prefix to store artifacts for 's3' datastore.
-DATASTORE_SYSROOT_S3 = from_conf("METAFLOW_DATASTORE_SYSROOT_S3")
+DATASTORE_SYSROOT_S3 = from_conf('METAFLOW_DATASTORE_SYSROOT_S3')
 # S3 datatools root location
-DATATOOLS_SUFFIX = from_conf("METAFLOW_DATATOOLS_SUFFIX", "data")
+DATATOOLS_SUFFIX = from_conf('METAFLOW_DATATOOLS_SUFFIX', 'data')
 DATATOOLS_S3ROOT = from_conf(
-    "METAFLOW_DATATOOLS_S3ROOT",
-    "%s/%s" % (from_conf("METAFLOW_DATASTORE_SYSROOT_S3"), DATATOOLS_SUFFIX)
-    if from_conf("METAFLOW_DATASTORE_SYSROOT_S3")
-    else None,
-)
+    'METAFLOW_DATATOOLS_S3ROOT', 
+        '%s/%s' % (from_conf('METAFLOW_DATASTORE_SYSROOT_S3'), DATATOOLS_SUFFIX)
+            if from_conf('METAFLOW_DATASTORE_SYSROOT_S3') else None)
 # Local datatools root location
 DATATOOLS_LOCALROOT = from_conf(
-    "METAFLOW_DATATOOLS_LOCALROOT",
-    "%s/%s" % (from_conf("METAFLOW_DATASTORE_SYSROOT_LOCAL"), DATATOOLS_SUFFIX)
-    if from_conf("METAFLOW_DATASTORE_SYSROOT_LOCAL")
-    else None,
-)
+    'METAFLOW_DATATOOLS_LOCALROOT',
+        '%s/%s' % (from_conf('METAFLOW_DATASTORE_SYSROOT_LOCAL'), DATATOOLS_SUFFIX)
+            if from_conf('METAFLOW_DATASTORE_SYSROOT_LOCAL') else None)
 
 # S3 endpoint url
-S3_ENDPOINT_URL = from_conf("METAFLOW_S3_ENDPOINT_URL", None)
-S3_VERIFY_CERTIFICATE = from_conf("METAFLOW_S3_VERIFY_CERTIFICATE", None)
+S3_ENDPOINT_URL = from_conf('METAFLOW_S3_ENDPOINT_URL', None)
+S3_VERIFY_CERTIFICATE = from_conf('METAFLOW_S3_VERIFY_CERTIFICATE', None)
 
 ###
 # Datastore local cache
 ###
 # Path to the client cache
-CLIENT_CACHE_PATH = from_conf("METAFLOW_CLIENT_CACHE_PATH", "/tmp/metaflow_client")
+CLIENT_CACHE_PATH = from_conf('METAFLOW_CLIENT_CACHE_PATH', '/tmp/metaflow_client')
 # Maximum size (in bytes) of the cache
-CLIENT_CACHE_MAX_SIZE = from_conf("METAFLOW_CLIENT_CACHE_MAX_SIZE", 10000)
+CLIENT_CACHE_MAX_SIZE = from_conf('METAFLOW_CLIENT_CACHE_MAX_SIZE', 10000)
 
 ###
 # Metadata configuration
 ###
-METADATA_SERVICE_URL = from_conf("METAFLOW_SERVICE_URL")
-METADATA_SERVICE_NUM_RETRIES = from_conf("METAFLOW_SERVICE_RETRY_COUNT", 5)
-METADATA_SERVICE_AUTH_KEY = from_conf("METAFLOW_SERVICE_AUTH_KEY")
-METADATA_SERVICE_HEADERS = json.loads(from_conf("METAFLOW_SERVICE_HEADERS", "{}"))
+METADATA_SERVICE_URL = from_conf('METAFLOW_SERVICE_URL')
+METADATA_SERVICE_NUM_RETRIES = from_conf('METAFLOW_SERVICE_RETRY_COUNT', 5)
+METADATA_SERVICE_AUTH_KEY = from_conf('METAFLOW_SERVICE_AUTH_KEY')
+METADATA_SERVICE_HEADERS = json.loads(from_conf('METAFLOW_SERVICE_HEADERS', '{}'))
 if METADATA_SERVICE_AUTH_KEY is not None:
-    METADATA_SERVICE_HEADERS["x-api-key"] = METADATA_SERVICE_AUTH_KEY
+    METADATA_SERVICE_HEADERS['x-api-key'] = METADATA_SERVICE_AUTH_KEY
 
 ###
 # AWS Batch configuration
 ###
 # IAM role for AWS Batch container with Amazon S3 access
 # (and AWS DynamoDb access for AWS StepFunctions, if enabled)
-ECS_S3_ACCESS_IAM_ROLE = from_conf("METAFLOW_ECS_S3_ACCESS_IAM_ROLE")
+ECS_S3_ACCESS_IAM_ROLE = from_conf('METAFLOW_ECS_S3_ACCESS_IAM_ROLE')
 # Job queue for AWS Batch
-BATCH_JOB_QUEUE = from_conf("METAFLOW_BATCH_JOB_QUEUE")
+BATCH_JOB_QUEUE = from_conf('METAFLOW_BATCH_JOB_QUEUE')
 # Default container image for AWS Batch
 BATCH_CONTAINER_IMAGE = from_conf("METAFLOW_BATCH_CONTAINER_IMAGE")
 # Default container registry for AWS Batch
 BATCH_CONTAINER_REGISTRY = from_conf("METAFLOW_BATCH_CONTAINER_REGISTRY")
 # Metadata service URL for AWS Batch
-BATCH_METADATA_SERVICE_URL = from_conf(
-    "METAFLOW_SERVICE_INTERNAL_URL", METADATA_SERVICE_URL
-)
+BATCH_METADATA_SERVICE_URL = from_conf('METAFLOW_SERVICE_INTERNAL_URL', METADATA_SERVICE_URL)
 BATCH_METADATA_SERVICE_HEADERS = METADATA_SERVICE_HEADERS
 
 ###
@@ -131,50 +129,45 @@ SFN_DYNAMO_DB_TABLE = from_conf("METAFLOW_SFN_DYNAMO_DB_TABLE")
 EVENTS_SFN_ACCESS_IAM_ROLE = from_conf("METAFLOW_EVENTS_SFN_ACCESS_IAM_ROLE")
 # Prefix for AWS Step Functions state machines. Set to stack name for Metaflow
 # sandbox.
-SFN_STATE_MACHINE_PREFIX = None
+SFN_STATE_MACHINE_PREFIX = from_conf("METAFLOW_SFN_STATE_MACHINE_PREFIX")
 
 ###
 # Conda configuration
 ###
 # Conda package root location on S3
 CONDA_PACKAGE_S3ROOT = from_conf(
-    "METAFLOW_CONDA_PACKAGE_S3ROOT",
-    "%s/conda" % from_conf("METAFLOW_DATASTORE_SYSROOT_S3"),
-)
+    'METAFLOW_CONDA_PACKAGE_S3ROOT',
+        '%s/conda' % from_conf('METAFLOW_DATASTORE_SYSROOT_S3'))
 
 ###
 # Debug configuration
 ###
-DEBUG_OPTIONS = ["subcommand", "sidecar", "s3client"]
+DEBUG_OPTIONS = ['subcommand', 'sidecar', 's3client']
 
 for typ in DEBUG_OPTIONS:
-    vars()["METAFLOW_DEBUG_%s" % typ.upper()] = from_conf(
-        "METAFLOW_DEBUG_%s" % typ.upper()
-    )
+    vars()['METAFLOW_DEBUG_%s' % typ.upper()] = from_conf('METAFLOW_DEBUG_%s' % typ.upper())
 
 ###
 # AWS Sandbox configuration
 ###
 # Boolean flag for metaflow AWS sandbox access
-AWS_SANDBOX_ENABLED = bool(from_conf("METAFLOW_AWS_SANDBOX_ENABLED", False))
+AWS_SANDBOX_ENABLED = bool(from_conf('METAFLOW_AWS_SANDBOX_ENABLED', False))
 # Metaflow AWS sandbox auth endpoint
-AWS_SANDBOX_STS_ENDPOINT_URL = from_conf("METAFLOW_SERVICE_URL")
+AWS_SANDBOX_STS_ENDPOINT_URL = from_conf('METAFLOW_SERVICE_URL')
 # Metaflow AWS sandbox API auth key
-AWS_SANDBOX_API_KEY = from_conf("METAFLOW_AWS_SANDBOX_API_KEY")
+AWS_SANDBOX_API_KEY = from_conf('METAFLOW_AWS_SANDBOX_API_KEY')
 # Internal Metadata URL
-AWS_SANDBOX_INTERNAL_SERVICE_URL = from_conf(
-    "METAFLOW_AWS_SANDBOX_INTERNAL_SERVICE_URL"
-)
+AWS_SANDBOX_INTERNAL_SERVICE_URL = from_conf('METAFLOW_AWS_SANDBOX_INTERNAL_SERVICE_URL')
 # AWS region
-AWS_SANDBOX_REGION = from_conf("METAFLOW_AWS_SANDBOX_REGION")
+AWS_SANDBOX_REGION = from_conf('METAFLOW_AWS_SANDBOX_REGION')
 
 
 # Finalize configuration
 if AWS_SANDBOX_ENABLED:
-    os.environ["AWS_DEFAULT_REGION"] = AWS_SANDBOX_REGION
+    os.environ['AWS_DEFAULT_REGION'] = AWS_SANDBOX_REGION
     BATCH_METADATA_SERVICE_URL = AWS_SANDBOX_INTERNAL_SERVICE_URL
-    METADATA_SERVICE_HEADERS["x-api-key"] = AWS_SANDBOX_API_KEY
-    SFN_STATE_MACHINE_PREFIX = from_conf("METAFLOW_AWS_SANDBOX_STACK_NAME")
+    METADATA_SERVICE_HEADERS['x-api-key'] = AWS_SANDBOX_API_KEY
+    SFN_STATE_MACHINE_PREFIX = from_conf('METAFLOW_AWS_SANDBOX_STACK_NAME')
 
 
 # MAX_ATTEMPTS is the maximum number of attempts, including the first
@@ -190,14 +183,15 @@ MAX_ATTEMPTS = 6
 # Note: `KFP_RUN_URL_PREFIX` is the URL prefix for KFP runs on your KFP cluster. The prefix includes
 # all parts of the URL except the run_id at the end which we append once the run is created.
 # For eg, this would look like: "https://<your-kf-cluster-url>/pipeline/#/runs/details/"
-KFP_RUN_URL_PREFIX = from_conf("KFP_RUN_URL_PREFIX")
+KFP_RUN_URL_PREFIX = from_conf('KFP_RUN_URL_PREFIX')
 
 # the naughty, naughty driver.py imported by lib2to3 produces
 # spam messages to the root logger. This is what is required
 # to silence it:
 class Filter(logging.Filter):
     def filter(self, record):
-        if record.pathname.endswith("driver.py") and "grammar" in record.msg:
+        if record.pathname.endswith('driver.py') and \
+           'grammar' in record.msg:
             return False
         return True
 
@@ -215,46 +209,27 @@ def get_version(pkg):
 def get_pinned_conda_libs(python_version):
     if python_version.startswith("3.5"):
         return {
-            "click": "7.1.2",
-            "requests": "2.24.0",
-            "boto3": "1.9.88",
-            "coverage": "4.5.1",
+            'click': '7.1.2',
+            'requests': '2.24.0',
+            'boto3': '1.9.88',
+            'coverage': '4.5.1'
         }
     else:
         return {
-            "click": "7.1.2",
-            "requests": "2.24.0",
-            "boto3": "1.14.47",
-            "coverage": "4.5.4",
+            'click': '7.1.2',
+            'requests': '2.24.0',
+            'boto3': '1.14.47',
+            'coverage': '4.5.4'
         }
 
 
-cached_aws_sandbox_creds = None
-
-
-def get_authenticated_boto3_client(module, params={}):
-    from metaflow.exception import MetaflowException
-    import requests
-
-    try:
-        import boto3
-    except (NameError, ImportError):
-        raise MetaflowException("Could not import module 'boto3'. Install boto3 first.")
-
-    if AWS_SANDBOX_ENABLED:
-        global cached_aws_sandbox_creds
-        if cached_aws_sandbox_creds is None:
-            # authenticate using STS
-            url = "%s/auth/token" % AWS_SANDBOX_STS_ENDPOINT_URL
-            headers = {"x-api-key": AWS_SANDBOX_API_KEY}
-            try:
-                r = requests.get(url, headers=headers)
-                r.raise_for_status()
-                cached_aws_sandbox_creds = r.json()
-            except requests.exceptions.HTTPError as e:
-                raise MetaflowException(repr(e))
-        return boto3.session.Session(**cached_aws_sandbox_creds).client(
-            module, **params
-        )
-
-    return boto3.client(module, **params)
+# Check if there is a an extension to Metaflow to load and override everything
+try:
+    import metaflow_custom.config.metaflow_config as extension_module
+except ImportError:
+    pass
+else:
+    # We load into globals whatever we have in extension_module
+    for n, o in extension_module.__dict__.items():
+        if not n.startswith('__'):
+            globals()[n] = o

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -216,7 +216,7 @@ def get_pinned_conda_libs(python_version):
             'boto3': '1.14.47',
             'coverage': '4.5.4'
         }
-
+        
 cached_aws_sandbox_creds = None
 
 

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -46,13 +46,11 @@ DEFAULT_DATASTORE = from_conf('METAFLOW_DEFAULT_DATASTORE', 'local')
 DEFAULT_METADATA = from_conf('METAFLOW_DEFAULT_METADATA', 'local')
 METAFLOW_USER = from_conf('METAFLOW_USER')
 
-METAFLOW_USER = from_conf('METAFLOW_USER')
-
 ##
 # KFP configuration
 ###
-KFP_SDK_NAMESPACE = from_conf("KFP_SDK_NAMESPACE", "kubeflow")
-KFP_SDK_API_NAMESPACE = from_conf("KFP_SDK_API_NAMESPACE", "kubeflow")
+KFP_SDK_NAMESPACE = from_conf('KFP_SDK_NAMESPACE', 'kubeflow')
+KFP_SDK_API_NAMESPACE = from_conf('KFP_SDK_API_NAMESPACE', 'kubeflow')
 
 ###
 # Datastore configuration
@@ -218,14 +216,12 @@ def get_pinned_conda_libs(python_version):
             'coverage': '4.5.4'
         }
 
-
 cached_aws_sandbox_creds = None
 
 
 def get_authenticated_boto3_client(module, params={}):
     from metaflow.exception import MetaflowException
     import requests
-
     try:
         import boto3
     except (NameError, ImportError):

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -252,9 +252,9 @@ class KubeflowPipelines(object):
             return KfpComponent(
                 node.name,
                 self._command(
-                    self.code_package_url, 
-                    self.environment, 
-                    node.name, 
+                    self.code_package_url,
+                    self.environment,
+                    node.name,
                     [step_cli],
                 ),
                 total_retries,
@@ -317,8 +317,10 @@ class KubeflowPipelines(object):
             # If the start step gets retried, we must be careful not to
             # regenerate multiple parameters tasks. Hence we check first if
             # _parameters exists already.
-            start_task_id_params_path = "{kfp_run_id}/_parameters/{task_id_params}".format(
-                kfp_run_id=kfp_run_id, task_id_params=task_id_params
+            start_task_id_params_path = (
+                "{kfp_run_id}/_parameters/{task_id_params}".format(
+                    kfp_run_id=kfp_run_id, task_id_params=task_id_params
+                )
             )
             exists = entrypoint + [
                 "dump",

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -86,9 +86,7 @@ class KubeflowPipelines(object):
         self.workflow_timeout = (
             workflow_timeout if workflow_timeout else 0  # 0 is unlimited
         )
-        self.workflow_ttl = (
-            workflow_ttl if workflow_ttl else 604800  # 1 week
-        )
+        self.workflow_ttl = workflow_ttl if workflow_ttl else 604800  # 1 week
 
         self._client = kfp.Client(namespace=api_namespace, userid=username, **kwargs)
 
@@ -118,7 +116,9 @@ class KubeflowPipelines(object):
         pipeline_conf.set_ttl_seconds_after_finished(self.workflow_ttl)
 
         kfp.compiler.Compiler().compile(
-            self.create_kfp_pipeline_from_flow_graph(), pipeline_file_path, pipeline_conf=pipeline_conf
+            self.create_kfp_pipeline_from_flow_graph(),
+            pipeline_file_path,
+            pipeline_conf=pipeline_conf,
         )
         return os.path.abspath(pipeline_file_path)
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -112,9 +112,10 @@ class KubeflowPipelines(object):
         """
         pipeline_conf = PipelineConf()
         pipeline_conf.set_timeout(self.workflow_timeout)
-        pipeline_conf.set_ttl_seconds_after_finished(
-            self.workflow_kubernetes_resources_ttl
-        )
+        if self.workflow_kubernetes_resources_ttl is not None: # if None, we use the Argo defaults
+            pipeline_conf.set_ttl_seconds_after_finished(
+                self.workflow_kubernetes_resources_ttl
+            )
 
         kfp.compiler.Compiler().compile(
             self.create_kfp_pipeline_from_flow_graph(),
@@ -251,7 +252,10 @@ class KubeflowPipelines(object):
             return KfpComponent(
                 node.name,
                 self._command(
-                    self.code_package_url, self.environment, node.name, [step_cli],
+                    self.code_package_url, 
+                    self.environment, 
+                    node.name, 
+                    [step_cli],
                 ),
                 total_retries,
                 self._get_resource_requirements(node),
@@ -494,9 +498,10 @@ class KubeflowPipelines(object):
             dsl.get_pipeline_conf().add_op_transformer(pipeline_transform)
             dsl.get_pipeline_conf().set_parallelism(self.max_parallelism)
             dsl.get_pipeline_conf().set_timeout(self.workflow_timeout)
-            dsl.get_pipeline_conf().set_ttl_seconds_after_finished(
-                self.workflow_kubernetes_resources_ttl
-            )
+            if self.workflow_kubernetes_resources_ttl is not None: # # if None, we use the Argo defaults
+                dsl.get_pipeline_conf().set_ttl_seconds_after_finished(
+                    self.workflow_kubernetes_resources_ttl
+                )
 
         return kfp_pipeline_from_flow
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -110,10 +110,8 @@ class KubeflowPipelines(object):
         """
         pipeline_conf = PipelineConf()
         pipeline_conf.set_timeout(self.workflow_timeout)
-        if ARGO_DEFAULT_TTL is not None: # if None, we use the Argo defaults
-            pipeline_conf.set_ttl_seconds_after_finished(
-                ARGO_DEFAULT_TTL
-            )
+        if ARGO_DEFAULT_TTL is not None:  # if None, we use the Argo defaults
+            pipeline_conf.set_ttl_seconds_after_finished(ARGO_DEFAULT_TTL)
 
         kfp.compiler.Compiler().compile(
             self.create_kfp_pipeline_from_flow_graph(),
@@ -250,10 +248,7 @@ class KubeflowPipelines(object):
             return KfpComponent(
                 node.name,
                 self._command(
-                    self.code_package_url,
-                    self.environment,
-                    node.name,
-                    [step_cli],
+                    self.code_package_url, self.environment, node.name, [step_cli],
                 ),
                 total_retries,
                 self._get_resource_requirements(node),
@@ -315,10 +310,8 @@ class KubeflowPipelines(object):
             # If the start step gets retried, we must be careful not to
             # regenerate multiple parameters tasks. Hence we check first if
             # _parameters exists already.
-            start_task_id_params_path = (
-                "{kfp_run_id}/_parameters/{task_id_params}".format(
-                    kfp_run_id=kfp_run_id, task_id_params=task_id_params
-                )
+            start_task_id_params_path = "{kfp_run_id}/_parameters/{task_id_params}".format(
+                kfp_run_id=kfp_run_id, task_id_params=task_id_params
             )
             exists = entrypoint + [
                 "dump",
@@ -498,10 +491,8 @@ class KubeflowPipelines(object):
             dsl.get_pipeline_conf().add_op_transformer(pipeline_transform)
             dsl.get_pipeline_conf().set_parallelism(self.max_parallelism)
             dsl.get_pipeline_conf().set_timeout(self.workflow_timeout)
-            if ARGO_DEFAULT_TTL is not None: # # if None, we use the Argo defaults
-                dsl.get_pipeline_conf().set_ttl_seconds_after_finished(
-                    ARGO_DEFAULT_TTL
-                )
+            if ARGO_DEFAULT_TTL is not None:  # # if None, we use the Argo defaults
+                dsl.get_pipeline_conf().set_ttl_seconds_after_finished(ARGO_DEFAULT_TTL)
 
         return kfp_pipeline_from_flow
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -9,7 +9,7 @@ import yaml
 import kfp
 from kfp import dsl
 from kfp.dsl import ContainerOp, PipelineConf
-from metaflow.metaflow_config import DATASTORE_SYSROOT_S3
+from metaflow.metaflow_config import DATASTORE_SYSROOT_S3, ARGO_DEFAULT_TTL
 
 from ... import R
 from ...environment import MetaflowEnvironment
@@ -61,7 +61,6 @@ class KubeflowPipelines(object):
         username=None,
         max_parallelism=None,
         workflow_timeout=None,
-        workflow_kubernetes_resources_ttl=None,
         **kwargs,
     ):
         """
@@ -85,7 +84,6 @@ class KubeflowPipelines(object):
         self.workflow_timeout = (
             workflow_timeout if workflow_timeout else 0  # 0 is unlimited
         )
-        self.workflow_kubernetes_resources_ttl = workflow_kubernetes_resources_ttl
 
         self._client = kfp.Client(namespace=api_namespace, userid=username, **kwargs)
 
@@ -112,9 +110,9 @@ class KubeflowPipelines(object):
         """
         pipeline_conf = PipelineConf()
         pipeline_conf.set_timeout(self.workflow_timeout)
-        if self.workflow_kubernetes_resources_ttl is not None: # if None, we use the Argo defaults
+        if ARGO_DEFAULT_TTL is not None: # if None, we use the Argo defaults
             pipeline_conf.set_ttl_seconds_after_finished(
-                self.workflow_kubernetes_resources_ttl
+                ARGO_DEFAULT_TTL
             )
 
         kfp.compiler.Compiler().compile(
@@ -500,9 +498,9 @@ class KubeflowPipelines(object):
             dsl.get_pipeline_conf().add_op_transformer(pipeline_transform)
             dsl.get_pipeline_conf().set_parallelism(self.max_parallelism)
             dsl.get_pipeline_conf().set_timeout(self.workflow_timeout)
-            if self.workflow_kubernetes_resources_ttl is not None: # # if None, we use the Argo defaults
+            if ARGO_DEFAULT_TTL is not None: # # if None, we use the Argo defaults
                 dsl.get_pipeline_conf().set_ttl_seconds_after_finished(
-                    self.workflow_kubernetes_resources_ttl
+                    ARGO_DEFAULT_TTL
                 )
 
         return kfp_pipeline_from_flow

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -8,8 +8,7 @@ import yaml
 
 import kfp
 from kfp import dsl
-from kfp.dsl import ContainerOp
-from kfp.dsl._pipeline import PipelineConf
+from kfp.dsl import ContainerOp, PipelineConf
 from metaflow.metaflow_config import DATASTORE_SYSROOT_S3
 
 from ... import R

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -248,7 +248,10 @@ class KubeflowPipelines(object):
             return KfpComponent(
                 node.name,
                 self._command(
-                    self.code_package_url, self.environment, node.name, [step_cli],
+                    self.code_package_url,
+                    self.environment,
+                    node.name,
+                    [step_cli],
                 ),
                 total_retries,
                 self._get_resource_requirements(node),
@@ -310,8 +313,10 @@ class KubeflowPipelines(object):
             # If the start step gets retried, we must be careful not to
             # regenerate multiple parameters tasks. Hence we check first if
             # _parameters exists already.
-            start_task_id_params_path = "{kfp_run_id}/_parameters/{task_id_params}".format(
-                kfp_run_id=kfp_run_id, task_id_params=task_id_params
+            start_task_id_params_path = (
+                "{kfp_run_id}/_parameters/{task_id_params}".format(
+                    kfp_run_id=kfp_run_id, task_id_params=task_id_params
+                )
             )
             exists = entrypoint + [
                 "dump",

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -8,6 +8,7 @@ from metaflow.metaflow_config import (
     KFP_RUN_URL_PREFIX,
     KFP_SDK_API_NAMESPACE,
     KFP_SDK_NAMESPACE,
+    ARGO_DEFAULT_TTL,
 )
 from metaflow.package import MetaflowPackage
 from metaflow.plugins.aws.step_functions.step_functions_cli import (
@@ -119,10 +120,7 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
     show_default=True,
 )
 @click.option(
-    "--pipeline-name",
-    "pipeline_name",
-    default=None,
-    help="If not set uses flow_name.",
+    "--pipeline-name", "pipeline_name", default=None, help="If not set uses flow_name.",
 )
 @click.option(
     "--max-parallelism",
@@ -134,7 +132,10 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
     "--workflow-timeout", default=None, type=int, help="Workflow timeout in seconds."
 )
 @click.option(
-    "--workflow-ttl", default=None, type=int, help="Workflow time to live in seconds."
+    "--workflow-kubernetes-resources-ttl",
+    default=ARGO_DEFAULT_TTL,
+    type=int,
+    help="Number of seconds until Argo workflows and pods are cleaned up AFTER a run finishes.",
 )
 @click.pass_obj
 def run(
@@ -150,7 +151,7 @@ def run(
     pipeline_name=None,
     max_parallelism=None,
     workflow_timeout=None,
-    workflow_ttl=None,
+    workflow_kubernetes_resources_ttl=ARGO_DEFAULT_TTL,
 ):
     """
     Analogous to step_functions_cli.py
@@ -166,7 +167,7 @@ def run(
         s3_code_package,
         max_parallelism,
         workflow_timeout,
-        workflow_ttl,
+        workflow_kubernetes_resources_ttl,
     )
 
     if yaml_only:
@@ -212,7 +213,7 @@ def make_flow(
     s3_code_package,
     max_parallelism,
     workflow_timeout,
-    workflow_ttl,
+    workflow_kubernetes_resources_ttl,
 ):
     """
     Analogous to step_functions_cli.py
@@ -272,5 +273,5 @@ def make_flow(
         username=get_username(),
         max_parallelism=max_parallelism,
         workflow_timeout=workflow_timeout,
-        workflow_ttl=workflow_ttl,
+        workflow_kubernetes_resources_ttl=workflow_kubernetes_resources_ttl,
     )

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -8,7 +8,6 @@ from metaflow.metaflow_config import (
     KFP_RUN_URL_PREFIX,
     KFP_SDK_API_NAMESPACE,
     KFP_SDK_NAMESPACE,
-    ARGO_DEFAULT_TTL,
 )
 from metaflow.package import MetaflowPackage
 from metaflow.plugins.aws.step_functions.step_functions_cli import (
@@ -133,7 +132,7 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
 )
 @click.option(
     "--workflow-kubernetes-resources-ttl",
-    default=ARGO_DEFAULT_TTL,
+    default=None,
     type=int,
     help="Number of seconds until Argo workflows and pods are cleaned up AFTER a run finishes.",
 )
@@ -151,7 +150,7 @@ def run(
     pipeline_name=None,
     max_parallelism=None,
     workflow_timeout=None,
-    workflow_kubernetes_resources_ttl=ARGO_DEFAULT_TTL,
+    workflow_kubernetes_resources_ttl=None,
 ):
     """
     Analogous to step_functions_cli.py

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -119,7 +119,10 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
     show_default=True,
 )
 @click.option(
-    "--pipeline-name", "pipeline_name", default=None, help="If not set uses flow_name.",
+    "--pipeline-name",
+    "pipeline_name",
+    default=None,
+    help="If not set uses flow_name.",
 )
 @click.option(
     "--max-parallelism",

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -133,6 +133,9 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
 @click.option(
     "--workflow-timeout", default=None, type=int, help="Workflow timeout in seconds."
 )
+@click.option(
+    "--workflow-ttl", default=None, type=int, help="Workflow time to live in seconds."
+)
 @click.pass_obj
 def run(
     obj,
@@ -147,6 +150,7 @@ def run(
     pipeline_name=None,
     max_parallelism=None,
     workflow_timeout=None,
+    workflow_ttl=None,
 ):
     """
     Analogous to step_functions_cli.py
@@ -162,6 +166,7 @@ def run(
         s3_code_package,
         max_parallelism,
         workflow_timeout,
+        workflow_ttl,
     )
 
     if yaml_only:
@@ -207,6 +212,7 @@ def make_flow(
     s3_code_package,
     max_parallelism,
     workflow_timeout,
+    workflow_ttl,
 ):
     """
     Analogous to step_functions_cli.py
@@ -266,4 +272,5 @@ def make_flow(
         username=get_username(),
         max_parallelism=max_parallelism,
         workflow_timeout=workflow_timeout,
+        workflow_ttl=workflow_ttl,
     )

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -130,12 +130,6 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
 @click.option(
     "--workflow-timeout", default=None, type=int, help="Workflow timeout in seconds."
 )
-@click.option(
-    "--workflow-kubernetes-resources-ttl",
-    default=None,
-    type=int,
-    help="Number of seconds until Argo workflows and pods are cleaned up AFTER a run finishes.",
-)
 @click.pass_obj
 def run(
     obj,
@@ -150,7 +144,6 @@ def run(
     pipeline_name=None,
     max_parallelism=None,
     workflow_timeout=None,
-    workflow_kubernetes_resources_ttl=None,
 ):
     """
     Analogous to step_functions_cli.py
@@ -166,7 +159,6 @@ def run(
         s3_code_package,
         max_parallelism,
         workflow_timeout,
-        workflow_kubernetes_resources_ttl,
     )
 
     if yaml_only:
@@ -212,7 +204,6 @@ def make_flow(
     s3_code_package,
     max_parallelism,
     workflow_timeout,
-    workflow_kubernetes_resources_ttl,
 ):
     """
     Analogous to step_functions_cli.py
@@ -272,5 +263,4 @@ def make_flow(
         username=get_username(),
         max_parallelism=max_parallelism,
         workflow_timeout=workflow_timeout,
-        workflow_kubernetes_resources_ttl=workflow_kubernetes_resources_ttl,
     )


### PR DESCRIPTION
This PR adds the following:
- Includes the workflow `ttl` (time to live, aka how long argo workflows remain after a KFP run is completed) to the `kfp run` command
- Includes both `timeout` and `ttl` to the `create_kfp_pipeline_yaml` function. Why? In an effort to make both the `aip-kfp-example` and `aip-metaflow-example` projects less likely to use up resources, we're enabling timeout and ttl by default. Currently, timeout will be 1 day and ttl will be 1 week. Once this PR is merged, a new Artifactory-based image with the updated `feature/kfp` branch installed will be updated [here](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-workflow/aip-metaflow-example/-/blob/master/Dockerfile#L2). With this new image, we'll have the ability to specify the parameters `--workflow-ttl` and `--workflow-timeout` within the example project [here](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-workflow/aip-metaflow-example/-/blob/master/dodo.py#L43) to prevent any customer projects from unintentionally using up resources.