### PR TITLE
Annotate K8s Pods with flow name, step, run_id for ddog integration

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -536,20 +536,20 @@ class KubeflowPipelines(object):
                 resource_requirements["local_storage_limit"]
             )
 
-    def _set_container_annotations(
+    def _set_container_labels(
         self, container_op: ContainerOp, node: DAGNode, metaflow_run_id: str
     ):
         prefix = "metaflow.org"
-        container_op.add_pod_annotation(f"{prefix}/flow_name", self.name)
-        container_op.add_pod_annotation(f"{prefix}/step", node.name)
-        container_op.add_pod_annotation(f"{prefix}/run_id", metaflow_run_id)
+        container_op.add_pod_label(f"{prefix}/flow_name", self.name)
+        container_op.add_pod_label(f"{prefix}/step", node.name)
+        container_op.add_pod_label(f"{prefix}/run_id", metaflow_run_id)
 
         if self.experiment:
-            container_op.add_pod_annotation(f"{prefix}/experiment", self.experiment)
+            container_op.add_pod_label(f"{prefix}/experiment", self.experiment)
         if self.tags and len(self.tags) > 0:
             for tag in self.tags:
                 annotation_name = f"{prefix}/tag_{tag}"
-                container_op.add_pod_annotation(annotation_name, "true")
+                container_op.add_pod_label(annotation_name, "true")
 
     def step_op(
         self,
@@ -788,7 +788,7 @@ class KubeflowPipelines(object):
                     }
 
                 KubeflowPipelines._set_container_resources(container_op, kfp_component)
-                self._set_container_annotations(container_op, node, metaflow_run_id)
+                self._set_container_labels(container_op, node, metaflow_run_id)
 
                 if node.type == "foreach":
                     # Please see nested_parallelfor.ipynb for how this works

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -106,6 +106,7 @@ class KubeflowPipelines(object):
         base_image=None,
         s3_code_package=True,
         tags=None,
+        experiment=None,
         namespace=None,
         kfp_namespace=None,
         api_namespace=None,
@@ -131,6 +132,7 @@ class KubeflowPipelines(object):
         self.event_logger = event_logger
         self.monitor = monitor
         self.tags = tags
+        self.experiment = experiment
         self.namespace = namespace
         self.kfp_namespace = kfp_namespace
         self.api_namespace = api_namespace
@@ -146,7 +148,7 @@ class KubeflowPipelines(object):
         self.notify_on_success = notify_on_success
         self._client = None
 
-    def create_run_on_kfp(self, experiment: str, run_name: str, flow_parameters: dict):
+    def create_run_on_kfp(self, run_name: str, flow_parameters: dict):
         """
         Creates a new run on KFP using the `kfp.Client()`.
         """
@@ -163,7 +165,7 @@ class KubeflowPipelines(object):
         return self._client.create_run_from_pipeline_func(
             pipeline_func=pipeline_func,
             arguments={"flow_parameters_json": json.dumps(flow_parameters)},
-            experiment_name=experiment,
+            experiment_name=self.experiment,
             run_name=run_name,
             namespace=self.kfp_namespace,
         )
@@ -504,7 +506,9 @@ class KubeflowPipelines(object):
         return " && ".join(cmds)
 
     @staticmethod
-    def _set_container_settings(container_op: ContainerOp, kfp_component: KfpComponent):
+    def _set_container_resources(
+        container_op: ContainerOp, kfp_component: KfpComponent
+    ):
         resource_requirements: Dict[str, str] = kfp_component.resource_requirements
         if "memory" in resource_requirements:
             container_op.container.set_memory_request(resource_requirements["memory"])
@@ -531,6 +535,21 @@ class KubeflowPipelines(object):
             container_op.container.set_ephemeral_storage_limit(
                 resource_requirements["local_storage_limit"]
             )
+
+    def _set_container_annotations(
+        self, container_op: ContainerOp, node: DAGNode, metaflow_run_id: str
+    ):
+        prefix = "metaflow.org"
+        container_op.add_pod_annotation(f"{prefix}/flow_name", self.name)
+        container_op.add_pod_annotation(f"{prefix}/step", node.name)
+        container_op.add_pod_annotation(f"{prefix}/run_id", metaflow_run_id)
+
+        if self.experiment:
+            container_op.add_pod_annotation(f"{prefix}/experiment", self.experiment)
+        if self.tags and len(self.tags) > 0:
+            for tag in self.tags:
+                annotation_name = f"{prefix}/tag_{tag}"
+                container_op.add_pod_annotation(annotation_name, "true")
 
     def step_op(
         self,
@@ -699,9 +718,10 @@ class KubeflowPipelines(object):
                     METAFLOW_SERVICE_URL=METADATA_SERVICE_URL,
                     METAFLOW_USER=METAFLOW_USER,
                 )
+                metaflow_run_id = f"kfp-{dsl.RUN_ID_PLACEHOLDER}"
                 step_op_args = dict(
                     cmd_template=kfp_component.cmd_template,
-                    kfp_run_id=f"kfp-{dsl.RUN_ID_PLACEHOLDER}",
+                    metaflow_run_id=metaflow_run_id,
                     metaflow_configs=metaflow_configs,
                     passed_in_split_indexes=passed_in_split_indexes,
                     preceding_component_inputs=preceding_component_inputs,
@@ -767,7 +787,8 @@ class KubeflowPipelines(object):
                         for name in next_kfp_decorator_component.preceding_component_outputs
                     }
 
-                KubeflowPipelines._set_container_settings(container_op, kfp_component)
+                KubeflowPipelines._set_container_resources(container_op, kfp_component)
+                self._set_container_annotations(container_op, node, metaflow_run_id)
 
                 if node.type == "foreach":
                     # Please see nested_parallelfor.ipynb for how this works

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -548,8 +548,7 @@ class KubeflowPipelines(object):
             container_op.add_pod_label(f"{prefix}/experiment", self.experiment)
         if self.tags and len(self.tags) > 0:
             for tag in self.tags:
-                annotation_name = f"{prefix}/tag_{tag}"
-                container_op.add_pod_label(annotation_name, "true")
+                container_op.add_pod_label(f"{prefix}/tag_{tag}", "true")
 
     def step_op(
         self,

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -390,7 +390,7 @@ def make_flow(
 
     datastore = (
         None
-        if (not s3_code_package and yaml_only)
+        if (not s3_code_package)
         else obj.datastore(
             obj.flow.name,
             mode="w",

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -270,6 +270,7 @@ def run(
         obj,
         pipeline_name if pipeline_name else obj.flow.name,
         tags,
+        experiment,
         namespace,
         kfp_namespace,
         api_namespace,
@@ -303,9 +304,7 @@ def run(
             "Deploying *%s* to Kubeflow Pipelines..." % current.flow_name,
             bold=True,
         )
-        run_pipeline_result = flow.create_run_on_kfp(
-            experiment, run_name, flow_parameters
-        )
+        run_pipeline_result = flow.create_run_on_kfp(run_name, flow_parameters)
 
         obj.echo("\nRun created successfully!\n")
 
@@ -366,6 +365,7 @@ def make_flow(
     obj,
     name,
     tags,
+    experiment,
     namespace,
     kfp_namespace,
     api_namespace,
@@ -436,6 +436,7 @@ def make_flow(
         base_image=base_image,
         s3_code_package=s3_code_package,
         tags=tags,
+        experiment=experiment,
         namespace=namespace,
         kfp_namespace=kfp_namespace,
         api_namespace=api_namespace,

--- a/metaflow/plugins/kfp/kfp_step_function.py
+++ b/metaflow/plugins/kfp/kfp_step_function.py
@@ -3,7 +3,7 @@ from typing import List, Dict
 
 def kfp_step_function(
     cmd_template: str,
-    kfp_run_id: str,
+    metaflow_run_id: str,
     metaflow_configs: Dict[str, str],
     passed_in_split_indexes: str = '""',  # only if is_inside_foreach
     preceding_component_inputs: List[
@@ -40,7 +40,7 @@ def kfp_step_function(
     }
 
     cmd = cmd_template.format(
-        run_id=kfp_run_id,
+        run_id=metaflow_run_id,
         passed_in_split_indexes=passed_in_split_indexes,
     )
 

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -129,7 +129,6 @@ test:internal:
         bash -c "
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.dev-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing && 
-          export METAFLOW_DATASTORE_SYSROOT_S3=s3://aip-example-dev/metaflow/ && 
           export METAFLOW_USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests && 
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -129,9 +129,8 @@ test:internal:
         bash -c "
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.dev-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing && 
-          export METAFLOW_DATASTORE_SYSROOT_S3=s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/dev/aip-example
           export METAFLOW_USER=${GITLAB_USER_EMAIL} &&
-          cd /home/zservice/metaflow/metaflow/plugins/kfp/tests && 
+          cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
   artifacts:
@@ -165,9 +164,8 @@ test:nonprod:
         bash -c "
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.stage-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-dev && 
-          export METAFLOW_DATASTORE_SYSROOT_S3=s3://aip-example-stage/metaflow/ && 
           export METAFLOW_USER=${GITLAB_USER_EMAIL} &&
-          cd /home/zservice/metaflow/metaflow/plugins/kfp/tests && 
+          cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
   artifacts:
@@ -201,9 +199,8 @@ test:prod:
         bash -c "
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.prod-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-prod && 
-          export METAFLOW_DATASTORE_SYSROOT_S3=s3://aip-example-prod/metaflow/ &&
-          export METAFLOW_USER=${GITLAB_USER_EMAIL} && 
-          cd /home/zservice/metaflow/metaflow/plugins/kfp/tests && 
+          export METAFLOW_USER=${GITLAB_USER_EMAIL} &&
+          cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
   artifacts:

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -129,6 +129,7 @@ test:internal:
         bash -c "
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.dev-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing && 
+          export METAFLOW_DATASTORE_SYSROOT_S3=s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/dev/aip-example
           export METAFLOW_USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests && 
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -129,7 +129,7 @@ test:internal:
         bash -c "
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.dev-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing && 
-          export METAFLOW_USER=${GITLAB_USER_EMAIL} &&
+          export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
@@ -162,9 +162,9 @@ test:nonprod:
         -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION 
         ${BUILT_IMAGE_FULL_PATH}
         bash -c "
-          export KFP_RUN_URL_PREFIX=https://kubeflow.corp.stage-k8s.zg-aip.net/ && 
-          export KFP_SDK_NAMESPACE=metaflow-integration-testing-dev && 
-          export METAFLOW_USER=${GITLAB_USER_EMAIL} &&
+          export KFP_RUN_URL_PREFIX=https://kubeflow.corp.stage-k8s.zg-aip.net/ &&
+          export KFP_SDK_NAMESPACE=metaflow-integration-testing-dev &&
+          export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
@@ -199,7 +199,7 @@ test:prod:
         bash -c "
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.prod-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-prod && 
-          export METAFLOW_USER=${GITLAB_USER_EMAIL} &&
+          export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -56,15 +56,15 @@ annotations = {
     "metaflow.org/step": "MF_STEP",
     "metaflow.org/run_id": "MF_RUN_ID",
     "metaflow.org/experiment": "MF_EXPERIMENT",
-    "metaflow.org/tag_mf_test": "MF_TAG_MF_TEST",
-    "metaflow.org/tag_t1": "MF_TAG_T1",
+    "metaflow.org/tag_metaflow_test": "MF_TAG_METAFLOW_TEST",
+    "metaflow.org/tag_test_t1": "MF_TAG_TEST_T1",
 }
 for annotation, env_name in annotations.items():
     kubernetes_vars.append(
         V1EnvVar(
             name=env_name,
             value_from=V1EnvVarSource(
-                field_ref=V1ObjectFieldSelector(field_path=f"metadata.annotations['{annotation}']")
+                field_ref=V1ObjectFieldSelector(field_path=f"metadata.labels['{annotation}']")
             ),
         )
     )
@@ -102,8 +102,8 @@ class ResourcesFlow(FlowSpec):
         assert os.environ.get("MF_STEP") == current.step_name
         assert os.environ.get("MF_RUN_ID") == current.run_id
         assert os.environ.get("MF_EXPERIMENT") == "mf_test"
-        assert os.environ.get("MF_TAG_MF_TEST") == "true"
-        assert os.environ.get("MF_TAG_T1") == "true"
+        assert os.environ.get("MF_TAG_METAFLOW_TEST") == "true"
+        assert os.environ.get("MF_TAG_TEST_T1") == "true"
 
         self.next(self.end)
 

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -9,7 +9,7 @@ from kubernetes.client import (
     V1ResourceFieldSelector,
 )
 
-from metaflow import FlowSpec, step, environment, resources
+from metaflow import FlowSpec, step, environment, resources, current
 
 
 def get_env_vars(env_resources: Dict[str, str]) -> List[V1EnvVar]:
@@ -51,6 +51,25 @@ kubernetes_vars.append(
     )
 )
 
+annotations = {
+    "metaflow.org/flow_name": "MF_NAME",
+    "metaflow.org/step": "MF_STEP",
+    "metaflow.org/run_id": "MF_RUN_ID",
+    "metaflow.org/experiment": "MF_EXPERIMENT",
+    "metaflow.org/tag_mf_test": "MF_TAG_MF_TEST",
+    "metaflow.org/tag_t1": "MF_TAG_T1",
+}
+for annotation, env_name in annotations.items():
+    kubernetes_vars.append(
+        V1EnvVar(
+            name=env_name,
+            value_from=V1EnvVarSource(
+                field_ref=V1ObjectFieldSelector(field_path=f"metadata.annotations['{annotation}']")
+            ),
+        )
+    )
+
+
 
 class ResourcesFlow(FlowSpec):
     @resources(
@@ -78,6 +97,13 @@ class ResourcesFlow(FlowSpec):
         assert os.environ.get("LOCAL_STORAGE_LIMIT") == "242000000"
         assert os.environ.get("MEMORY") == "500000000"
         assert os.environ.get("MEMORY_LIMIT") == "1000000000"
+
+        assert os.environ.get("MF_NAME") == current.flow_name
+        assert os.environ.get("MF_STEP") == current.step_name
+        assert os.environ.get("MF_RUN_ID") == current.run_id
+        assert os.environ.get("MF_EXPERIMENT") == "mf_test"
+        assert os.environ.get("MF_TAG_MF_TEST") == "true"
+        assert os.environ.get("MF_TAG_T1") == "true"
 
         self.next(self.end)
 

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -61,7 +61,7 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
     # `check_valid_logs_process` process.
 
     test_cmd = (
-        f"{_python()} {full_path} --datastore=s3 kfp run "
+        f"{_python()} {full_path} --datastore=s3 kfp run --no-s3-code-package "
         f"--wait-for-completion --workflow-timeout 1800 "
         f"--max-parallelism 3 --experiment mf_test --tag t1"
     )

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -63,7 +63,7 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
     test_cmd = (
         f"{_python()} {full_path} --datastore=s3 kfp run --no-s3-code-package "
         f"--wait-for-completion --workflow-timeout 1800 "
-        f"--max-parallelism 3 --experiment mf_test --tag t1"
+        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
     )
     if pytestconfig.getoption("image"):
         test_cmd += (

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -61,7 +61,7 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
     # `check_valid_logs_process` process.
 
     test_cmd = (
-        f"{_python()} {full_path} --datastore=s3 kfp run --no-s3-code-package "
+        f"{_python()} {full_path} --datastore=s3 kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
     )

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -63,7 +63,7 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
     test_cmd = (
         f"{_python()} {full_path} --datastore=s3 kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
-        f"--max-parallelism 3 "
+        f"--max-parallelism 3 --experiment mf_test --tag t1"
     )
     if pytestconfig.getoption("image"):
         test_cmd += (


### PR DESCRIPTION
- prefix labels with `metaflow.org/`

example pod annotation with run:
```bash
python resources_flow.py kfp run --experiment mf_test --tag t1
```
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    metaflow.org/experiment: mf_test
    metaflow.org/flow_name: ResourcesFlow
    metaflow.org/run_id: kfp-1047f250-6d8d-441b-b81e-285abe19620e
    metaflow.org/step: start
    metaflow.org/tag_aip-metaflow-sandbox: "true"
    metaflow.org/tag_mf_test: "true"
    metaflow.org/tag_t1: "true"
```