### PR TITLE
fix for logs in metaflow kfp plugin

### DIFF
--- a/metaflow/plugins/kfp/kfp_decorator.py
+++ b/metaflow/plugins/kfp/kfp_decorator.py
@@ -107,6 +107,19 @@ class KfpInternalDecorator(StepDecorator):
         # Register book-keeping metadata for debugging.
         metadata.register_metadata(run_id, step_name, task_id, entries)
 
+        for logtype in ['stdout', 'stderr']:
+            datum = [
+                    MetaDatum(field='log_location_%s' % logtype,
+                            value=json.dumps({
+                                'ds_type': 's3',
+                                'location': datastore.get_log_location(logtype),
+                                'attempt': retry_count}),
+                            type='log_path',
+                            tags=[])
+                    ]
+            # Register log related metadata for debugging.
+            metadata.register_metadata(run_id, step_name, task_id, datum)
+
         if metadata.TYPE == "local":
             self.ds_root = datastore.root
         else:

--- a/metaflow/plugins/kfp/kfp_decorator.py
+++ b/metaflow/plugins/kfp/kfp_decorator.py
@@ -107,16 +107,21 @@ class KfpInternalDecorator(StepDecorator):
         # Register book-keeping metadata for debugging.
         metadata.register_metadata(run_id, step_name, task_id, entries)
 
-        for logtype in ['stdout', 'stderr']:
+        for logtype in ["stdout", "stderr"]:
             datum = [
-                    MetaDatum(field='log_location_%s' % logtype,
-                            value=json.dumps({
-                                'ds_type': 's3',
-                                'location': datastore.get_log_location(logtype),
-                                'attempt': retry_count}),
-                            type='log_path',
-                            tags=[])
-                    ]
+                MetaDatum(
+                    field="log_location_%s" % logtype,
+                    value=json.dumps(
+                        {
+                            "ds_type": "s3",
+                            "location": datastore.get_log_location(logtype),
+                            "attempt": retry_count,
+                        }
+                    ),
+                    type="log_path",
+                    tags=[],
+                )
+            ]
             # Register log related metadata for debugging.
             metadata.register_metadata(run_id, step_name, task_id, datum)
 


### PR DESCRIPTION
Bug: task.stdout and task.stderr isn't fetching the logs, happens only in KFP plugin (**AIP-3607**)
Fix: Added and registered task metadata entries for 'log_location_stdout' and 'log_location_stderr'