### PR TITLE
Metaflow writes and reads KFP pipeline parameters

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import os
 import sys
 from pathlib import Path
@@ -89,14 +90,19 @@ class KubeflowPipelines(object):
 
         self._client = kfp.Client(namespace=api_namespace, userid=username, **kwargs)
 
-    def create_run_on_kfp(self, experiment_name: str, run_name: str):
+    def create_run_on_kfp(
+        self, experiment_name: str, run_name: str, flow_parameters: dict
+    ):
         """
         Creates a new run on KFP using the `kfp.Client()`.
         """
         # TODO: first create KFP Pipeline, then an experiment if provided else default experiment.
         run_pipeline_result = self._client.create_run_from_pipeline_func(
             pipeline_func=self.create_kfp_pipeline_from_flow_graph(),
-            arguments={"datastore_root": DATASTORE_SYSROOT_S3},
+            arguments={
+                "datastore_root": DATASTORE_SYSROOT_S3,
+                "flow_parameters_json": json.dumps(flow_parameters),
+            },
             experiment_name=experiment_name,
             run_name=run_name,
             namespace=self.namespace,
@@ -438,7 +444,10 @@ class KubeflowPipelines(object):
             op.execution_options.caching_strategy.max_cache_staleness = "P0D"
 
         @dsl.pipeline(name=self.name, description=self.graph.doc)
-        def kfp_pipeline_from_flow(datastore_root: str = DATASTORE_SYSROOT_S3):
+        def kfp_pipeline_from_flow(
+            datastore_root: str = DATASTORE_SYSROOT_S3,
+            flow_parameters_json: str = None,
+        ):
             visited: Dict[str, ContainerOp] = {}
 
             def build_kfp_dag(node: DAGNode, passed_in_split_indexes=None):
@@ -451,6 +460,9 @@ class KubeflowPipelines(object):
                     kfp_run_id=f"kfp-{dsl.RUN_ID_PLACEHOLDER}",
                     passed_in_split_indexes=passed_in_split_indexes,
                     metaflow_service_url=METADATA_SERVICE_URL,
+                    flow_parameters_json=flow_parameters_json
+                    if node.name == "start"
+                    else None,
                 )
 
                 KubeflowPipelines._set_container_settings(

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -1,8 +1,9 @@
 import posixpath
 
 import click
+import json
 
-from metaflow import current, decorators
+from metaflow import current, decorators, parameters, JSONType
 from metaflow.datastore.datastore import TransformableObject
 from metaflow.exception import MetaflowException
 from metaflow.metaflow_config import (
@@ -54,6 +55,7 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
     )
 
 
+@parameters.add_custom_parameters(deploy_mode=True)
 @kubeflow_pipelines.command(
     help="Deploy a new version of this workflow to Kubeflow Pipelines."
 )
@@ -153,10 +155,22 @@ def run(
     max_parallelism=None,
     workflow_timeout=None,
     wait_for_completion=False,
+    **kwargs
 ):
     """
     Analogous to step_functions_cli.py
     """
+
+    def _convert_value(param: parameters.Parameter):
+        v = kwargs.get(param.name)
+        return json.dumps(v) if param.kwargs.get("type") == JSONType else v
+
+    flow_parameters = {
+        param.name: _convert_value(param)
+        for _, param in obj.flow._get_parameters()
+        if kwargs.get(param.name) is not None
+    }
+
     obj.check(obj.graph, obj.flow, obj.environment, pylint=obj.pylint)
     check_metadata_service_version(obj)
     flow = make_flow(
@@ -186,7 +200,9 @@ def run(
         obj.echo(
             "Deploying *%s* to Kubeflow Pipelines..." % current.flow_name, bold=True
         )
-        run_pipeline_result = flow.create_run_on_kfp(experiment_name, run_name)
+        run_pipeline_result = flow.create_run_on_kfp(
+            experiment_name, run_name, flow_parameters
+        )
 
         obj.echo("\nRun created successfully!\n")
 

--- a/metaflow/plugins/kfp/kfp_step_function.py
+++ b/metaflow/plugins/kfp/kfp_step_function.py
@@ -4,6 +4,7 @@ def kfp_step_function(
     kfp_run_id: str,
     passed_in_split_indexes: str = '""',  # only if is_inside_foreach
     metaflow_service_url: str = "",
+    flow_parameters_json: str = None,  # json formatted string
 ) -> list:
     """
     Renders and runs the cmd_template containing Metaflow step/init commands to
@@ -20,19 +21,19 @@ def kfp_step_function(
         passed_in_split_indexes=passed_in_split_indexes,
     )
 
+    env = dict(
+        os.environ,
+        METAFLOW_USER="kfp-user",  # TODO: what should this be for a non-scheduled run?
+        METAFLOW_SERVICE_URL=metaflow_service_url,
+    )
+    if flow_parameters_json is not None:
+        env["METAFLOW_PARAMETERS"] = flow_parameters_json
+
     # TODO: Map username to KFP specific user/profile/namespace
     # Running Metaflow
     # KFP orchestrator -> running MF runtime (runs user code, handles state)
     with Popen(
-        cmd,
-        shell=True,
-        universal_newlines=True,
-        executable="/bin/bash",
-        env=dict(
-            os.environ,
-            METAFLOW_USER="kfp-user",  # TODO: what should this be for a non-scheduled run?
-            METAFLOW_SERVICE_URL=metaflow_service_url,
-        ),
+        cmd, shell=True, universal_newlines=True, executable="/bin/bash", env=env
     ) as process:
         pass
 

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -65,7 +65,9 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
         f"--wait-for-completion --max-parallelism 3 "
     )
     if pytestconfig.getoption("image"):
-        test_cmd += f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+        test_cmd += (
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+        )
 
     run_and_wait_process = run(
         test_cmd,

--- a/metaflow/tutorials/09-hellokfp/parameter_flow.py
+++ b/metaflow/tutorials/09-hellokfp/parameter_flow.py
@@ -1,0 +1,58 @@
+import socket
+from metaflow import FlowSpec, Parameter, step
+
+
+def get_host_name(*arg) -> str:
+    return socket.gethostname()
+
+
+class ParameterFlow(FlowSpec):
+    """
+    A flow where Metaflow prints 'Hi'.
+
+    The hello step uses @resource decorator that only works when kfp plug-in is used.
+    """
+
+    alpha = Parameter(
+        'alpha',
+        help='param with default',
+        default=0.01,
+    )
+
+    beta = Parameter(
+        'beta',
+        help='param with no default',
+        type=int,
+        required=True
+    )
+
+    host_name = Parameter(
+        'host_name',
+        help='Deploy-time param evaluated at deployment',
+        type=str,
+        default=get_host_name,
+        required=True
+    )
+
+    @step
+    def start(self):
+        """
+        All flows must have a step named 'start' that is the first step in the flow.
+        """
+        print(f"Alpha: {self.alpha}")
+        print(f"Beta: {self.beta}")
+        print(f"Host name: {self.host_name}")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """
+        All flows must have an 'end' step, which is the last step in the flow.
+        """
+        print(f"Alpha: {self.alpha}")
+        print(f"Beta: {self.beta}")
+        print(f"Host name: {self.host_name}")
+
+
+if __name__ == '__main__':
+    ParameterFlow()


### PR DESCRIPTION
### Changes:

- Adding ability for KFP plug-in to read parameters from cli and env.
  - When triggering KFP run from local click cli, parameters can be set using standard Metaflow way. (i.e. `--beta 10`)
  - (To be tested) When triggering from KFP, parameters can be overwritten by changing the json formatted PipelineParameter

### Implementation:
Mostly imitating implementation of aws step function plug-in. Once json formatted parameter is passed to Metaflow process env as `METAFLOW_PARAMETERS` environmental variable, it is read by this line in [set_batch_environment.py](https://github.com/zillow/metaflow/blob/feature/kfp/metaflow/plugins/aws/step_functions/set_batch_environment.py#L8) and taken over by existing step function code.

### Testing:
Ran `python metaflow/tutorials/09-hellokfp/parameter_flow.py kfp run --beta 10` to trigger a kfp run in sandbox cluster: https://kubeflow.corp.dev.zg-aip.net/_/pipeline/#/runs/details/03b1cf14-41f3-49cb-90a1-6a90bff0333d
Look in logs of start and end steps for printed parameter values in the end.
```
Alpha: 0.01
Beta: 10
```

### Todos:
- Verify usage in rent zest
- Change parameter passing for kfp side to be per-parameter (instead of json) for convenience.

Thanks to @talebzeghmi for helping to navigate through quite some complexity.