### PR TITLE
AIP-4386 - Adding tags for flow name, step name, and experiment name

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -664,11 +664,15 @@ class KubeflowPipelines(object):
         self, container_op: ContainerOp, node: DAGNode, metaflow_run_id: str
     ):
         prefix = "metaflow.org"
+        # for the ZGCP Costs Ledger
+        container_op.add_pod_label("tags.ledger.zgtools.net/ai-flow-name", self.name)
         container_op.add_pod_label(f"{prefix}/flow_name", self.name)
         container_op.add_pod_label(f"{prefix}/step", node.name)
         container_op.add_pod_label(f"{prefix}/run_id", metaflow_run_id)
 
         if self.experiment:
+            # for the ZGCP Costs Ledger
+            container_op.add_pod_label("tags.ledger.zgtools.net/ai-experiment-name", self.experiment)
             container_op.add_pod_label(f"{prefix}/experiment", self.experiment)
         if self.tags and len(self.tags) > 0:
             for tag in self.tags:

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -672,7 +672,9 @@ class KubeflowPipelines(object):
         container_op.add_pod_label(f"{prefix}/run_id", metaflow_run_id)
 
         if self.experiment:
-            container_op.add_pod_label("tags.ledger.zgtools.net/ai-experiment-name", self.experiment)
+            container_op.add_pod_label(
+                "tags.ledger.zgtools.net/ai-experiment-name", self.experiment
+            )
             container_op.add_pod_label(f"{prefix}/experiment", self.experiment)
         if self.tags and len(self.tags) > 0:
             for tag in self.tags:

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -664,14 +664,14 @@ class KubeflowPipelines(object):
         self, container_op: ContainerOp, node: DAGNode, metaflow_run_id: str
     ):
         prefix = "metaflow.org"
-        # for the ZGCP Costs Ledger
+        # tags.ledger.zgtools.net/* pod labels required for the ZGCP Costs Ledger
         container_op.add_pod_label("tags.ledger.zgtools.net/ai-flow-name", self.name)
         container_op.add_pod_label(f"{prefix}/flow_name", self.name)
+        container_op.add_pod_label("tags.ledger.zgtools.net/ai-step-name", node.name)
         container_op.add_pod_label(f"{prefix}/step", node.name)
         container_op.add_pod_label(f"{prefix}/run_id", metaflow_run_id)
 
         if self.experiment:
-            # for the ZGCP Costs Ledger
             container_op.add_pod_label("tags.ledger.zgtools.net/ai-experiment-name", self.experiment)
             container_op.add_pod_label(f"{prefix}/experiment", self.experiment)
         if self.tags and len(self.tags) > 0:


### PR DESCRIPTION
This PR creates `tags.ledger.zgtools.net/*` prefixed pod labels for flow, step, and experiment names. The prefix ensures these labels are properly appear in the `tag` feature on Tableau.

I have verified these labels do indeed appear on Tableau.