### PR TITLE
Ensuring the integration tests cause Gitlab pipeline to error on failures

### DIFF
--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -349,7 +349,7 @@ def run(
             response = flow._client.wait_for_run_completion(
                 run_pipeline_result.run_id, timeout=wait_for_completion_timeout
             )
-            succeeded = (response.run.status == "Succeeded",)
+            succeeded = response.run.status == "Succeeded"
             show_status(run_id, kfp_run_url, obj.echo, succeeded)
 
 

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -128,7 +128,7 @@ test:internal:
         ${BUILT_IMAGE_FULL_PATH}
         bash -c "
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.dev-k8s.zg-aip.net/ && 
-          export KFP_SDK_NAMESPACE=metaflow-integration-testing && 
+          export KFP_SDK_NAMESPACE=metaflow-integration-testing-internal && 
           export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
@@ -163,7 +163,7 @@ test:nonprod:
         ${BUILT_IMAGE_FULL_PATH}
         bash -c "
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.stage-k8s.zg-aip.net/ &&
-          export KFP_SDK_NAMESPACE=metaflow-integration-testing-dev &&
+          export KFP_SDK_NAMESPACE=metaflow-integration-testing-stage &&
           export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg

--- a/metaflow/plugins/kfp/tests/flows/raise_error_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/raise_error_flow.py
@@ -1,0 +1,27 @@
+from metaflow import FlowSpec, step
+
+
+class RaiseErrorFlow(FlowSpec):
+    """
+    This flow is intended to "test" the Metaflow integration testing framework.
+    In the past, the Metaflow integration test has incorrectly reported failing 
+    fails are passing within the Gitlab (and this Github UI). This flow is supposed
+    to fail, and we ensure the integration test detects that.
+    """
+    @step
+    def start(self):
+        print("This step should complete successfuly!")
+        self.next(self.error_step)
+
+    @step
+    def error_step(self):
+        raise Exception("This exception is intended to test the integration test!")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print("This step should not be reachable!")
+
+
+if __name__ == "__main__":
+    RaiseErrorFlow()

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -44,7 +44,7 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
     file_paths = [
         file_name
         for file_name in listdir(flow_dir_path)
-        if isfile(join(flow_dir_path, file_name)) and not file_name.startswith(".") and not "raise_failure_flow" in file_name
+        if isfile(join(flow_dir_path, file_name)) and not file_name.startswith(".") and not "raise_error_flow" in file_name
     ]
     return file_paths
 

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -76,7 +76,6 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
         stdout=PIPE,
         shell=True,
     )
-    # ensures the subprocess.run command returns with exit code 0
     assert run_and_wait_process.returncode == 0
 
     return

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -44,9 +44,32 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
     file_paths = [
         file_name
         for file_name in listdir(flow_dir_path)
-        if isfile(join(flow_dir_path, file_name)) and not file_name.startswith(".")
+        if isfile(join(flow_dir_path, file_name)) and not file_name.startswith(".") and not "raise_failure_flow" in file_name
     ]
     return file_paths
+
+
+# this test ensures the integration tests fail correctly
+def test_raise_failure_flow(pytestconfig, flow_file_path: str) -> None:
+    test_cmd = (
+        f"{_python()} flows/raise_failure_flow --datastore=s3 kfp run "
+        f"--wait-for-completion --workflow-timeout 1800 "
+        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+    )
+    if pytestconfig.getoption("image"):
+        test_cmd += (
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+        )
+
+    run_and_wait_process = run(
+        test_cmd,
+        universal_newlines=True,
+        stdout=PIPE,
+        shell=True,
+    )
+    assert run_and_wait_process.returncode == 1
+
+    return
 
 
 @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -75,7 +75,6 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
         universal_newlines=True,
         stdout=PIPE,
         shell=True,
-        # check=True, # ensures the kfp run command returns with exit code 0
     )
     # ensures the subprocess.run command returns with exit code 0
     assert run_and_wait_process.returncode == 0

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -50,7 +50,7 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
 
 
 # this test ensures the integration tests fail correctly
-def test_raise_failure_flow(pytestconfig, flow_file_path: str) -> None:
+def test_raise_failure_flow(pytestconfig) -> None:
     test_cmd = (
         f"{_python()} flows/raise_failure_flow --datastore=s3 kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
@@ -67,6 +67,7 @@ def test_raise_failure_flow(pytestconfig, flow_file_path: str) -> None:
         stdout=PIPE,
         shell=True,
     )
+    # this ensures the testing framework correctly detects that this test has failed
     assert run_and_wait_process.returncode == 1
 
     return

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -52,7 +52,7 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
 # this test ensures the integration tests fail correctly
 def test_raise_failure_flow(pytestconfig) -> None:
     test_cmd = (
-        f"{_python()} flows/raise_failure_flow --datastore=s3 kfp run "
+        f"{_python()} flows/raise_failure_flow.py --datastore=s3 kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
     )
@@ -67,7 +67,8 @@ def test_raise_failure_flow(pytestconfig) -> None:
         stdout=PIPE,
         shell=True,
     )
-    # this ensures the testing framework correctly detects that this test has failed
+    # this ensures the integration testing framework correctly catches a failing flow
+    # and reports the error
     assert run_and_wait_process.returncode == 1
 
     return

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -52,7 +52,7 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
 # this test ensures the integration tests fail correctly
 def test_raise_failure_flow(pytestconfig) -> None:
     test_cmd = (
-        f"{_python()} flows/raise_failure_flow.py --datastore=s3 kfp run "
+        f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
     )

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -75,7 +75,9 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
         universal_newlines=True,
         stdout=PIPE,
         shell=True,
+        check=True, # ensures the kfp run command returns with exit code 0
     )
+    # ensures the subprocess.run command returns with exit code 0
     assert run_and_wait_process.returncode == 0
 
     return

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -75,7 +75,7 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
         universal_newlines=True,
         stdout=PIPE,
         shell=True,
-        check=True, # ensures the kfp run command returns with exit code 0
+        # check=True, # ensures the kfp run command returns with exit code 0
     )
     # ensures the subprocess.run command returns with exit code 0
     assert run_and_wait_process.returncode == 0


### PR DESCRIPTION
The integration testing framework has been incorrectly reporting tests as successful for the last several weeks because `(response.run.status == "Succeeded",)` resolves as `(False,)` when `status != "Succeeded"`, and this tuple resolves to `true`. This `succeeded` always resolves to `true`, and the appropriate Metaflow exception is not raised. 