### PR TITLE
Increase wait_for_completion timeout to 30 minutes

### DIFF
--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -336,7 +336,7 @@ def run(
             show_status(run_id, kfp_run_url, obj.echo, succeeded)
         elif wait_for_completion:
             response = flow._client.wait_for_run_completion(
-                run_pipeline_result.run_id, timeout=500
+                run_pipeline_result.run_id, timeout=1800
             )
             succeeded = (response.run.status == "Succeeded",)
             show_status(run_id, kfp_run_url, obj.echo, succeeded)

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -336,7 +336,7 @@ def run(
             show_status(run_id, kfp_run_url, obj.echo, succeeded)
         elif wait_for_completion:
             response = flow._client.wait_for_run_completion(
-                run_pipeline_result.run_id, timeout=1800
+                run_pipeline_result.run_id, timeout=workflow_timeout
             )
             succeeded = (response.run.status == "Succeeded",)
             show_status(run_id, kfp_run_url, obj.echo, succeeded)

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -62,7 +62,7 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
 
     test_cmd = (
         f"{_python()} {full_path} --datastore=s3 kfp run "
-        f"--wait-for-completion --max-parallelism 3 "
+        f"--wait-for-completion --workflow-timeout 1800 --max-parallelism 3 "
     )
     if pytestconfig.getoption("image"):
         test_cmd += (


### PR DESCRIPTION
We have received lots of failures in the aip-metaflow-integration-testing-repo because the original timeout of 500 seconds was too short (flows successfully completed, but due to late scheduling, took a while to complete).