### PR TITLE
Switch from k8s labels->annotations for label special chars

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -666,19 +666,20 @@ class KubeflowPipelines(object):
         prefix = "metaflow.org"
         # tags.ledger.zgtools.net/* pod labels required for the ZGCP Costs Ledger
         container_op.add_pod_label("tags.ledger.zgtools.net/ai-flow-name", self.name)
-        container_op.add_pod_label(f"{prefix}/flow_name", self.name)
         container_op.add_pod_label("tags.ledger.zgtools.net/ai-step-name", node.name)
-        container_op.add_pod_label(f"{prefix}/step", node.name)
-        container_op.add_pod_label(f"{prefix}/run_id", metaflow_run_id)
-
         if self.experiment:
             container_op.add_pod_label(
                 "tags.ledger.zgtools.net/ai-experiment-name", self.experiment
             )
-            container_op.add_pod_label(f"{prefix}/experiment", self.experiment)
+
+        container_op.add_pod_annotation(f"{prefix}/flow_name", self.name)
+        container_op.add_pod_annotation(f"{prefix}/step", node.name)
+        container_op.add_pod_annotation(f"{prefix}/run_id", metaflow_run_id)
+        if self.experiment:
+            container_op.add_pod_annotation(f"{prefix}/experiment", self.experiment)
         if self.tags and len(self.tags) > 0:
             for tag in self.tags:
-                container_op.add_pod_label(f"{prefix}/tag_{tag}", "true")
+                container_op.add_pod_annotation(f"{prefix}/tag_{tag}", "true")
 
     def step_op(
         self,

--- a/metaflow/plugins/kfp/tests/flows/accelerator_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/accelerator_flow.py
@@ -2,6 +2,7 @@ import os
 
 from metaflow import FlowSpec, step, resources, accelerator
 
+
 class AcceleratorFlow(FlowSpec):
     @accelerator(type="nvidia-tesla-v100")
     @resources(

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -43,6 +43,14 @@ kubernetes_vars = get_env_vars(
         "MEMORY_LIMIT": "limits.memory",
     }
 )
+kubernetes_vars.append(
+    V1EnvVar(
+        name="MY_POD_NAME",
+        value_from=V1EnvVarSource(
+            field_ref=V1ObjectFieldSelector(field_path="metadata.name")
+        ),
+    )
+)
 
 annotations = {
     "metaflow.org/flow_name": "MF_NAME",
@@ -102,7 +110,7 @@ class ResourcesFlow(FlowSpec):
         assert os.environ.get("MY_ENV") == "value"
 
         # test kubernetes_vars
-        assert "resourcesflow" in os.environ.get("POD_NAME")
+        assert "resourcesflow" in os.environ.get("MY_POD_NAME")
         assert os.environ.get("CPU") == "100"
         assert os.environ.get("CPU_LIMIT") == "600"
         assert os.environ.get("LOCAL_STORAGE") == "100000000"

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -146,6 +146,7 @@ def test_compile_only_accelerator_test() -> None:
             break
     assert toleration_found
 
+
 @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
 def test_flows(pytestconfig, flow_file_path: str) -> None:
     full_path = join("flows", flow_file_path)


### PR DESCRIPTION
Moved `metaflow.org/*` from labels to annotations because k8s labels don't support `:`, example this tag wouldn't be supported: `user:talebz`

The k8s labels and annotations that the MF kfp plugin adds:
```yaml
kind: Pod
apiVersion: v1
metadata:
  name: resourcesflow-jjjml-2034224594
  namespace: aip-metaflow-sandbox
 ...
  labels:
    zodiac.zillowgroup.net/environment: aianalytics_sandbox
    zodiac.zillowgroup.net/owner: rajeshg
    zodiac.zillowgroup.net/service: aip-example
    zodiac.zillowgroup.net/team: ai-platform-foundation
  annotations:
    metaflow.org/experiment: metaflow_test
    metaflow.org/flow_name: ResourcesFlow
    metaflow.org/run_id: kfp-ef797804-5426-4843-a0b0-ab7769bc75d7
    metaflow.org/step: start
    metaflow.org/tag_metaflow_test: 'true'
    metaflow.org/tag_test_t1: 'true'
```