### PR TITLE
Compiled Flow metadata Fix & Add KF plus Zodiac tags

### DIFF
--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -258,10 +258,7 @@ def run(
         if kwargs.get(param.name) is not None
     }
 
-    # Add additional tags
-    if kfp_namespace:
-        tags = tags + (kfp_namespace,)
-
+    # Add experiment as tag
     if experiment:
         tags = tags + (experiment,)
 

--- a/metaflow/plugins/kfp/kfp_step_function.py
+++ b/metaflow/plugins/kfp/kfp_step_function.py
@@ -48,7 +48,10 @@ def kfp_step_function(
         name: value for name, value in metaflow_configs.items() if value
     }
 
-    if not "METAFLOW_USER" in metaflow_configs_new:
+    if (
+        not "METAFLOW_USER" in metaflow_configs_new
+        and metaflow_configs_new["METAFLOW_USER"] is None
+    ):
         metaflow_configs_new["METAFLOW_USER"] = "kfp-user"
 
     env = {

--- a/metaflow/plugins/kfp/kfp_step_function.py
+++ b/metaflow/plugins/kfp/kfp_step_function.py
@@ -50,7 +50,7 @@ def kfp_step_function(
 
     if (
         not "METAFLOW_USER" in metaflow_configs_new
-        and metaflow_configs_new["METAFLOW_USER"] is None
+        or metaflow_configs_new["METAFLOW_USER"] is None
     ):
         metaflow_configs_new["METAFLOW_USER"] = "kfp-user"
 

--- a/metaflow/plugins/kfp/tests/flows/failure_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/failure_flow.py
@@ -20,7 +20,7 @@ class FailureFlow(FlowSpec):
     @retry(times=0)
     @step
     def no_retry(self):
-        argo_node_name = os.environ.get("ARGO_NODE_NAME")
+        argo_node_name = os.environ.get("MF_ARGO_NODE_NAME")
         assert not argo_node_name.endswith(")")
         assert self.retry_count == 1
         self.next(self.compute)

--- a/metaflow/plugins/kfp/tests/flows/metadata_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/metadata_flow.py
@@ -1,0 +1,47 @@
+from metaflow import FlowSpec, step, current, Step
+
+import os
+from random import random
+
+
+class MetadataFlow(FlowSpec):
+    start_message = "MetadataFlow is starting."
+
+    @step
+    def start(self):
+        print(self.start_message)
+        self.x = random()
+        print("self.x", self.x)
+        self.next(self.end)
+
+    @step
+    def end(self):
+        start_step: Step = Step(f"{current.flow_name}/{current.run_id}/start")
+        print("start_step", start_step)
+        x = start_step.task.data.x
+        print("self.x=", self.x)
+        print("Metaflow client start_step.task.data.x=", x)
+        assert x == self.x
+
+        logs = start_step.task.stdout
+        print()
+        print(">>>> start step logs")
+        print(logs)
+        print("<<<<")
+        print()
+        assert self.start_message in logs
+
+        start_step_tags: frozenset = start_step.tags
+        print("start_step_tags", start_step_tags)
+        assert "test_t1" in start_step_tags
+        assert "metaflow_test" in start_step_tags
+        assert f"zodiac_service:{os.environ['ZODIAC_SERVICE']}" in start_step_tags
+        assert f"zodiac_team:{os.environ['ZODIAC_TEAM']}" in start_step_tags
+        assert f"argo_workflow:{os.environ['MF_ARGO_WORKFLOW_NAME']}" in start_step_tags
+        assert f"pod_namespace:{os.environ['MF_POD_NAMESPACE']}" in start_step_tags
+
+        print("MetadataFlow is all done.")
+
+
+if __name__ == "__main__":
+    MetadataFlow()

--- a/metaflow/plugins/kfp/tests/flows/raise_error_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/raise_error_flow.py
@@ -4,10 +4,11 @@ from metaflow import FlowSpec, step
 class RaiseErrorFlow(FlowSpec):
     """
     This flow is intended to "test" the Metaflow integration testing framework.
-    In the past, the Metaflow integration test has incorrectly reported failing 
+    In the past, the Metaflow integration test has incorrectly reported failing
     fails are passing within the Gitlab (and this Github UI). This flow is supposed
     to fail, and we ensure the integration test detects that.
     """
+
     @step
     def start(self):
         print("This step should complete successfuly!")

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -44,7 +44,9 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
     file_paths = [
         file_name
         for file_name in listdir(flow_dir_path)
-        if isfile(join(flow_dir_path, file_name)) and not file_name.startswith(".") and not "raise_error_flow" in file_name
+        if isfile(join(flow_dir_path, file_name))
+        and not file_name.startswith(".")
+        and not "raise_error_flow" in file_name
     ]
     return file_paths
 

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -44,9 +44,7 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
     file_paths = [
         file_name
         for file_name in listdir(flow_dir_path)
-        if isfile(join(flow_dir_path, file_name))
-        and not file_name.startswith(".")
-        and not "raise_error_flow" in file_name
+        if isfile(join(flow_dir_path, file_name)) and not file_name.startswith(".") and not "raise_error_flow" in file_name
     ]
     return file_paths
 


### PR DESCRIPTION
`python metaflow/plugins/kfp/tests/flows/metadata_flow.py kfp run --experiment metaflow_test --tag test_t1`

```python
tags = Flow("MetadataFlow").latest_run.tags
tags
```


```python
{'argo_workflow:metadataflow-578gp',
 'date:2021-06-09',
 'metaflow_test',
 'metaflow_version:2.2.3',
 'pod_name:metadataflow-578gp-1849418204',
 'pod_namespace:zestimate-dev',
 'python_version:3.6.8',
 'runtime:dev',
 'test_t1',
 'user:talebz',
 'zodiac_service:zestimate',
 'zodiac_team:ai-zestimates'}
```

The bug was that at compile time, this line of code would always default to `local` and hence metadata wouldn't be sent to the Metaflow `service`
https://github.com/zillow/metaflow/blob/524a12e0d8054f8dae4513e2b9c9c1ee938f2790/metaflow/plugins/kfp/kfp.py#L446