### PR TITLE
Integ tests by default run on stage + adding params to run on other environments

### DIFF
--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -107,7 +107,7 @@ build:
     paths:
       - ${_IMAGE_TAG_FILE} # we pass this file as an artifact to be read in the testing stages
 
-test:internal:
+test_internal:
   extends: 
     - .devex_internal_eks # sets up AWS environment variables
     - .generate_kubeconfig # creates the .kube directory for the appropriate cluster
@@ -139,7 +139,7 @@ test:internal:
     - if: '$DEPLOY_INTERNAL == "false"'
       when: never
 
-test:nonprod:
+test_nonprod:
   extends: 
     - .devex_nonprod_eks
     - .generate_kubeconfig
@@ -171,7 +171,7 @@ test:nonprod:
     - if: '$DEPLOY_STAGE == "false"'
       when: never
 
-test:prod:
+test_prod:
   extends: 
     - .devex_prod_eks
     - .generate_kubeconfig

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -107,7 +107,7 @@ build:
     paths:
       - ${_IMAGE_TAG_FILE} # we pass this file as an artifact to be read in the testing stages
 
-test_internal:
+test:internal:
   extends: 
     - .devex_internal_eks # sets up AWS environment variables
     - .generate_kubeconfig # creates the .kube directory for the appropriate cluster
@@ -136,10 +136,9 @@ test_internal:
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH}
         "
   rules:
-    - if: '$DEPLOY_INTERNAL == "false"'
-      when: never
+    - if: '$DEPLOY_INTERNAL == "true"'
 
-test_nonprod:
+test:nonprod:
   extends: 
     - .devex_nonprod_eks
     - .generate_kubeconfig
@@ -168,10 +167,9 @@ test_nonprod:
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH}
         "
   rules:
-    - if: '$DEPLOY_STAGE == "false"'
-      when: never
+    - if: '$DEPLOY_STAGE == "true"'
 
-test_prod:
+test:prod:
   extends: 
     - .devex_prod_eks
     - .generate_kubeconfig
@@ -200,5 +198,4 @@ test_prod:
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH}
         "
   rules:
-    - if: '$DEPLOY_PROD == "false"'
-      when: never
+    - if: '$DEPLOY_PROD == "true"'

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -17,9 +17,9 @@ variables:
   ARTIFACTORY_WEB_APP_URL: https://artifactory.zgtools.net/artifactory/webapp/#/packages/docker
   _SHARED_ENV_FILE: 'shared.env'
   _IMAGE_TAG_FILE: 'image_tag_file.txt'
-  DEPLOY_INTERNAL: "false"
-  DEPLOY_STAGE: "true"
-  DEPLOY_PROD: "true"
+  DEPLOY_INTERNAL: "true"
+  DEPLOY_STAGE: "false"
+  DEPLOY_PROD: "false"
 
 .base:job-with-artifacts:
   artifacts:

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -17,9 +17,9 @@ variables:
   ARTIFACTORY_WEB_APP_URL: https://artifactory.zgtools.net/artifactory/webapp/#/packages/docker
   _SHARED_ENV_FILE: 'shared.env'
   _IMAGE_TAG_FILE: 'image_tag_file.txt'
-  DEPLOY_INTERNAL: "true"
-  DEPLOY_STAGE: "false"
-  DEPLOY_PROD: "false"
+  DEPLOY_INTERNAL: "false"
+  DEPLOY_STAGE: "true"
+  DEPLOY_PROD: "true"
 
 .base:job-with-artifacts:
   artifacts:

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -17,6 +17,9 @@ variables:
   ARTIFACTORY_WEB_APP_URL: https://artifactory.zgtools.net/artifactory/webapp/#/packages/docker
   _SHARED_ENV_FILE: 'shared.env'
   _IMAGE_TAG_FILE: 'image_tag_file.txt'
+  DEPLOY_INTERNAL: "true"
+  DEPLOY_STAGE: "false"
+  DEPLOY_PROD: "false"
 
 .base:job-with-artifacts:
   artifacts:
@@ -132,6 +135,9 @@ test:internal:
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests && 
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH}
         "
+  rules:
+    - if: '$DEPLOY_INTERNAL == "false"'
+      when: never
 
 test:nonprod:
   extends: 
@@ -161,6 +167,9 @@ test:nonprod:
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests && 
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH}
         "
+  rules:
+    - if: '$DEPLOY_STAGE == "false"'
+      when: never
 
 test:prod:
   extends: 
@@ -190,3 +199,6 @@ test:prod:
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests && 
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH}
         "
+  rules:
+    - if: '$DEPLOY_PROD == "false"'
+      when: never

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -17,8 +17,8 @@ variables:
   ARTIFACTORY_WEB_APP_URL: https://artifactory.zgtools.net/artifactory/webapp/#/packages/docker
   _SHARED_ENV_FILE: 'shared.env'
   _IMAGE_TAG_FILE: 'image_tag_file.txt'
-  DEPLOY_INTERNAL: "true"
-  DEPLOY_STAGE: "false"
+  DEPLOY_INTERNAL: "false"
+  DEPLOY_STAGE: "true" # want to mimic the example projects, which run on stage
   DEPLOY_PROD: "false"
 
 .base:job-with-artifacts:


### PR DESCRIPTION
Two primary changes:

- To mimic the behavior of the aip-*-example projects, the integrations tests now run by default only on the stage environment. For the Metaflow developer scenario, whenever a user makes a commit or PR, the pipeline is deployed only to the Kubeflow stage cluster.
- From the AIP testing framework, one can manually pass in the variables `DEPLOY_INTERNAL`, `DEPLOY_STAGE`, and `DEPLOY_PROD` to run tests on a specific cluster at a time.