### PR TITLE
@s3_sensor flow decorator to allow flows to wait on S3 path

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -591,7 +591,7 @@ class KubeflowPipelines(object):
                 mode=mode,
             )
             container_op.add_pvolumes({volume_dir: volume})
-            
+
         if kfp_component.accelerator_decorator:
             accelerator_type: str = kfp_component.accelerator_decorator.attributes[
                 "type"

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -985,13 +985,15 @@ class KubeflowPipelines(object):
             if s3_sensor_deco:
                 print("We have found an S3 Sensor!")
                 path = s3_sensor_deco.path
+                key = s3_sensor_deco.key
+                prefix = s3_sensor_deco.key
                 timeout = s3_sensor_deco.timeout
                 print("path: ", path)
                 print("timeout: ", timeout)
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="gcr.io/cloud-builders/kubectl",
-                )(path=path, timeout=timeout).set_display_name(
+                )(path=path, key=key, prefix=prefix, timeout=timeout).set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -992,6 +992,10 @@ class KubeflowPipelines(object):
                 print("key: ", key)
                 print("prefix: ", prefix)
                 print("timeout: ", timeout)
+
+                print(flow_parameters_json)
+                print(json.loads(flow_parameters_json))
+
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -991,7 +991,7 @@ class KubeflowPipelines(object):
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="gcr.io/cloud-builders/kubectl",
-                )(path=path, timeout=timeout).set_display_name(
+                )(path="{{path}}", timeout=timeout).set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -989,6 +989,8 @@ class KubeflowPipelines(object):
                 prefix = s3_sensor_deco.key
                 timeout = s3_sensor_deco.timeout
                 print("bucket: ", bucket)
+                print("key: ", key)
+                print("prefix: ", prefix)
                 print("timeout: ", timeout)
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -801,7 +801,7 @@ class KubeflowPipelines(object):
         timeout_seconds = s3_sensor_deco.timeout_seconds
         polling_interval_seconds = s3_sensor_deco.polling_interval_seconds
         path_formatter = s3_sensor_deco.path_formatter
-        os_vars = s3_sensor_deco.os_vars
+        os_expandvars = s3_sensor_deco.os_expandvars
 
         # see https://github.com/kubeflow/pipelines/pull/1946/files
         # KFP does not support the serialization of Python functions directly. The KFP team took
@@ -825,7 +825,7 @@ class KubeflowPipelines(object):
             polling_interval_seconds=polling_interval_seconds,
             path_formatter_code_encoded=path_formatter_code_encoded,
             flow_parameters_json=flow_parameters_json,
-            os_vars=os_vars,
+            os_expandvars=os_expandvars,
         ).set_display_name(
             "s3_sensor"
         )

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -981,10 +981,13 @@ class KubeflowPipelines(object):
                 )
 
             s3_sensor_op = None
-            if self.flow._flow_decorators.get('s3_sensor'):
+            s3_sensor_deco = self.flow._flow_decorators.get('s3_sensor')
+            if s3_sensor_deco:
                 print("We have found an S3 Sensor!")
-                path = self.flow._flow_decorators.get('s3_sensor').attributes["path"]
-                timeout = self.flow._flow_decorators.get('s3_sensor').attributes["timeout"]
+                path = s3_sensor_deco.path
+                timeout = s3_sensor_deco.timeout
+                print("path: ", path)
+                print("timeout: ", timeout)
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="gcr.io/cloud-builders/kubectl",

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -986,7 +986,7 @@ class KubeflowPipelines(object):
                 print("We have found an S3 Sensor!")
                 bucket = s3_sensor_deco.bucket
                 key = s3_sensor_deco.key
-                prefix = s3_sensor_deco.key
+                prefix = s3_sensor_deco.prefix
                 timeout = s3_sensor_deco.timeout
                 print("bucket: ", bucket)
                 print("key: ", key)

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -176,6 +176,7 @@ class KubeflowPipelines(object):
         if KFP_USER_DOMAIN:
             kfp_client_user_email += f"@{KFP_USER_DOMAIN}"
 
+        self.flow_parameters = flow_parameters
         self._client = kfp.Client(
             namespace=self.api_namespace, userid=kfp_client_user_email
         )
@@ -993,8 +994,7 @@ class KubeflowPipelines(object):
                 print("prefix: ", prefix)
                 print("timeout: ", timeout)
 
-                print(flow_parameters_json)
-                print(json.loads(flow_parameters_json))
+                print(self.flow_parameters)
 
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -992,7 +992,7 @@ class KubeflowPipelines(object):
                 print("timeout: ", timeout)
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
-                    base_image="gcr.io/cloud-builders/kubectl",
+                    base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
                 )(bucket=bucket, key=key, prefix=prefix, timeout=timeout).set_display_name(
                     "s3_sensor"
                 )

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -6,6 +6,9 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
+import pickle
+import base64
+
 import kfp
 import yaml
 from kfp import dsl
@@ -992,13 +995,16 @@ class KubeflowPipelines(object):
                 print("key: ", key)
                 print("timeout: ", timeout)
 
+                # see https://github.com/kubeflow/pipelines/pull/1946/files
+                formatter_encoded = base64.b64encode(pickle.dumps(formatter)).decode('ascii')
+
                 print(flow_parameters_json)
                 print(type(flow_parameters_json))
 
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
-                )(bucket=bucket, key=key, timeout=timeout, formatter=formatter, flow_parameters_json=flow_parameters_json).set_display_name(
+                )(bucket=bucket, key=key, timeout=timeout, formatter_encoded=formatter_encoded, flow_parameters_json=flow_parameters_json).set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -1001,7 +1001,7 @@ class KubeflowPipelines(object):
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
-                )(bucket=bucket, key=key, prefix=prefix, timeout=timeout, workflow_parameters_json="{{workflow_parameters_json}}").set_display_name(
+                )(bucket=bucket, key=key, prefix=prefix, timeout=timeout, flow_parameters_json="{{flow_parameters_json}}").set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -801,6 +801,7 @@ class KubeflowPipelines(object):
         timeout_seconds = s3_sensor_deco.timeout_seconds
         polling_interval_seconds = s3_sensor_deco.polling_interval_seconds
         path_formatter = s3_sensor_deco.path_formatter
+        os_vars = s3_sensor_deco.os_vars
 
         # see https://github.com/kubeflow/pipelines/pull/1946/files
         # KFP does not support the serialization of Python functions directly. The KFP team took
@@ -824,6 +825,7 @@ class KubeflowPipelines(object):
             polling_interval_seconds=polling_interval_seconds,
             path_formatter_code_encoded=path_formatter_code_encoded,
             flow_parameters_json=flow_parameters_json,
+            os_vars=os_vars,
         ).set_display_name(
             "s3_sensor"
         )

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -812,9 +812,12 @@ class KubeflowPipelines(object):
         # which couldn't be resolved when the path_formatter function was unpickled within the running
         # container. Instead, we took the approach of marshalling just the code of the path_formatter
         # function, and reconstructing the function within the kf_s3_sensor.py code.
-        path_formatter_code_encoded = base64.b64encode(
-            marshal.dumps(path_formatter.__code__)
-        ).decode("ascii")
+        if path_formatter:
+            path_formatter_code_encoded = base64.b64encode(
+                marshal.dumps(path_formatter.__code__)
+            ).decode("ascii")
+        else:
+            path_formatter_code_encoded = ""
 
         s3_sensor_op = func_to_container_op(
             wait_for_s3_path,

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -994,6 +994,8 @@ class KubeflowPipelines(object):
                 print("prefix: ", prefix)
                 print("timeout: ", timeout)
 
+                print(flow_parameters_json)
+                print(type(flow_parameters_json))
                 print(self.flow_parameters)
 
                 s3_sensor_op = func_to_container_op(

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -984,7 +984,7 @@ class KubeflowPipelines(object):
                 )
 
             s3_sensor_op = None
-            s3_sensor_deco = self.flow._flow_decorators.get('s3_sensor')
+            s3_sensor_deco = self.flow._flow_decorators.get("s3_sensor")
             if s3_sensor_deco:
                 path = s3_sensor_deco.path
                 timeout_seconds = s3_sensor_deco.timeout_seconds
@@ -998,7 +998,9 @@ class KubeflowPipelines(object):
                 # which couldn't be resolved when the formatter function was unpickled within the running
                 # container. Instead, we took the approach of marshalling just the code of the formatter
                 # function, and reconstructing the function within the kf_s3_sensor.py code.
-                formatter_code_encoded = base64.b64encode(marshal.dumps(formatter.__code__)).decode('ascii')
+                formatter_code_encoded = base64.b64encode(
+                    marshal.dumps(formatter.__code__)
+                ).decode("ascii")
 
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
@@ -1008,7 +1010,7 @@ class KubeflowPipelines(object):
                     timeout_seconds=timeout_seconds,
                     polling_interval_seconds=polling_interval_seconds,
                     formatter_code_encoded=formatter_code_encoded,
-                    flow_parameters_json=flow_parameters_json
+                    flow_parameters_json=flow_parameters_json,
                 ).set_display_name(
                     "s3_sensor"
                 )
@@ -1035,7 +1037,7 @@ class KubeflowPipelines(object):
                 node = self.graph[step]
                 for parent_step in node.in_funcs:
                     visited[node.name].after(visited[parent_step])
-            
+
             # ensure the start step only begins after the s3_sensor step completes
             if s3_sensor_op:
                 visited["start"].after(s3_sensor_op)

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -987,8 +987,7 @@ class KubeflowPipelines(object):
             s3_sensor_op = None
             s3_sensor_deco = self.flow._flow_decorators.get('s3_sensor')
             if s3_sensor_deco:
-                bucket = s3_sensor_deco.bucket
-                key = s3_sensor_deco.key
+                path = s3_sensor_deco.path
                 timeout = s3_sensor_deco.timeout
                 polling_interval = s3_sensor_deco.polling_interval
                 formatter = s3_sensor_deco.formatter
@@ -1007,8 +1006,7 @@ class KubeflowPipelines(object):
                     wait_for_s3_path,
                     base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
                 )(
-                    bucket=bucket,
-                    key=key,
+                    path=path,
                     timeout=timeout,
                     polling_interval=polling_interval,
                     formatter_code_encoded=formatter_code_encoded,

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -1001,7 +1001,7 @@ class KubeflowPipelines(object):
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
-                )(bucket=bucket, key=key, prefix=prefix, timeout=timeout).set_display_name(
+                )(bucket=bucket, key=key, prefix=prefix, timeout=timeout, workflow_parameters_json="{{workflow_parameters_json}}").set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -987,6 +987,7 @@ class KubeflowPipelines(object):
                 bucket = s3_sensor_deco.bucket
                 key = s3_sensor_deco.key
                 timeout = s3_sensor_deco.timeout
+                formatter = s3_sensor_deco.formatter
                 print("bucket: ", bucket)
                 print("key: ", key)
                 print("timeout: ", timeout)
@@ -997,7 +998,7 @@ class KubeflowPipelines(object):
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
-                )(bucket=bucket, key=key, timeout=timeout, flow_parameters_json=flow_parameters_json).set_display_name(
+                )(bucket=bucket, key=key, timeout=timeout, formatter=formatter, flow_parameters_json=flow_parameters_json).set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
+import marshal
 import pickle
 import base64
 
@@ -996,7 +997,8 @@ class KubeflowPipelines(object):
                 print("timeout: ", timeout)
 
                 # see https://github.com/kubeflow/pipelines/pull/1946/files
-                formatter_encoded = base64.b64encode(pickle.dumps(formatter)).decode('ascii')
+                # formatter_encoded = base64.b64encode(pickle.dumps(formatter)).decode('ascii')
+                formatter_encoded = base64.b64encode(marshal.dumps(formatter.__code__)).decode('ascii')
 
                 print(flow_parameters_json)
                 print(type(flow_parameters_json))

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -824,7 +824,6 @@ class KubeflowPipelines(object):
                 preceding_kfp_component_op: ContainerOp = None,
                 preceding_component_outputs_dict: Dict[str, dsl.PipelineParam] = None,
                 workflow_uid: str = None,
-                s3_sensor_uid: str = None,
             ):
                 if node.name in visited:
                     return
@@ -936,7 +935,6 @@ class KubeflowPipelines(object):
                             preceding_kfp_component_op=next_kfp_component_op,
                             preceding_component_outputs_dict=next_preceding_component_outputs_dict,
                             workflow_uid=workflow_uid,
-                            s3_sensor_uid=s3_sensor_uid,
                         )
 
                     # Handle the ParallelFor join step, and pass in
@@ -947,7 +945,6 @@ class KubeflowPipelines(object):
                         preceding_kfp_component_op=next_kfp_component_op,
                         preceding_component_outputs_dict=next_preceding_component_outputs_dict,
                         workflow_uid=workflow_uid,
-                        s3_sensor_uid=s3_sensor_uid,
                     )
                 else:
                     for step in node.out_funcs:
@@ -968,7 +965,6 @@ class KubeflowPipelines(object):
                                 preceding_kfp_component_op=next_kfp_component_op,
                                 preceding_component_outputs_dict=next_preceding_component_outputs_dict,
                                 workflow_uid=workflow_uid,
-                                s3_sensor_uid=s3_sensor_uid,
                             )
 
             workflow_uid_op = None
@@ -997,7 +993,6 @@ class KubeflowPipelines(object):
                 build_kfp_dag(
                     self.graph["start"],
                     workflow_uid=workflow_uid_op.output if workflow_uid_op else None,
-                    s3_sensor_uid=s3_sensor_op.output if s3_sensor_op else None,
                 )
 
             if self.notify:

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -991,7 +991,7 @@ class KubeflowPipelines(object):
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="gcr.io/cloud-builders/kubectl",
-                )(path="{{path}}", timeout=timeout).set_display_name(
+                )(path=path, timeout=timeout).set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -815,6 +815,8 @@ class KubeflowPipelines(object):
 
         s3_sensor_op = func_to_container_op(
             wait_for_s3_path,
+            # We plan to add the Dockerfile of image hsezhiyan/metaflow-zillow:2.0 to this repo
+            # https://zbrt.atl.zillow.net/browse/AIP-4571
             base_image="hsezhiyan/metaflow-zillow:2.0",
         )(
             path=path,
@@ -1016,7 +1018,7 @@ class KubeflowPipelines(object):
                                 workflow_uid=workflow_uid,
                             )
 
-            workflow_uid_op = None
+            workflow_uid_op: ContainerOp = None
             if any(
                 "volume" in s.resource_requirements
                 for s in step_to_kfp_component_map.values()
@@ -1029,7 +1031,7 @@ class KubeflowPipelines(object):
                 )
                 KubeflowPipelines._set_minimal_container_resources(workflow_uid_op)
 
-            s3_sensor_op = None
+            s3_sensor_op: ContainerOp = None
             s3_sensor_deco = self.flow._flow_decorators.get("s3_sensor")
             if s3_sensor_deco:
                 s3_sensor_op = self._create_s3_sensor_op(

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -984,16 +984,16 @@ class KubeflowPipelines(object):
             s3_sensor_deco = self.flow._flow_decorators.get('s3_sensor')
             if s3_sensor_deco:
                 print("We have found an S3 Sensor!")
-                path = s3_sensor_deco.path
+                bucket = s3_sensor_deco.bucket
                 key = s3_sensor_deco.key
                 prefix = s3_sensor_deco.key
                 timeout = s3_sensor_deco.timeout
-                print("path: ", path)
+                print("bucket: ", bucket)
                 print("timeout: ", timeout)
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="gcr.io/cloud-builders/kubectl",
-                )(path=path, key=key, prefix=prefix, timeout=timeout).set_display_name(
+                )(bucket=bucket, key=key, prefix=prefix, timeout=timeout).set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -993,19 +993,18 @@ class KubeflowPipelines(object):
                 polling_interval = s3_sensor_deco.polling_interval
                 formatter = s3_sensor_deco.formatter
 
-                # formatter_encoded = base64.b64encode(pickle.dumps(formatter)).decode('ascii')
                 # see https://github.com/kubeflow/pipelines/pull/1946/files
                 # KFP does not support the serialization of Python functions directly. The KFP team took
                 # the approach of using base64 encoding + pickle. Pickle didn't quite work out
-                # in this case because pickling a function directly stores references to the functions path,
+                # in this case because pickling a function directly stores references to the function's path,
                 # which couldn't be resolved when the formatter function was unpickled within the running
                 # container. Instead, we took the approach of mashalling just the code of the formatter
-                # function, and reconstructing the function within the s3_sensor code.
+                # function, and reconstructing the function within the kf_s3_sensor.py code.
                 formatter_code_encoded = base64.b64encode(marshal.dumps(formatter.__code__)).decode('ascii')
 
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
-                    base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
+                    base_image="hsezhiyan/s3_sensor:1.0",
                 )(
                     bucket=bucket,
                     key=key,

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -1019,7 +1019,7 @@ class KubeflowPipelines(object):
             
             # ensure start only begins after the s3_sensor completes
             if s3_sensor_op:
-                self.graph["start"].after(s3_sensor_op)
+                visited["start"].after(s3_sensor_op)
 
             dsl.get_pipeline_conf().add_op_transformer(pipeline_transform)
             dsl.get_pipeline_conf().set_parallelism(self.max_parallelism)

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -1001,7 +1001,7 @@ class KubeflowPipelines(object):
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
-                )(bucket=bucket, key=key, prefix=prefix, timeout=timeout, flow_parameters_json=flow_parameters_json.value).set_display_name(
+                )(bucket=bucket, key=key, prefix=prefix, timeout=timeout, flow_parameters_json=flow_parameters_json).set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import marshal
-import pickle
 import base64
 
 import kfp
@@ -1039,7 +1038,7 @@ class KubeflowPipelines(object):
                 for parent_step in node.in_funcs:
                     visited[node.name].after(visited[parent_step])
             
-            # ensure the start steps only begins after the s3_sensor step completes
+            # ensure the start step only begins after the s3_sensor step completes
             if s3_sensor_op:
                 visited["start"].after(s3_sensor_op)
                 # ensure volume creation also happens after the s3_sensor step completes

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -986,10 +986,9 @@ class KubeflowPipelines(object):
             s3_sensor_op = None
             s3_sensor_deco = self.flow._flow_decorators.get('s3_sensor')
             if s3_sensor_deco:
-                bucket = s3_sensor_deco.bucket
-                key = s3_sensor_deco.key
-                timeout = s3_sensor_deco.timeout
-                polling_interval = s3_sensor_deco.polling_interval
+                path = s3_sensor_deco.path
+                timeout_seconds = s3_sensor_deco.timeout_seconds
+                polling_interval_seconds = s3_sensor_deco.polling_interval_seconds
                 formatter = s3_sensor_deco.formatter
 
                 # see https://github.com/kubeflow/pipelines/pull/1946/files
@@ -997,7 +996,7 @@ class KubeflowPipelines(object):
                 # the approach of using base64 encoding + pickle. Pickle didn't quite work out
                 # in this case because pickling a function directly stores references to the function's path,
                 # which couldn't be resolved when the formatter function was unpickled within the running
-                # container. Instead, we took the approach of mashalling just the code of the formatter
+                # container. Instead, we took the approach of marshalling just the code of the formatter
                 # function, and reconstructing the function within the kf_s3_sensor.py code.
                 formatter_code_encoded = base64.b64encode(marshal.dumps(formatter.__code__)).decode('ascii')
 
@@ -1005,10 +1004,9 @@ class KubeflowPipelines(object):
                     wait_for_s3_path,
                     base_image="hsezhiyan/s3_sensor:1.0",
                 )(
-                    bucket=bucket,
-                    key=key,
-                    timeout=timeout,
-                    polling_interval=polling_interval,
+                    path=path,
+                    timeout_seconds=timeout_seconds,
+                    polling_interval_seconds=polling_interval_seconds,
                     formatter_code_encoded=formatter_code_encoded,
                     flow_parameters_json=flow_parameters_json
                 ).set_display_name(

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -987,7 +987,8 @@ class KubeflowPipelines(object):
             s3_sensor_op = None
             s3_sensor_deco = self.flow._flow_decorators.get('s3_sensor')
             if s3_sensor_deco:
-                path = s3_sensor_deco.path
+                bucket = s3_sensor_deco.bucket
+                key = s3_sensor_deco.key
                 timeout = s3_sensor_deco.timeout
                 polling_interval = s3_sensor_deco.polling_interval
                 formatter = s3_sensor_deco.formatter
@@ -1006,7 +1007,8 @@ class KubeflowPipelines(object):
                     wait_for_s3_path,
                     base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
                 )(
-                    path=path,
+                    bucket=bucket,
+                    key=key,
                     timeout=timeout,
                     polling_interval=polling_interval,
                     formatter_code_encoded=formatter_code_encoded,

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -1001,7 +1001,7 @@ class KubeflowPipelines(object):
                 s3_sensor_op = func_to_container_op(
                     wait_for_s3_path,
                     base_image="analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu:3.2.64d2bf12.hs-aip-4502",
-                )(bucket=bucket, key=key, prefix=prefix, timeout=timeout, flow_parameters_json="{{flow_parameters_json}}").set_display_name(
+                )(bucket=bucket, key=key, prefix=prefix, timeout=timeout, flow_parameters_json=flow_parameters_json.value).set_display_name(
                     "s3_sensor"
                 )
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -625,12 +625,10 @@ class KubeflowPipelines(object):
             )
             container_op.add_affinity(affinity)
             container_op.add_toleration(toleration)
-    
+
     # used by the workflow_uid_op and the s3_sensor_op to tighten resources
     # to ensure customers don't bear unnecesarily large costs
-    def _set_hardcoded_container_resources(
-        self, container_op: ContainerOp 
-    ):
+    def _set_hardcoded_container_resources(self, container_op: ContainerOp):
         container_op.container.set_cpu_request("0.1")
         container_op.container.set_cpu_limit("0.5")
         container_op.container.set_memory_request("10M")
@@ -795,9 +793,7 @@ class KubeflowPipelines(object):
         return func
 
     def _create_s3_sensor_op(
-        self,
-        s3_sensor_deco: FlowDecorator,
-        flow_parameters_json: str
+        self, s3_sensor_deco: FlowDecorator, flow_parameters_json: str
     ) -> ContainerOp:
         path = s3_sensor_deco.path
         timeout_seconds = s3_sensor_deco.timeout_seconds
@@ -1036,7 +1032,7 @@ class KubeflowPipelines(object):
             if s3_sensor_deco:
                 s3_sensor_op = self._create_s3_sensor_op(
                     s3_sensor_deco=s3_sensor_deco,
-                    flow_parameters_json=flow_parameters_json
+                    flow_parameters_json=flow_parameters_json,
                 )
 
             def call_build_kfp_dag():

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -5,6 +5,9 @@ def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int) -> None:
 
     s3 = boto3.resource('s3')
     
+    print("key: ", key)
+    print("prefix: ", prefix)
+
     start_time = time.time()
     while True:
         if bucket:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,8 +1,5 @@
-from typing import Callable
-
 def wait_for_s3_path(
-    bucket: str,
-    key: str,
+    path: str,
     timeout: int,
     polling_interval: int,
     formatter_code_encoded: str,
@@ -12,11 +9,22 @@ def wait_for_s3_path(
     import botocore
     import base64
     import marshal
-    import pickle
     import json
     import time
 
+    from typing import Tuple
+
     s3 = boto3.resource('s3')
+
+    def split_s3_path(path: str) -> Tuple[str, str]:
+        path = path.replace("s3://", "")
+        bucket, key = path.split("/", 1)
+        return bucket, key
+    
+    try:
+        bucket, key = split_s3_path(path)
+    except:
+        raise Exception("Please specify a valid S3 path.")
     
     flow_parameters_json = json.loads(flow_parameters_json)
     formatter_code = marshal.loads(base64.b64decode(formatter_code_encoded))

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -10,7 +10,7 @@ def wait_for_s3_path(
     path: str,
     timeout_seconds: int,
     polling_interval_seconds: int,
-    formatter_code_encoded: str,
+    func_code_encoded: str,
     flow_parameters_json: str,
 ) -> None:
     import boto3
@@ -29,21 +29,21 @@ def wait_for_s3_path(
 
     flow_parameters_json = json.loads(flow_parameters_json)
 
-    formatter_code = marshal.loads(base64.b64decode(formatter_code_encoded))
+    func_code = marshal.loads(base64.b64decode(func_code_encoded))
 
     def formatter(key: str, flow_parameters_json: dict) -> str:
         pass
 
-    formatter.__code__ = formatter_code
+    formatter.__code__ = func_code
     path = formatter(path, flow_parameters_json)
 
     bucket, key = split_s3_path(path)
 
-    s3 = boto3.resource("s3")
+    s3 = boto3.client("s3")
     start_time = time.time()
     while True:
         try:
-            s3.Object(bucket, key).load()
+            s3.head_object(Bucket=bucket, Key=key)
         except botocore.exceptions.ClientError as e:
             print("Object not found. Waiting...")
         else:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -8,6 +8,7 @@ def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int, flow_para
     print("key: ", key)
     print("prefix: ", prefix)
     print("flow_parameters_json: ", flow_parameters_json)
+    print("type(flow_parameters_json): ", type(flow_parameters_json))
 
     start_time = time.time()
     while True:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -6,6 +6,7 @@ This function is called within the s3_sensor_op running container.
 """
 import boto3
 
+
 def wait_for_s3_path(
     path: str,
     timeout_seconds: int,
@@ -24,8 +25,10 @@ def wait_for_s3_path(
 
     flow_parameters = json.loads(flow_parameters_json)
     path_formatter_code = marshal.loads(base64.b64decode(path_formatter_code_encoded))
+
     def path_formatter(key: str, flow_parameters: dict) -> str:
         pass
+
     path_formatter.__code__ = path_formatter_code
     path = path_formatter(path, flow_parameters)
     # default variable substitution

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -24,7 +24,7 @@ def wait_for_s3_path(
         pass
     formatter.__code__ = formatter_code
 
-    #key = formatter(key, flow_parameters_json)
+    key = formatter(key, flow_parameters_json)
 
     print("key: ", key)
     print("flow_parameters_json: ", flow_parameters_json)

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,4 +1,4 @@
-def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int, workflow_parameters_json: str) -> None:
+def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int, flow_parameters_json: str) -> None:
     import boto3
     import botocore
     import time
@@ -7,7 +7,7 @@ def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int, workflow_
     
     print("key: ", key)
     print("prefix: ", prefix)
-    print("workflow_parameters_json: ", workflow_parameters_json)
+    print("flow_parameters_json: ", flow_parameters_json)
 
     start_time = time.time()
     while True:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,7 +1,38 @@
-def wait_for_s3_path(path: str, timeout: int) -> None:
-    print("path: ", path)
-    print("timeout: ", timeout)
-    import time
-    print("Waiting for sleep to end...")
-    time.sleep(60)
-    print("Sleep completed...")
+import boto3
+import botocore
+import time
+
+s3 = boto3.resource('s3')
+
+def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int) -> None:
+    start_time = time.time()
+    while True:
+        if bucket:
+            try:
+                s3.Object(bucket, key).load()
+            except botocore.exceptions.ClientError as e:
+                print("Object not found. Waiting...")
+            else:
+                print("Object found! Step complete.")
+                break
+        else:
+            bucket_resource = s3.Bucket(bucket)
+            # we limit the number of filtered objects to 1 for efficiency
+            # .filter() returns a type of generator, but we check if the number
+            # of objects in the generator is > 0. Performing list(s3_objects)
+            # is much more efficient when the s3_objects contains just one element
+            s3_objects = bucket_resource.objects.filter(Prefix=prefix).limit(1)
+            s3_objects_list = list(s3_objects)
+
+            if len(s3_objects_list) > 0:
+                print("Path found. Step complete.")
+                break
+            else:
+                print("Patt not found. Waiting...")
+
+        current_time = time.time()
+        elapsed_time = current_time - start_time
+        if timeout is not -1 and elapsed_time > timeout:
+            raise Exception("Timed out while waiting for S3 key.")
+
+        time.sleep(60)

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,6 +1,3 @@
-import base64
-import pickle
-import json
 from typing import Callable
 
 def wait_for_s3_path(
@@ -12,6 +9,9 @@ def wait_for_s3_path(
 ) -> None:
     import boto3
     import botocore
+    import base64
+    import pickle
+    import json
     import time
 
     s3 = boto3.resource('s3')

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,3 +1,5 @@
+import base64
+import pickle
 import json
 from typing import Callable
 
@@ -5,7 +7,7 @@ def wait_for_s3_path(
     bucket: str,
     key: str,
     timeout: int,
-    formatter: Callable,
+    formatter_encoded: str,
     flow_parameters_json: str
 ) -> None:
     import boto3
@@ -15,11 +17,13 @@ def wait_for_s3_path(
     s3 = boto3.resource('s3')
     
     flow_parameters_json = json.loads(flow_parameters_json)
+    formatter = pickle.loads(base64.b64decode(formatter_encoded))
     key = formatter(key, flow_parameters_json)
 
     print("key: ", key)
     print("flow_parameters_json: ", flow_parameters_json)
     print("type(flow_parameters_json): ", type(flow_parameters_json))
+    print("type(formatter): ", formatter)
 
     start_time = time.time()
     while True:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -46,6 +46,6 @@ def wait_for_s3_path(
         current_time = time.time()
         elapsed_time = current_time - start_time
         if timeout is not -1 and elapsed_time > timeout:
-            raise Exception("Timed out while waiting for S3 key or prefixed path..")
+            raise Exception("Timed out while waiting for S3 key..")
 
         time.sleep(polling_interval)

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -4,12 +4,14 @@ This function is called within the s3_sensor_op running container.
 (2) It splits the formatted path into an S3 bucket and key 
 (3) It polls for an object with the specified bucket and key until timeout
 """
+
+
 def wait_for_s3_path(
     path: str,
     timeout_seconds: int,
     polling_interval_seconds: int,
     formatter_code_encoded: str,
-    flow_parameters_json: str
+    flow_parameters_json: str,
 ) -> None:
     import boto3
     import botocore
@@ -28,14 +30,16 @@ def wait_for_s3_path(
     flow_parameters_json = json.loads(flow_parameters_json)
 
     formatter_code = marshal.loads(base64.b64decode(formatter_code_encoded))
+
     def formatter(key: str, flow_parameters_json: dict) -> str:
         pass
+
     formatter.__code__ = formatter_code
     path = formatter(path, flow_parameters_json)
 
     bucket, key = split_s3_path(path)
 
-    s3 = boto3.resource('s3')
+    s3 = boto3.resource("s3")
     start_time = time.time()
     while True:
         try:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,5 +1,6 @@
-def wait_for_s3_path(path: str, timeout: int) -> str:
+def wait_for_s3_path(path: str, timeout: int) -> None:
     print("path: ", path)
+    print("timeout: ", timeout)
     import time
     print("Waiting for sleep to end...")
     time.sleep(60)

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -13,7 +13,7 @@ def wait_for_s3_path(
     polling_interval_seconds: int,
     path_formatter_code_encoded: str,
     flow_parameters_json: str,
-) -> None:
+) -> str:
     import boto3
     import botocore
     import base64
@@ -26,11 +26,11 @@ def wait_for_s3_path(
     flow_parameters = json.loads(flow_parameters_json)
     path_formatter_code = marshal.loads(base64.b64decode(path_formatter_code_encoded))
 
-    def path_formatter(key: str, flow_parameters: dict) -> str:
+    def path_formatter_template(key: str, flow_parameters: dict) -> str:
         pass
 
-    path_formatter.__code__ = path_formatter_code
-    path = path_formatter(path, flow_parameters)
+    path_formatter_template.__code__ = path_formatter_code
+    path = path_formatter_template(path, flow_parameters)
     # default variable substitution
     path = path.format(**flow_parameters)
     parsed_path = urlparse(path)
@@ -39,17 +39,19 @@ def wait_for_s3_path(
     s3 = boto3.client("s3")
     start_time = time.time()
     while True:
-        try:
-            s3.head_object(Bucket=bucket, Key=key)
-        except botocore.exceptions.ClientError as e:
-            print("Object not found. Waiting...")
-        else:
-            print("Object found! Step complete.")
-            break
-
         current_time = time.time()
         elapsed_time = current_time - start_time
         if timeout_seconds is not -1 and elapsed_time > timeout_seconds:
             raise TimeoutError("Timed out while waiting for S3 key..")
 
+        try:
+            s3.head_object(Bucket=bucket, Key=key)
+        except botocore.exceptions.ClientError as e:
+            print(".")
+        else:
+            print(f"Object found at path {path}! Elapsed time: {elapsed_time}.")
+            break
+
         time.sleep(polling_interval_seconds)
+
+    return path

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -13,7 +13,7 @@ def wait_for_s3_path(
     polling_interval_seconds: int,
     path_formatter_code_encoded: str,
     flow_parameters_json: str,
-    os_vars: bool,
+    os_expandvars: bool,
 ) -> str:
     import boto3
     import botocore
@@ -33,7 +33,7 @@ def wait_for_s3_path(
 
     path_formatter_template.__code__ = path_formatter_code
     path = path_formatter_template(path, flow_parameters)
-    if os_vars:
+    if os_expandvars:
         # expand OS env variables
         path = os.path.expandvars(path)
     # default variable substitution

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -10,7 +10,7 @@ def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int) -> None:
 
     start_time = time.time()
     while True:
-        if bucket:
+        if key:
             try:
                 s3.Object(bucket, key).load()
             except botocore.exceptions.ClientError as e:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -10,6 +10,7 @@ def wait_for_s3_path(
     import boto3
     import botocore
     import base64
+    import marshal
     import pickle
     import json
     import time
@@ -18,12 +19,17 @@ def wait_for_s3_path(
     
     flow_parameters_json = json.loads(flow_parameters_json)
     #formatter = pickle.loads(base64.b64decode(formatter_encoded))
+    formatter_code = marshal.loads(base64.b64decode(formatter_encoded))
+    def formatter(key: str, flow_parameters_json: dict) -> str:
+        pass
+    formatter.__code__ = formatter_code
+
     #key = formatter(key, flow_parameters_json)
 
     print("key: ", key)
     print("flow_parameters_json: ", flow_parameters_json)
     print("type(flow_parameters_json): ", type(flow_parameters_json))
-    #print("type(formatter): ", formatter)
+    print("type(formatter): ", formatter)
 
     start_time = time.time()
     while True:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,8 +1,13 @@
+"""
+This function is called within the s3_sensor_op running container.
+(1) It decodes the formatter function's code and runs it to obtain a final S3 path
+(2) It splits the formatted path into an S3 bucket and key 
+(3) It polls for an object with the specified bucket and key until timeout
+"""
 def wait_for_s3_path(
-    bucket: str,
-    key: str,
-    timeout: int,
-    polling_interval: int,
+    path: str,
+    timeout_seconds: int,
+    polling_interval_seconds: int,
     formatter_code_encoded: str,
     flow_parameters_json: str
 ) -> None:
@@ -12,16 +17,25 @@ def wait_for_s3_path(
     import marshal
     import json
     import time
+    from datetime import date
+    from typing import Tuple
 
-    s3 = boto3.resource('s3')
+    def split_s3_path(path: str) -> Tuple[str, str]:
+        path = path.replace("s3://", "")
+        bucket, key = path.split("/", 1)
+        return bucket, key
 
     flow_parameters_json = json.loads(flow_parameters_json)
+
     formatter_code = marshal.loads(base64.b64decode(formatter_code_encoded))
     def formatter(key: str, flow_parameters_json: dict) -> str:
         pass
     formatter.__code__ = formatter_code
-    key = formatter(key, flow_parameters_json)
+    path = formatter(path, flow_parameters_json)
 
+    bucket, key = split_s3_path(path)
+
+    s3 = boto3.resource('s3')
     start_time = time.time()
     while True:
         try:
@@ -34,7 +48,7 @@ def wait_for_s3_path(
 
         current_time = time.time()
         elapsed_time = current_time - start_time
-        if timeout is not -1 and elapsed_time > timeout:
+        if timeout_seconds is not -1 and elapsed_time > timeout_seconds:
             raise Exception("Timed out while waiting for S3 key..")
 
-        time.sleep(polling_interval)
+        time.sleep(polling_interval_seconds)

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -17,13 +17,13 @@ def wait_for_s3_path(
     s3 = boto3.resource('s3')
     
     flow_parameters_json = json.loads(flow_parameters_json)
-    formatter = pickle.loads(base64.b64decode(formatter_encoded))
-    key = formatter(key, flow_parameters_json)
+    #formatter = pickle.loads(base64.b64decode(formatter_encoded))
+    #key = formatter(key, flow_parameters_json)
 
     print("key: ", key)
     print("flow_parameters_json: ", flow_parameters_json)
     print("type(flow_parameters_json): ", type(flow_parameters_json))
-    print("type(formatter): ", formatter)
+    #print("type(formatter): ", formatter)
 
     start_time = time.time()
     while True:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,39 +1,35 @@
-def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int, flow_parameters_json: str) -> None:
+import json
+from typing import Callable
+
+def wait_for_s3_path(
+    bucket: str,
+    key: str,
+    timeout: int,
+    formatter: Callable,
+    flow_parameters_json: str
+) -> None:
     import boto3
     import botocore
     import time
 
     s3 = boto3.resource('s3')
     
+    flow_parameters_json = json.loads(flow_parameters_json)
+    key = formatter(key, flow_parameters_json)
+
     print("key: ", key)
-    print("prefix: ", prefix)
     print("flow_parameters_json: ", flow_parameters_json)
     print("type(flow_parameters_json): ", type(flow_parameters_json))
 
     start_time = time.time()
     while True:
-        if key:
-            try:
-                s3.Object(bucket, key).load()
-            except botocore.exceptions.ClientError as e:
-                print("Object not found. Waiting...")
-            else:
-                print("Object found! Step complete.")
-                break
+        try:
+            s3.Object(bucket, key).load()
+        except botocore.exceptions.ClientError as e:
+            print("Object not found. Waiting...")
         else:
-            bucket_resource = s3.Bucket(bucket)
-            # we limit the number of filtered objects to 1 for efficiency
-            # .filter() returns a type of generator, but we check if the number
-            # of objects in the generator is > 0. Performing list(s3_objects)
-            # is much more efficient when the s3_objects contains just one element
-            s3_objects = bucket_resource.objects.filter(Prefix=prefix).limit(1)
-            s3_objects_list = list(s3_objects)
-
-            if len(s3_objects_list) > 0:
-                print("Path found. Step complete.")
-                break
-            else:
-                print("Path not found. Waiting...")
+            print("Object found! Step complete.")
+            break
 
         current_time = time.time()
         elapsed_time = current_time - start_time

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,4 +1,5 @@
 def wait_for_s3_path(path: str, timeout: int) -> str:
+    print("path: ", path)
     import time
     print("Waiting for sleep to end...")
     time.sleep(60)

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -4,7 +4,8 @@ def wait_for_s3_path(
     bucket: str,
     key: str,
     timeout: int,
-    formatter_encoded: str,
+    polling_interval: int,
+    formatter_code_encoded: str,
     flow_parameters_json: str
 ) -> None:
     import boto3
@@ -18,18 +19,11 @@ def wait_for_s3_path(
     s3 = boto3.resource('s3')
     
     flow_parameters_json = json.loads(flow_parameters_json)
-    #formatter = pickle.loads(base64.b64decode(formatter_encoded))
-    formatter_code = marshal.loads(base64.b64decode(formatter_encoded))
+    formatter_code = marshal.loads(base64.b64decode(formatter_code_encoded))
     def formatter(key: str, flow_parameters_json: dict) -> str:
         pass
     formatter.__code__ = formatter_code
-
     key = formatter(key, flow_parameters_json)
-
-    print("key: ", key)
-    print("flow_parameters_json: ", flow_parameters_json)
-    print("type(flow_parameters_json): ", type(flow_parameters_json))
-    print("type(formatter): ", formatter)
 
     start_time = time.time()
     while True:
@@ -46,4 +40,4 @@ def wait_for_s3_path(
         if timeout is not -1 and elapsed_time > timeout:
             raise Exception("Timed out while waiting for S3 key or prefixed path..")
 
-        time.sleep(1)
+        time.sleep(polling_interval)

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,4 +1,4 @@
-def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int) -> None:
+def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int, workflow_parameters_json: str) -> None:
     import boto3
     import botocore
     import time
@@ -7,6 +7,7 @@ def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int) -> None:
     
     print("key: ", key)
     print("prefix: ", prefix)
+    print("workflow_parameters_json: ", workflow_parameters_json)
 
     start_time = time.time()
     while True:
@@ -36,6 +37,6 @@ def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int) -> None:
         current_time = time.time()
         elapsed_time = current_time - start_time
         if timeout is not -1 and elapsed_time > timeout:
-            raise Exception("Timed out while waiting for S3 key.")
+            raise Exception("Timed out while waiting for S3 key or prefixed path..")
 
         time.sleep(1)

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,5 +1,6 @@
 def wait_for_s3_path(
-    path: str,
+    bucket: str,
+    key: str,
     timeout: int,
     polling_interval: int,
     formatter_code_encoded: str,
@@ -12,20 +13,8 @@ def wait_for_s3_path(
     import json
     import time
 
-    from typing import Tuple
-
     s3 = boto3.resource('s3')
 
-    def split_s3_path(path: str) -> Tuple[str, str]:
-        path = path.replace("s3://", "")
-        bucket, key = path.split("/", 1)
-        return bucket, key
-    
-    try:
-        bucket, key = split_s3_path(path)
-    except:
-        raise Exception("Please specify a valid S3 path.")
-    
     flow_parameters_json = json.loads(flow_parameters_json)
     formatter_code = marshal.loads(base64.b64decode(formatter_code_encoded))
     def formatter(key: str, flow_parameters_json: dict) -> str:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,0 +1,5 @@
+def wait_for_s3_path(path: str, timeout: int) -> str:
+    import time
+    print("Waiting for sleep to end...")
+    time.sleep(60)
+    print("Sleep completed...")

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -13,6 +13,7 @@ def wait_for_s3_path(
     polling_interval_seconds: int,
     path_formatter_code_encoded: str,
     flow_parameters_json: str,
+    os_vars: bool,
 ) -> str:
     import boto3
     import botocore
@@ -22,6 +23,7 @@ def wait_for_s3_path(
     import time
     from typing import Tuple
     from urllib.parse import urlparse
+    import os
 
     flow_parameters = json.loads(flow_parameters_json)
     path_formatter_code = marshal.loads(base64.b64decode(path_formatter_code_encoded))
@@ -31,6 +33,9 @@ def wait_for_s3_path(
 
     path_formatter_template.__code__ = path_formatter_code
     path = path_formatter_template(path, flow_parameters)
+    if os_vars:
+        # expand OS env variables
+        path = os.path.expandvars(path)
     # default variable substitution
     path = path.format(**flow_parameters)
     parsed_path = urlparse(path)

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -28,18 +28,14 @@ def wait_for_s3_path(
         pass
     path_formatter.__code__ = path_formatter_code
     path = path_formatter(path, flow_parameters)
-    print("path: ", path)
     # default variable substitution
     path = path.format(**flow_parameters)
-    print("path: ", path)
     parsed_path = urlparse(path)
     bucket, key = parsed_path.netloc, parsed_path.path.lstrip("/")
-    print(bucket, key)
 
     s3 = boto3.client("s3")
     start_time = time.time()
     while True:
-        print("Entered here!")
         try:
             s3.head_object(Bucket=bucket, Key=key)
         except botocore.exceptions.ClientError as e:

--- a/metaflow/plugins/kfp/kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/kfp_s3_sensor.py
@@ -1,10 +1,10 @@
-import boto3
-import botocore
-import time
-
-s3 = boto3.resource('s3')
-
 def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int) -> None:
+    import boto3
+    import botocore
+    import time
+
+    s3 = boto3.resource('s3')
+    
     start_time = time.time()
     while True:
         if bucket:
@@ -28,11 +28,11 @@ def wait_for_s3_path(bucket: str, key: str, prefix: str, timeout: int) -> None:
                 print("Path found. Step complete.")
                 break
             else:
-                print("Patt not found. Waiting...")
+                print("Path not found. Waiting...")
 
         current_time = time.time()
         elapsed_time = current_time - start_time
         if timeout is not -1 and elapsed_time > timeout:
             raise Exception("Timed out while waiting for S3 key.")
 
-        time.sleep(60)
+        time.sleep(1)

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -1,23 +1,29 @@
 from metaflow.decorators import FlowDecorator
 from metaflow.exception import MetaflowException
 
+from types import FunctionType
+
 class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
     defaults = {
         "bucket": None,
         "key": "",
-        "prefix": "",
-        "timeout": -1 # no timeout
+        "timeout": -1, # no timeout
+        "formatter": lambda key, flow_parameters_json: key
     }
 
     def flow_init(self, flow, graph,  environment, datastore, logger, echo, options):
         self.bucket = self.attributes["bucket"]
         self.key = self.attributes["key"]
-        self.prefix = self.attributes["prefix"]
         self.timeout = self.attributes["timeout"]
+        self.formatter = self.attributes["formatter"]
 
         if not self.bucket:
             raise MetaflowException("You must specify a S3 bucket within @s3_sensor.")
 
-        if not self.key and not self.prefix:
+        if not self.key:
             raise MetaflowException("You must specify either key or prefix.")
+
+        if not isinstance(self.formatter, FunctionType):
+            raise MetaflowException("formatter must be a function.")
+        

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -5,38 +5,62 @@ from types import FunctionType
 from typing import Tuple
 
 def identity_formatter(path: str, flow_parameters_json: dict) -> str:
-    return key
+    return path
 
-def split_s3_path(path: str) -> Tuple[str, str]:
-    path = path.replace("s3://", "")
-    bucket, key = path.split("/", 1)
-    return bucket, key
 
+"""
+@s3_sensor is implemented as a flow decorator that's used by customers to ensure 
+a workflow only begins after a key in S3 has been written to. 
+
+Example usage:
+
+    def formatter(path: str, flow_parameters_json: dict) -> str:
+        return path.replace("FLOW_ID", flow_parameters_json["FLOW_ID"])
+
+    @s3_sensor(
+        path="s3://aip-example-sandbox/metaflow/S3SensorFlow/data/$date/61/FLOW_ID",
+        timeout_seconds=3600, # 1 hour
+        polling_interval_seconds=90,
+        formatter=formatter
+    )
+    class S3SensorFlow(FlowSpec):    
+        @step
+        def start(self):
+            print("S3SensorFlow is starting.")
+            self.next(self.hello)
+
+        @step
+        def hello(self):
+            self.next(self.end)
+
+        @step
+        def end(self):
+            print("S3SensorFlow is all done.")
+"""
 class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
     defaults = {
         "path": "",
-        "timeout": 3600,
-        "polling_interval": 300,
+        "timeout_seconds": 3600,
+        "polling_interval_seconds": 300,
         "formatter": identity_formatter
     }
 
     def flow_init(self, flow, graph,  environment, datastore, logger, echo, options):
         self.path = self.attributes["path"]
-        self.timeout = self.attributes["timeout"]
-        self.polling_interval = self.attributes["polling_interval"]
+        self.timeout_seconds = self.attributes["timeout_seconds"]
+        self.polling_interval_seconds = self.attributes["polling_interval_seconds"]
         self.formatter = self.attributes["formatter"]
 
         if not self.path:
             raise MetaflowException("You must specify a S3 path within @s3_sensor.")
 
-        try:
-            self.bucket, self.key = split_s3_path(self.path)
-        except:
-            raise MetaflowException(
-                "Please specify a valid S3 path. Your path must be "
-                "prefixed with s3:// and contain a non-empty key."
-            )
+        if not self.path.startswith("s3://"):
+            raise MetaflowException("Your path must be prefixed with s3://")
+        
+        prefix_removed_path = self.path.replace("s3://", "", 1)
+        if len(prefix_removed_path.split("/", 1)) == 1:
+            raise MetaflowException("Your path must contain both a bucket and key, separated by a slash.")
 
         if not isinstance(self.formatter, FunctionType):
             raise MetaflowException("formatter must be a function.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -46,14 +46,14 @@ class S3SensorDecorator(FlowDecorator):
         "path": "",
         "timeout_seconds": 3600,
         "polling_interval_seconds": 300,
-        "formatter": identity_formatter,
+        "func": identity_formatter,
     }
 
     def flow_init(self, flow, graph, environment, datastore, logger, echo, options):
         self.path = self.attributes["path"]
         self.timeout_seconds = self.attributes["timeout_seconds"]
         self.polling_interval_seconds = self.attributes["polling_interval_seconds"]
-        self.formatter = self.attributes["formatter"]
+        self.func = self.attributes["func"]
 
         if not self.path:
             raise MetaflowException("You must specify a S3 path within @s3_sensor.")
@@ -67,5 +67,5 @@ class S3SensorDecorator(FlowDecorator):
                 "Your path must contain both a bucket and key, separated by a slash."
             )
 
-        if not isinstance(self.formatter, FunctionType):
+        if not isinstance(self.func, FunctionType):
             raise MetaflowException("formatter must be a function.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -5,12 +5,19 @@ class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
     defaults = {
         "path": None,
+        "key": "",
+        "prefix": "",
         "timeout": -1 # no timeout
     }
 
     def flow_init(self, flow, graph,  environment, datastore, logger, echo, options):
         self.path = self.attributes["path"]
+        self.key = self.attributes["key"]
+        self.prefix = self.attributes["prefix"]
         self.timeout = self.attributes["timeout"]
 
         if not self.path:
             raise MetaflowException("You must specify a S3 path within @s3_sensor.")
+
+        if not self.key and not self.prefix:
+            raise MetaflowException("You must specify either key or prefix.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -16,8 +16,8 @@ class S3SensorDecorator(FlowDecorator):
         self.prefix = self.attributes["prefix"]
         self.timeout = self.attributes["timeout"]
 
-        if not self.path:
-            raise MetaflowException("You must specify a S3 path within @s3_sensor.")
+        if not self.bucket:
+            raise MetaflowException("You must specify a S3 bucket within @s3_sensor.")
 
         if not self.key and not self.prefix:
             raise MetaflowException("You must specify either key or prefix.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -1,5 +1,5 @@
 from metaflow.decorators import FlowDecorator
-
+from metaflow.exception import MetaflowException
 
 class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
@@ -11,3 +11,6 @@ class S3SensorDecorator(FlowDecorator):
     def flow_init(self, flow, graph,  environment, datastore, logger, echo, options):
         self.path = self.attributes["path"]
         self.timeout = self.attributes["timeout"]
+
+        if not self.path:
+            raise MetaflowException("You must specify a S3 path within @s3_sensor.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -3,13 +3,16 @@ from metaflow.exception import MetaflowException
 
 from types import FunctionType
 
+def identity_formatter(key: str, flow_parameters_json: dict) -> str:
+    return key
+
 class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
     defaults = {
         "bucket": None,
         "key": "",
         "timeout": -1, # no timeout
-        "formatter": lambda key, flow_parameters_json: key
+        "formatter": identity_formatter
     }
 
     def flow_init(self, flow, graph,  environment, datastore, logger, echo, options):

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -5,7 +5,7 @@ class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
     defaults = {
         "path": None,
-        "timeout": None
+        "timeout": -1 # no timeout
     }
 
     def flow_init(self, flow, graph,  environment, datastore, logger, echo, options):

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -28,13 +28,12 @@ Example usage:
 
     If FLOW_ID is a parameter you've passed to your flow, the substitution
     of FLOW_ID in the `path` variable is automatically done for you if you
-    # specify the variable in braces ({}) (e.g. {FLOW_ID})
+    specify the variable in braces ({}) (e.g. {FLOW_ID}).
 
     @s3_sensor(
         path="s3://aip-example-sandbox/metaflow/S3SensorFlow/data/61/{FLOW_ID}",
         timeout_seconds=3600, # 1 hour
         polling_interval_seconds=90,
-        path_formatter=formatter
     )
     class S3SensorFlow(FlowSpec):    
         ...

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -4,6 +4,44 @@ from metaflow.exception import MetaflowException
 from types import FunctionType
 from typing import Tuple
 
+"""
+Within identity_formatter, which is passed in as the func parameter,
+customers have access to all variables in flow_parameters_json (which 
+include all parameters passed in through the flow at compile and run time by
+KFP) as well as a number of environment variables, including:
+
+MF_POD_NAME
+MF_POD_NAMESPACE
+MF_ARGO_NODE_NAME
+MF_ARGO_WORKFLOW_NAME
+ZODIAC_SERVICE
+ZODIAC_TEAM
+POD_NAMESPACE
+KFP_SDK_NAMESPACE
+POD_NAME
+POD_IP
+ARGO_WORKFLOW_NAME
+K8S_CLUSTER_NAME
+K8S_CLUSTER_ENV
+METAFLOW_NOTIFY_EMAIL_SMTP_HOST
+METAFLOW_NOTIFY_EMAIL_SMTP_PORT
+METAFLOW_NOTIFY_EMAIL_FROM
+METAFLOW_NOTIFY_EMAIL_BODY
+METAFLOW_NOTIFY_ON_ERROR
+KFP_RUN_URL_PREFIX
+METAFLOW_DEFAULT_DATASTORE
+METAFLOW_DEFAULT_METADATA
+METAFLOW_SERVICE_URL
+METAFLOW_DATASTORE_SYSROOT_S3
+WAGGLE_DANCE_DEFAULT_ENVIRONMENT
+WAGGLE_DANCE_DEV_ENDPOINT
+WAGGLE_DANCE_STAGE_ENDPOINT
+WAGGLE_DANCE_PROD_READ_ONLY_ENDPOINT
+WAGGLE_DANCE_PROD_ENDPOINT
+AWS_ROLE_ARN
+AWS_WEB_IDENTITY_TOKEN_FILE
+"""
+
 
 def identity_formatter(path: str, flow_parameters_json: dict) -> str:
     return path

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -4,7 +4,7 @@ from metaflow.exception import MetaflowException
 from types import FunctionType
 
 def identity_formatter(key: str, flow_parameters_json: dict) -> str:
-    return key
+    return key + "at_the_end!"
 
 class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -4,7 +4,7 @@ from metaflow.exception import MetaflowException
 from types import FunctionType
 from typing import Tuple
 
-def identity_formatter(key: str, flow_parameters_json: dict) -> str:
+def identity_formatter(path: str, flow_parameters_json: dict) -> str:
     return key
 
 def split_s3_path(path: str) -> Tuple[str, str]:

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -16,8 +16,7 @@ class S3SensorDecorator(FlowDecorator):
     }
 
     def flow_init(self, flow, graph,  environment, datastore, logger, echo, options):
-        self.bucket = self.attributes["bucket"]
-        self.key = self.attributes["key"]
+        self.path = self.attributes["path"]
         self.timeout = self.attributes["timeout"]
         self.polling_interval = self.attributes["polling_interval"]
         self.formatter = self.attributes["formatter"]

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -1,4 +1,3 @@
-from _typeshed import NoneType
 from metaflow.decorators import FlowDecorator
 from metaflow.exception import MetaflowException
 
@@ -105,7 +104,8 @@ class S3SensorDecorator(FlowDecorator):
                 )
 
         # if the user provides a path_formatter, it must be a function
-        if not isinstance(self.path_formatter, FunctionType) and not isinstance(
-            self.path_formatter, NoneType
+        if (
+            not isinstance(self.path_formatter, FunctionType)
+            and not self.path_formatter
         ):
             raise MetaflowException("path_formatter must be a function.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -3,47 +3,20 @@ from metaflow.exception import MetaflowException
 
 from types import FunctionType
 from typing import Tuple
+from urllib.parse import urlparse
 
 """
-Within identity_formatter, which is passed in as the func parameter,
+Within identity_formatter, which is passed in as the path_formatter parameter,
 customers have access to all variables in flow_parameters_json (which 
 include all parameters passed in through the flow at compile and run time by
-KFP) as well as a number of environment variables, including:
+KFP) as well as a number of environment variables.
 
-MF_POD_NAME
-MF_POD_NAMESPACE
-MF_ARGO_NODE_NAME
-MF_ARGO_WORKFLOW_NAME
-ZODIAC_SERVICE
-ZODIAC_TEAM
-POD_NAMESPACE
-KFP_SDK_NAMESPACE
-POD_NAME
-POD_IP
-ARGO_WORKFLOW_NAME
-K8S_CLUSTER_NAME
-K8S_CLUSTER_ENV
-METAFLOW_NOTIFY_EMAIL_SMTP_HOST
-METAFLOW_NOTIFY_EMAIL_SMTP_PORT
-METAFLOW_NOTIFY_EMAIL_FROM
-METAFLOW_NOTIFY_EMAIL_BODY
-METAFLOW_NOTIFY_ON_ERROR
-KFP_RUN_URL_PREFIX
-METAFLOW_DEFAULT_DATASTORE
-METAFLOW_DEFAULT_METADATA
-METAFLOW_SERVICE_URL
-METAFLOW_DATASTORE_SYSROOT_S3
-WAGGLE_DANCE_DEFAULT_ENVIRONMENT
-WAGGLE_DANCE_DEV_ENDPOINT
-WAGGLE_DANCE_STAGE_ENDPOINT
-WAGGLE_DANCE_PROD_READ_ONLY_ENDPOINT
-WAGGLE_DANCE_PROD_ENDPOINT
-AWS_ROLE_ARN
-AWS_WEB_IDENTITY_TOKEN_FILE
+Please see metaflow/plugin/environment_decorator.py for details on how
+to add environment variables to be accessible within steps.
 """
 
 
-def identity_formatter(path: str, flow_parameters_json: dict) -> str:
+def identity_formatter(path: str, flow_parameters: dict) -> str:
     return path
 
 
@@ -53,14 +26,14 @@ a workflow only begins after a key in S3 has been written to.
 
 Example usage:
 
-    def formatter(path: str, flow_parameters_json: dict) -> str:
-        return path.replace("FLOW_ID", flow_parameters_json["FLOW_ID"])
+    def formatter(path: str, flow_parameters: dict) -> str:
+        return path.replace("FLOW_ID", flow_parameters["FLOW_ID"])
 
     @s3_sensor(
         path="s3://aip-example-sandbox/metaflow/S3SensorFlow/data/$date/61/FLOW_ID",
         timeout_seconds=3600, # 1 hour
         polling_interval_seconds=90,
-        formatter=formatter
+        path_formatter=formatter
     )
     class S3SensorFlow(FlowSpec):    
         @step
@@ -84,26 +57,21 @@ class S3SensorDecorator(FlowDecorator):
         "path": "",
         "timeout_seconds": 3600,
         "polling_interval_seconds": 300,
-        "func": identity_formatter,
+        "path_formatter": identity_formatter,
     }
 
     def flow_init(self, flow, graph, environment, datastore, logger, echo, options):
         self.path = self.attributes["path"]
         self.timeout_seconds = self.attributes["timeout_seconds"]
         self.polling_interval_seconds = self.attributes["polling_interval_seconds"]
-        self.func = self.attributes["func"]
+        self.path_formatter = self.attributes["path_formatter"]
 
         if not self.path:
             raise MetaflowException("You must specify a S3 path within @s3_sensor.")
 
-        if not self.path.startswith("s3://"):
-            raise MetaflowException("Your path must be prefixed with s3://")
+        parsed_path = urlparse(self.path)
+        if not parsed_path.scheme:
+            raise MetaflowException("Please provide a valid S3 path.")
 
-        prefix_removed_path = self.path.replace("s3://", "", 1)
-        if len(prefix_removed_path.split("/", 1)) == 1:
-            raise MetaflowException(
-                "Your path must contain both a bucket and key, separated by a slash."
-            )
-
-        if not isinstance(self.func, FunctionType):
-            raise MetaflowException("formatter must be a function.")
+        if not isinstance(self.path_formatter, FunctionType):
+            raise MetaflowException("path_formatter must be a function.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -104,8 +104,5 @@ class S3SensorDecorator(FlowDecorator):
                 )
 
         # if the user provides a path_formatter, it must be a function
-        if (
-            not isinstance(self.path_formatter, FunctionType)
-            and not self.path_formatter
-        ):
+        if self.path_formatter and not isinstance(self.path_formatter, FunctionType):
             raise MetaflowException("path_formatter must be a function.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -4,14 +4,15 @@ from metaflow.exception import MetaflowException
 from types import FunctionType
 
 def identity_formatter(key: str, flow_parameters_json: dict) -> str:
-    return key + "at_the_end!"
+    return key
 
 class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
     defaults = {
         "bucket": None,
         "key": "",
-        "timeout": -1, # no timeout
+        "timeout": 3600, # no timeout
+        "polling_interval": 300,
         "formatter": identity_formatter
     }
 
@@ -19,6 +20,7 @@ class S3SensorDecorator(FlowDecorator):
         self.bucket = self.attributes["bucket"]
         self.key = self.attributes["key"]
         self.timeout = self.attributes["timeout"]
+        self.polling_interval = self.attributes["polling_interval"]
         self.formatter = self.attributes["formatter"]
 
         if not self.bucket:

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -9,8 +9,7 @@ def identity_formatter(key: str, flow_parameters_json: dict) -> str:
 class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
     defaults = {
-        "bucket": None,
-        "key": "",
+        "path": "",
         "timeout": 3600, # no timeout
         "polling_interval": 300,
         "formatter": identity_formatter

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -68,7 +68,7 @@ class S3SensorDecorator(FlowDecorator):
         "timeout_seconds": 3600,
         "polling_interval_seconds": 300,
         "path_formatter": identity_formatter,
-        "os_vars": False
+        "os_vars": False,
     }
 
     def flow_init(self, flow, graph, environment, datastore, logger, echo, options):
@@ -80,7 +80,7 @@ class S3SensorDecorator(FlowDecorator):
 
         if not self.path:
             raise MetaflowException("You must specify a S3 path within @s3_sensor.")
-        
+
         if not self.os_vars:
             parsed_path = urlparse(self.path)
             if not parsed_path.scheme:
@@ -88,7 +88,9 @@ class S3SensorDecorator(FlowDecorator):
 
             bucket, key = parsed_path.netloc, parsed_path.path.lstrip("/")
             if not bucket or not key:
-                raise MetaflowException("Your S3 path must have a nonempty bucket and key.")
+                raise MetaflowException(
+                    "Your S3 path must have a nonempty bucket and key."
+                )
 
         if not isinstance(self.path_formatter, FunctionType):
             raise MetaflowException("path_formatter must be a function.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -26,9 +26,9 @@ a workflow only begins after a key in S3 has been written to.
 
 Example usage:
 
-    If FLOW_ID is a parameter you've passed to your flow, the substitution
-    of FLOW_ID in the `path` variable is automatically done for you if you
-    specify the variable in braces ({}) (e.g. {FLOW_ID}).
+    If flow_id is a parameter you've passed to your flow, the substitution
+    of flow_id in the `path` variable is automatically done for you if you
+    specify the variable in braces ({}) (e.g. {flow_id}).
 
     @s3_sensor(
         path="s3://aip-example-sandbox/metaflow/S3SensorFlow/data/61/{FLOW_ID}",
@@ -38,7 +38,7 @@ Example usage:
     class S3SensorFlow(FlowSpec):    
         ...
 
-    If you want to format FLOW_ID (or any other variable in flow_parameters), you
+    If you want to format flow_id (or any other variable in flow_parameters), you
     can do so with a separate `path_formatter` function:
 
     def formatter(path: str, flow_parameters: dict) -> str:

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -4,6 +4,7 @@ from metaflow.exception import MetaflowException
 from types import FunctionType
 from typing import Tuple
 
+
 def identity_formatter(path: str, flow_parameters_json: dict) -> str:
     return path
 
@@ -37,16 +38,18 @@ Example usage:
         def end(self):
             print("S3SensorFlow is all done.")
 """
+
+
 class S3SensorDecorator(FlowDecorator):
-    name = 's3_sensor'
+    name = "s3_sensor"
     defaults = {
         "path": "",
         "timeout_seconds": 3600,
         "polling_interval_seconds": 300,
-        "formatter": identity_formatter
+        "formatter": identity_formatter,
     }
 
-    def flow_init(self, flow, graph,  environment, datastore, logger, echo, options):
+    def flow_init(self, flow, graph, environment, datastore, logger, echo, options):
         self.path = self.attributes["path"]
         self.timeout_seconds = self.attributes["timeout_seconds"]
         self.polling_interval_seconds = self.attributes["polling_interval_seconds"]
@@ -57,11 +60,12 @@ class S3SensorDecorator(FlowDecorator):
 
         if not self.path.startswith("s3://"):
             raise MetaflowException("Your path must be prefixed with s3://")
-        
+
         prefix_removed_path = self.path.replace("s3://", "", 1)
         if len(prefix_removed_path.split("/", 1)) == 1:
-            raise MetaflowException("Your path must contain both a bucket and key, separated by a slash.")
+            raise MetaflowException(
+                "Your path must contain both a bucket and key, separated by a slash."
+            )
 
         if not isinstance(self.formatter, FunctionType):
             raise MetaflowException("formatter must be a function.")
-        

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -4,14 +4,14 @@ from metaflow.exception import MetaflowException
 class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
     defaults = {
-        "path": None,
+        "bucket": None,
         "key": "",
         "prefix": "",
         "timeout": -1 # no timeout
     }
 
     def flow_init(self, flow, graph,  environment, datastore, logger, echo, options):
-        self.path = self.attributes["path"]
+        self.bucket = self.attributes["bucket"]
         self.key = self.attributes["key"]
         self.prefix = self.attributes["prefix"]
         self.timeout = self.attributes["timeout"]

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -42,16 +42,22 @@ Example usage:
     can do so with a separate `path_formatter` function:
 
     def formatter(path: str, flow_parameters: dict) -> str:
-        return path.format(FLOW_ID, my_parse_func(flow_parameters["FLOW_ID"]))
+        path.format(year, flow_parameters["date"].split("-")[-1])
 
     @s3_sensor(
-        path="s3://aip-example-sandbox/metaflow/S3SensorFlow/data/61/{FLOW_ID}",
+        path="s3://aip-example-sandbox/metaflow/S3SensorFlow/data/61/{flow_id}/year={year}",
         timeout_seconds=3600, # 1 hour
         polling_interval_seconds=90,
         path_formatter=formatter
     )
     class S3SensorFlow(FlowSpec):    
         ...
+
+    Note, in this example, `flow_parameters` looks like:
+    {
+        "flow_id": "random_flow_id",
+        "date": "07-02-2021"
+    }
 """
 
 

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -1,3 +1,4 @@
+from _typeshed import NoneType
 from metaflow.decorators import FlowDecorator
 from metaflow.exception import MetaflowException
 
@@ -13,25 +14,25 @@ KFP) as well as a number of environment variables.
 
 Please see metaflow/plugin/environment_decorator.py for details on how
 to add environment variables to be accessible within steps.
-"""
 
-
-def identity_formatter(path: str, flow_parameters: dict) -> str:
-    return path
-
-
-"""
 @s3_sensor is implemented as a flow decorator that's used by customers to ensure 
 a workflow only begins after a key in S3 has been written to. 
 
 Example usage:
 
+    Note: In the below examples, flow_paramaters = 
+    {
+        "flow_id": "random_flow_id",
+        "date": "07-02-2021"
+    }
+
     If flow_id is a parameter you've passed to your flow, the substitution
     of flow_id in the `path` variable is automatically done for you if you
-    specify the variable in braces ({}) (e.g. {flow_id}).
+    specify the variable in braces ({}) (e.g. {flow_id}) AND IF you don't provide
+    your own path formatter and don't pass in env variables.
 
     @s3_sensor(
-        path="s3://aip-example-sandbox/metaflow/S3SensorFlow/data/61/{FLOW_ID}",
+        path="s3://aip-example-sandbox/metaflow/S3SensorFlow/data/61/flow_id={flow_id}",
         timeout_seconds=3600, # 1 hour
         polling_interval_seconds=90,
     )
@@ -41,15 +42,8 @@ Example usage:
     If you want to format flow_id (or any other variable in flow_parameters), you
     can do so with a separate `path_formatter` function.
 
-    Note, in this example, `flow_parameters` looks like, so `flow_id` is automatically
-    substituted into {flow_id}.
-    {
-        "flow_id": "random_flow_id",
-        "date": "07-02-2021"
-    }
-
     def formatter(path: str, flow_parameters: dict) -> str:
-        path.format(year=flow_parameters["date"].split("-")[-1])
+        path.format(flow_id=1234, year=flow_parameters["date"].split("-")[-1])
 
     @s3_sensor(
         path="s3://aip-example-sandbox/metaflow/S3SensorFlow/data/61/{flow_id}/year={year}",
@@ -60,6 +54,8 @@ Example usage:
     class S3SensorFlow(FlowSpec):    
         ...
 
+    In the above example, we needed to provide `flow_id` in the formatter function because
+    we passed in a custom path_formatter function.
 
     If you plan to use env variables present in the pods on Kubeflow, use os_expandvars=True.
     Note: os_expandvars=False by default.
@@ -79,7 +75,7 @@ class S3SensorDecorator(FlowDecorator):
         "path": "",
         "timeout_seconds": 3600,
         "polling_interval_seconds": 300,
-        "path_formatter": identity_formatter,
+        "path_formatter": None,
         "os_expandvars": False,
     }
 
@@ -93,7 +89,9 @@ class S3SensorDecorator(FlowDecorator):
         if not self.path:
             raise MetaflowException("You must specify a S3 path within @s3_sensor.")
 
-        if self.path_formatter is not identity_formatter and not self.os_expandvars:
+        # path_formatter must not be provided and os_expandvars must be false
+        # for us to perform this compilation check.
+        if not self.path_formatter and not self.os_expandvars:
             parsed_path = urlparse(self.path)
             if not parsed_path.scheme or parsed_path.scheme not in ["s3", "s3a", "s3n"]:
                 raise MetaflowException(
@@ -106,5 +104,8 @@ class S3SensorDecorator(FlowDecorator):
                     "Your S3 path must have a nonempty bucket and key."
                 )
 
-        if not isinstance(self.path_formatter, FunctionType):
+        # if the user provides a path_formatter, it must be a function
+        if not isinstance(self.path_formatter, FunctionType) and not isinstance(
+            self.path_formatter, NoneType
+        ):
             raise MetaflowException("path_formatter must be a function.")

--- a/metaflow/plugins/kfp/s3_sensor_decorator.py
+++ b/metaflow/plugins/kfp/s3_sensor_decorator.py
@@ -16,7 +16,7 @@ class S3SensorDecorator(FlowDecorator):
     name = 's3_sensor'
     defaults = {
         "path": "",
-        "timeout": 3600, # no timeout
+        "timeout": 3600,
         "polling_interval": 300,
         "formatter": identity_formatter
     }

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -131,6 +131,7 @@ test:internal:
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-internal && 
           export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
+          python -c "import os; print(os.environ[\"METAFLOW_DATASTORE_SYSROOT_S3\"])"
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --env dev --cov-config=setup.cfg
         "
   artifacts:

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -130,7 +130,6 @@ test:internal:
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.dev-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-internal && 
           export USER=${GITLAB_USER_EMAIL} &&
-          export METAFLOW_DATASTORE_SYSROOT_S3=s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/dev/aip-integration-testing &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
@@ -166,7 +165,6 @@ test:nonprod:
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.stage-k8s.zg-aip.net/ &&
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-stage &&
           export USER=${GITLAB_USER_EMAIL} &&
-          export METAFLOW_DATASTORE_SYSROOT_S3=s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/stage/aip-integration-testing &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
@@ -202,7 +200,6 @@ test:prod:
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.prod-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-prod && 
           export USER=${GITLAB_USER_EMAIL} &&
-          export METAFLOW_DATASTORE_SYSROOT_S3=s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/prod/aip-integration-testing
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -130,9 +130,9 @@ test:internal:
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.dev-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-internal && 
           export USER=${GITLAB_USER_EMAIL} &&
+          export METAFLOW_DATASTORE_SYSROOT_S3=s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/dev/aip-integration-testing &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -c "import os; print(os.environ[\"METAFLOW_DATASTORE_SYSROOT_S3\"])"
-          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --env dev --cov-config=setup.cfg
+          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
   artifacts:
     when: always
@@ -166,8 +166,9 @@ test:nonprod:
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.stage-k8s.zg-aip.net/ &&
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-stage &&
           export USER=${GITLAB_USER_EMAIL} &&
+          export METAFLOW_DATASTORE_SYSROOT_S3=s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/stage/aip-integration-testing &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --env stage --cov-config=setup.cfg
+          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
   artifacts:
     when: always
@@ -201,8 +202,9 @@ test:prod:
           export KFP_RUN_URL_PREFIX=https://kubeflow.corp.prod-k8s.zg-aip.net/ && 
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-prod && 
           export USER=${GITLAB_USER_EMAIL} &&
+          export METAFLOW_DATASTORE_SYSROOT_S3=s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/prod/aip-integration-testing
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --env prod --cov-config=setup.cfg
+          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
         "
   artifacts:
     when: always

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -131,7 +131,7 @@ test:internal:
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-internal && 
           export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
+          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --env dev --cov-config=setup.cfg
         "
   artifacts:
     when: always
@@ -166,7 +166,7 @@ test:nonprod:
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-stage &&
           export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
+          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --env stage --cov-config=setup.cfg
         "
   artifacts:
     when: always
@@ -201,7 +201,7 @@ test:prod:
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-prod && 
           export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
+          python -m pytest -s -n 2 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --env prod --cov-config=setup.cfg
         "
   artifacts:
     when: always

--- a/metaflow/plugins/kfp/tests/README.md
+++ b/metaflow/plugins/kfp/tests/README.md
@@ -31,3 +31,8 @@ Currently, due to Gitlab's polling, it takes about 20 minutes for these tests to
 `curl -X POST "https://gitlab.zgtools.net/api/v4/projects/20508/mirror/pull?private_token=[PRIVATE_TOKEN]"`
 
 Please reach out to @hariharans on Slack (for Zillow employees) to obtain the private token to run on Zillow internal Gitlab infrastructure.
+
+# Unit Tests
+
+On top of the integration tests, we also have units tests. Currently, we only have unit tests for the
+`@s3_sensor` decorator.

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -3,5 +3,4 @@ def pytest_addoption(parser):
     The image on Artifactory that corresponds to the currently
     committed Metaflow version.
     """
-    parser.addoption("--env", action="store", default=None)
     parser.addoption("--image", action="store", default=None)

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -3,4 +3,5 @@ def pytest_addoption(parser):
     The image on Artifactory that corresponds to the currently
     committed Metaflow version.
     """
+    parser.addoption("--env", action="store", default=None)
     parser.addoption("--image", action="store", default=None)

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -1,0 +1,38 @@
+from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
+
+def formatter(path: str, flow_parameters_json: dict) -> str:
+    return path.replace("CODE_PACKAGE_ID", flow_parameters_json["code_package_id"])
+
+@s3_sensor(
+    path="s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/dev/aip-integration-testing/HelloFlow/data/6f/CODE_PACKAGE_ID",
+    timeout_seconds=45,
+    polling_interval_seconds=1,
+    formatter=formatter
+)
+class S3SensorFlow(FlowSpec):
+    
+    # This parameter is just for testing @s3_sensor. In an actual flow,
+    # it doesn't make sense to pass the code package's metadata
+    # as a parameter, as that is transparently done behind the scenes.
+    alpha = Parameter(
+        "code_package_id",
+        default="6ff80f2870922f04ed6960dba2f23c7223e699a7",
+    )
+
+    @step
+    def start(self):
+        print("S3SensorFlow is starting.")
+        self.next(self.hello)
+
+    @step
+    def hello(self):
+        print("Hi!")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print("S3SensorFlow is all done.")
+
+
+if __name__ == "__main__":
+    S3SensorFlow()

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -2,11 +2,14 @@ from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
 
 
 def formatter(path: str, flow_parameters_json: dict) -> str:
-    return path.replace("CODE_PACKAGE_ID", flow_parameters_json["code_package_id"])
+    import os
+
+    path = path.replace("CODE_PACKAGE_ID", flow_parameters_json["code_package_id"])
+    path = path.replace("POD_NAMESPACE", os.environ["POD_NAMESPACE"])
 
 
 @s3_sensor(
-    path="s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/dev/aip-integration-testing/HelloFlow/data/6f/CODE_PACKAGE_ID",
+    path="s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/dev/POD_NAMESPACE/HelloFlow/data/6f/CODE_PACKAGE_ID",
     timeout_seconds=45,
     polling_interval_seconds=1,
     formatter=formatter,

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -2,7 +2,10 @@ from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
 
 
 def formatter(path: str, flow_parameters: dict) -> str:
-    return path.format(file_name=flow_parameters["file_name"])
+    return path.format(
+        env=flow_parameters["env"],
+        file_name=flow_parameters["file_name"]
+    )
 
 
 """
@@ -12,7 +15,7 @@ The test creates a random file and uploads it to S3, and this flow waits on the 
 of that file.
 """
 @s3_sensor(
-    path="s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/dev/aip-integration-testing/{file_name}",
+    path="s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/{env}/aip-integration-testing/{file_name}",
     timeout_seconds=300,
     polling_interval_seconds=5,
     path_formatter=formatter,

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -1,13 +1,6 @@
 from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
 
 
-def formatter(path: str, flow_parameters: dict) -> str:
-    return path.format(
-        env=flow_parameters["env"],
-        file_name=flow_parameters["file_name"]
-    )
-
-
 """
 This test flow ensures that @s3_sensor properly waits for path to be written
 to in S3. In run_integration_tests.py, we have a special test just for this flow.
@@ -16,17 +9,17 @@ of that file.
 """
 @s3_sensor(
     path="s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/{env}/aip-integration-testing/{file_name}",
-    timeout_seconds=300,
+    timeout_seconds=600,
     polling_interval_seconds=5,
-    path_formatter=formatter,
 )
 class S3SensorFlow(FlowSpec):
 
-    s3_file = Parameter(
+    file_name = Parameter(
         "file_name",
-        default="file_name"
     )
-
+    env = Parameter(
+        "env"
+    )
     @step
     def start(self):
         print("S3SensorFlow is starting.")

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -1,6 +1,5 @@
 from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
 
-from os import environ
 from os.path import join
 """
 This test flow ensures that @s3_sensor properly waits for path to be written
@@ -9,17 +8,15 @@ The test creates a random file and uploads it to S3, and this flow waits on the 
 of that file.
 """
 @s3_sensor(
-    path=join(environ["METAFLOW_DATASTORE_SYSROOT_S3"], "{file_name}"),
+    path=join("$METAFLOW_DATASTORE_SYSROOT_S3", "{file_name}"),
     timeout_seconds=600,
     polling_interval_seconds=5,
+    os_vars=True,
 )
 class S3SensorFlow(FlowSpec):
 
     file_name = Parameter(
         "file_name",
-    )
-    env = Parameter(
-        "env"
     )
     @step
     def start(self):

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -1,20 +1,22 @@
 from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
 
+
 def formatter(path: str, flow_parameters_json: dict) -> str:
     return path.replace("CODE_PACKAGE_ID", flow_parameters_json["code_package_id"])
+
 
 @s3_sensor(
     path="s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/dev/aip-integration-testing/HelloFlow/data/6f/CODE_PACKAGE_ID",
     timeout_seconds=45,
     polling_interval_seconds=1,
-    formatter=formatter
+    formatter=formatter,
 )
 class S3SensorFlow(FlowSpec):
-    
+
     # This parameter is just for testing @s3_sensor. In an actual flow,
     # it doesn't make sense to pass the code package's metadata
     # as a parameter, as that is transparently done behind the scenes.
-    alpha = Parameter(
+    code_package_id = Parameter(
         "code_package_id",
         default="6ff80f2870922f04ed6960dba2f23c7223e699a7",
     )

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -11,7 +11,7 @@ of that file.
     path=join("$METAFLOW_DATASTORE_SYSROOT_S3", "{file_name}"),
     timeout_seconds=600,
     polling_interval_seconds=5,
-    os_vars=True,
+    os_expandvars=True,
 )
 class S3SensorFlow(FlowSpec):
 

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -1,6 +1,7 @@
 from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
 
-
+from os import environ
+from os.path import join
 """
 This test flow ensures that @s3_sensor properly waits for path to be written
 to in S3. In run_integration_tests.py, we have a special test just for this flow.
@@ -8,7 +9,7 @@ The test creates a random file and uploads it to S3, and this flow waits on the 
 of that file.
 """
 @s3_sensor(
-    path="s3://serve-datalake-zillowgroup/zillow/workflow_sdk/metaflow_28d/{env}/aip-integration-testing/{file_name}",
+    path=join(environ["METAFLOW_DATASTORE_SYSROOT_S3"], "{file_name}"),
     timeout_seconds=600,
     polling_interval_seconds=5,
 )

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -4,6 +4,11 @@ import boto3
 import time
 from subprocess import run, PIPE
 
+from os import environ
+from os.path import join
+
+from urllib.parse import urlparse
+
 class UploadToS3Flow(FlowSpec):
 
     file_name = Parameter(
@@ -25,13 +30,14 @@ class UploadToS3Flow(FlowSpec):
             shell=True
         )
 
-        print("File name: ", self.file_name)
+        root = urlparse(environ["METAFLOW_DATASTORE_SYSROOT_S3"])
+        bucket, key = root.netloc, root.path.lstrip("/")
 
         s3 = boto3.resource('s3')
         s3.meta.client.upload_file(
             f"./{self.file_name}", 
             "serve-datalake-zillowgroup",
-            f"zillow/workflow_sdk/metaflow_28d/{self.env}/aip-integration-testing/{self.file_name}"
+            join(key, self.file_name)
         )
         self.next(self.end)
     @step

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -4,7 +4,7 @@ import boto3
 import time
 from subprocess import run, PIPE
 
-from os import getenv
+from os import environ
 from os.path import join
 
 from urllib.parse import urlparse
@@ -28,7 +28,7 @@ class UploadToS3Flow(FlowSpec):
         )
         # using os.getenv with a default because the Gitlab runners do not have access to the 
         # METAFLOW_DATASTORE_SYSROOT_S3 env var
-        root = urlparse(getenv("METAFLOW_DATASTORE_SYSROOT_S3", "s3://random_bucket/random_key"))
+        root = urlparse(environ["METAFLOW_DATASTORE_SYSROOT_S3"])
         bucket, key = root.netloc, root.path.lstrip("/")
 
         s3 = boto3.resource('s3')

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -9,35 +9,30 @@ from os.path import join
 
 from urllib.parse import urlparse
 
+
 class UploadToS3Flow(FlowSpec):
 
     file_name = Parameter(
         "file_name",
     )
+
     @step
     def start(self):
         print("Waiting to upload file...")
         time.sleep(100)
         print(f"Uploading {self.file_name} to S3...")
 
-        run(
-            f"touch {self.file_name}",
-            universal_newlines=True,
-            stdout=PIPE,
-            shell=True
-        )
-        # using os.getenv with a default because the Gitlab runners do not have access to the 
-        # METAFLOW_DATASTORE_SYSROOT_S3 env var
+        run(f"touch {self.file_name}", universal_newlines=True, stdout=PIPE, shell=True)
+        # using environ with METAFLOW_DATASTORE_SYSROOT_S3 env var
         root = urlparse(environ["METAFLOW_DATASTORE_SYSROOT_S3"])
         bucket, key = root.netloc, root.path.lstrip("/")
 
-        s3 = boto3.resource('s3')
+        s3 = boto3.resource("s3")
         s3.meta.client.upload_file(
-            f"./{self.file_name}", 
-            bucket,
-            join(key, self.file_name)
+            f"./{self.file_name}", bucket, join(key, self.file_name)
         )
         self.next(self.end)
+
     @step
     def end(self):
         print("S3SensorFlow is all done.")

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -1,0 +1,41 @@
+from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
+
+import boto3
+from subprocess import run, PIPE
+
+class UploadToS3Flow(FlowSpec):
+
+    file_name = Parameter(
+        "file_name",
+    )
+    env = Parameter(
+        "env"
+    )
+    @step
+    def start(self):
+        print(f"Uploading {self.file_name} to S3...")
+        self.next(self.end)
+
+        run(
+            f"touch {self.file_name}",
+            universal_newlines=True,
+            stdout=PIPE,
+            shell=True
+        )
+
+        print("File name: ", self.file_name)
+
+        s3 = boto3.resource('s3')
+        s3.meta.client.upload_file(
+            f"./{self.file_name}", 
+            "serve-datalake-zillowgroup",
+            f"zillow/workflow_sdk/metaflow_28d/{self.env}/aip-integration-testing/{self.file_name}"
+        )
+
+    @step
+    def end(self):
+        print("S3SensorFlow is all done.")
+
+
+if __name__ == "__main__":
+    UploadToS3Flow()

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -14,9 +14,6 @@ class UploadToS3Flow(FlowSpec):
     file_name = Parameter(
         "file_name",
     )
-    env = Parameter(
-        "env"
-    )
     @step
     def start(self):
         print("Waiting to upload file...")

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -24,6 +24,7 @@ class UploadToS3Flow(FlowSpec):
 
         run(f"touch {self.file_name}", universal_newlines=True, stdout=PIPE, shell=True)
         # using environ with METAFLOW_DATASTORE_SYSROOT_S3 env var
+        # since it is available at run time in the pods on Kubeflow
         root = urlparse(environ["METAFLOW_DATASTORE_SYSROOT_S3"])
         bucket, key = root.netloc, root.path.lstrip("/")
 

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -36,7 +36,7 @@ class UploadToS3Flow(FlowSpec):
         s3 = boto3.resource('s3')
         s3.meta.client.upload_file(
             f"./{self.file_name}", 
-            "serve-datalake-zillowgroup",
+            bucket,
             join(key, self.file_name)
         )
         self.next(self.end)

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -1,6 +1,7 @@
 from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
 
 import boto3
+import time
 from subprocess import run, PIPE
 
 class UploadToS3Flow(FlowSpec):
@@ -13,8 +14,9 @@ class UploadToS3Flow(FlowSpec):
     )
     @step
     def start(self):
+        print("Waiting to upload file...")
+        time.sleep(100)
         print(f"Uploading {self.file_name} to S3...")
-        self.next(self.end)
 
         run(
             f"touch {self.file_name}",
@@ -31,7 +33,7 @@ class UploadToS3Flow(FlowSpec):
             "serve-datalake-zillowgroup",
             f"zillow/workflow_sdk/metaflow_28d/{self.env}/aip-integration-testing/{self.file_name}"
         )
-
+        self.next(self.end)
     @step
     def end(self):
         print("S3SensorFlow is all done.")

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -49,7 +49,12 @@ def _python():
         return "python"
 
 
-non_standard_test_flows = ["raise_error_flow.py", "accelerator_flow.py", "s3_sensor_flow.py", "upload_to_s3_flow.py"]
+non_standard_test_flows = [
+    "raise_error_flow.py",
+    "accelerator_flow.py",
+    "s3_sensor_flow.py",
+    "upload_to_s3_flow.py",
+]
 
 
 def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
@@ -67,7 +72,9 @@ def test_s3_sensor_flow(pytestconfig) -> None:
     # ensure the s3_sensor waits for some time before the key exists
     file_name = f"{uuid.uuid1()}.txt"
 
-    upload_to_s3_flow_cmd = f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
+    upload_to_s3_flow_cmd = (
+        f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
+    )
     s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
 
     main_config_cmds = (

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -7,10 +7,17 @@ from .... import R
 
 import kfp
 
+import boto3
+
 import pytest
 
 import yaml
 import tempfile
+
+import time
+
+import random
+import string
 
 """
 To run these tests from your terminal, go to the tests directory and run: 
@@ -51,20 +58,42 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
         and not file_name.startswith(".")
         and not "raise_error_flow" in file_name
         and not "accelerator_flow" in file_name
+        and not "s3_sensor_flow" in file_name
     ]
     return file_paths
 
 
-# this test ensures the integration tests fail correctly
-def test_raise_failure_flow(pytestconfig) -> None:
+def test_s3_sensor_flow(pytestconfig) -> None:
+    # ensure the s3_sensor needs to wait for some time before the key exists
+    time.sleep(30)
+    random_string = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(15))
+    file_name = f"{random_string}.txt"
+    # create a local file
+    run(
+        f"touch {file_name}",
+        universal_newlines=True,
+        stdout=PIPE,
+        shell=True
+    )
+
+    print("File name: ", file_name)
+
+    s3 = boto3.resource('s3')
+    s3.meta.client.upload_file(
+        f"./{file_name}", 
+        "serve-datalake-zillowgroup",
+        f"zillow/workflow_sdk/metaflow_28d/dev/aip-integration-testing/{file_name}"
+    )
+
     test_cmd = (
-        f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
+        f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
     )
     if pytestconfig.getoption("image"):
         test_cmd += (
-            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')} "
+            f"--file_name {file_name}"
         )
 
     run_and_wait_process = run(
@@ -73,11 +102,31 @@ def test_raise_failure_flow(pytestconfig) -> None:
         stdout=PIPE,
         shell=True,
     )
-    # this ensures the integration testing framework correctly catches a failing flow
-    # and reports the error
-    assert run_and_wait_process.returncode == 1
 
-    return
+
+# this test ensures the integration tests fail correctly
+# def test_raise_failure_flow(pytestconfig) -> None:
+#     test_cmd = (
+#         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
+#         f"--wait-for-completion --workflow-timeout 1800 "
+#         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+#     )
+#     if pytestconfig.getoption("image"):
+#         test_cmd += (
+#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+#         )
+
+#     run_and_wait_process = run(
+#         test_cmd,
+#         universal_newlines=True,
+#         stdout=PIPE,
+#         shell=True,
+#     )
+#     # this ensures the integration testing framework correctly catches a failing flow
+#     # and reports the error
+#     assert run_and_wait_process.returncode == 1
+
+#     return
 
 
 def exists_nvidia_accelerator(node_selector_term: Dict) -> bool:
@@ -102,78 +151,78 @@ def is_nvidia_accelerator_noschedule(toleration: Dict) -> bool:
     return False
 
 
-def test_compile_only_accelerator_test() -> None:
-    with tempfile.TemporaryDirectory() as yaml_tmp_dir:
-        yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
+# def test_compile_only_accelerator_test() -> None:
+#     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
+#         yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
 
-        compile_to_yaml_cmd = (
-            f"{_python()} flows/accelerator_flow.py --datastore=s3 kfp run "
-            f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
-        )
+#         compile_to_yaml_cmd = (
+#             f"{_python()} flows/accelerator_flow.py --datastore=s3 kfp run "
+#             f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
+#         )
 
-        compile_to_yaml_process = run(
-            compile_to_yaml_cmd,
-            universal_newlines=True,
-            stdout=PIPE,
-            shell=True,
-        )
-        assert compile_to_yaml_process.returncode == 0
+#         compile_to_yaml_process = run(
+#             compile_to_yaml_cmd,
+#             universal_newlines=True,
+#             stdout=PIPE,
+#             shell=True,
+#         )
+#         assert compile_to_yaml_process.returncode == 0
 
-        with open(f"{yaml_file_path}", "r") as stream:
-            try:
-                flow_yaml = yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
-                print(exc)
+#         with open(f"{yaml_file_path}", "r") as stream:
+#             try:
+#                 flow_yaml = yaml.safe_load(stream)
+#             except yaml.YAMLError as exc:
+#                 print(exc)
 
-        for step in flow_yaml["spec"]["templates"]:
-            if step["name"] == "start":
-                start_step = step
-                break
+#         for step in flow_yaml["spec"]["templates"]:
+#             if step["name"] == "start":
+#                 start_step = step
+#                 break
 
-    affinity_found = False
-    for node_selector_term in start_step["affinity"]["nodeAffinity"][
-        "requiredDuringSchedulingIgnoredDuringExecution"
-    ]["nodeSelectorTerms"]:
-        if exists_nvidia_accelerator(node_selector_term):
-            affinity_found = True
-            break
-    assert affinity_found
+#     affinity_found = False
+#     for node_selector_term in start_step["affinity"]["nodeAffinity"][
+#         "requiredDuringSchedulingIgnoredDuringExecution"
+#     ]["nodeSelectorTerms"]:
+#         if exists_nvidia_accelerator(node_selector_term):
+#             affinity_found = True
+#             break
+#     assert affinity_found
 
-    toleration_found = False
-    for toleration in start_step["tolerations"]:
-        if is_nvidia_accelerator_noschedule(toleration):
-            toleration_found = True
-            break
-    assert toleration_found
+#     toleration_found = False
+#     for toleration in start_step["tolerations"]:
+#         if is_nvidia_accelerator_noschedule(toleration):
+#             toleration_found = True
+#             break
+#     assert toleration_found
 
 
-@pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
-def test_flows(pytestconfig, flow_file_path: str) -> None:
-    full_path = join("flows", flow_file_path)
-    # In the process below, stdout=PIPE because we only want to capture stdout.
-    # The reason is that the click echo function prints to stderr, and contains
-    # the main logs (run link, graph validation, package uploading, etc). We
-    # want to ensure these logs are visible to users and not captured.
-    # We use the print function in kfp_cli.py to print a magic token containing the
-    # run id and capture this to correctly test logging. See the
-    # `check_valid_logs_process` process.
+# @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
+# def test_flows(pytestconfig, flow_file_path: str) -> None:
+#     full_path = join("flows", flow_file_path)
+#     # In the process below, stdout=PIPE because we only want to capture stdout.
+#     # The reason is that the click echo function prints to stderr, and contains
+#     # the main logs (run link, graph validation, package uploading, etc). We
+#     # want to ensure these logs are visible to users and not captured.
+#     # We use the print function in kfp_cli.py to print a magic token containing the
+#     # run id and capture this to correctly test logging. See the
+#     # `check_valid_logs_process` process.
 
-    test_cmd = (
-        f"{_python()} {full_path} --datastore=s3 kfp run "
-        f"--wait-for-completion --workflow-timeout 1800 "
-        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
-    )
-    if pytestconfig.getoption("image"):
-        test_cmd += (
-            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-        )
+#     test_cmd = (
+#         f"{_python()} {full_path} --datastore=s3 kfp run "
+#         f"--wait-for-completion --workflow-timeout 1800 "
+#         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+#     )
+#     if pytestconfig.getoption("image"):
+#         test_cmd += (
+#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+#         )
 
-    run_and_wait_process = run(
-        test_cmd,
-        universal_newlines=True,
-        stdout=PIPE,
-        shell=True,
-    )
-    assert run_and_wait_process.returncode == 0
+#     run_and_wait_process = run(
+#         test_cmd,
+#         universal_newlines=True,
+#         stdout=PIPE,
+#         shell=True,
+#     )
+#     assert run_and_wait_process.returncode == 0
 
-    return
+#     return

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -207,9 +207,9 @@ def exponential_backoff_from_kfam_errors(kfp_run_cmd: str, correct_return_code: 
     # as well as output to stdout and stderr (which users can see on the Gitlab logs). We check
     # if the error message is due to a KFAM issue, and if so, we do an exponential backoff.
 
-    backoff_intervals = [0, 2, 4, 8, 16, 32]
+    backoff_intervals_in_seconds = [0, 2, 4, 8, 16, 32]
 
-    for interval in backoff_intervals:
+    for interval in backoff_intervals_in_seconds:
         time.sleep(interval)
 
         run_and_wait_process = run(

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -70,7 +70,7 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
 
 def test_s3_sensor_flow(pytestconfig) -> None:
     # ensure the s3_sensor waits for some time before the key exists
-    file_name = f"{uuid.uuid1()}.txt"
+    file_name = f"s3-sensor-file-{uuid.uuid1()}.txt"
 
     upload_to_s3_flow_cmd = (
         f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -79,8 +79,8 @@ def test_s3_sensor_flow(pytestconfig) -> None:
 
     main_config_cmds = (
         f"--workflow-timeout 1800 "
-        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
-        f"--file_name {file_name} --env {pytestconfig.getoption('env')} "
+        f"--experiment metaflow_test --tag test_t1 "
+        f"--file_name {file_name} "
     )
     upload_to_s3_flow_cmd += main_config_cmds
     s3_sensor_flow_cmd += main_config_cmds
@@ -115,7 +115,7 @@ def test_raise_failure_flow(pytestconfig) -> None:
     test_cmd = (
         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
-        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+        f"--experiment metaflow_test --tag test_t1 "
     )
     if pytestconfig.getoption("image"):
         test_cmd += (

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -65,17 +65,17 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
 
 
 def test_s3_sensor_flow(pytestconfig) -> None:
-    # ensure the s3_sensor needs to wait for some time before the key exists
+    # ensure the s3_sensor waits for some time before the key exists
     random_string = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(15))
     file_name = f"{random_string}.txt"
 
     upload_to_s3_flow_cmd = f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
-    s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run "
+    s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
 
     main_config_cmds = (
-        f"--wait-for-completion --workflow-timeout 1800 "
+        f"--workflow-timeout 1800 "
         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
-        f"--file_name {file_name} --env {pytestconfig.getoption('env')}"
+        f"--file_name {file_name} --env {pytestconfig.getoption('env')} "
     )
     upload_to_s3_flow_cmd += main_config_cmds
     s3_sensor_flow_cmd += main_config_cmds
@@ -87,45 +87,47 @@ def test_s3_sensor_flow(pytestconfig) -> None:
         upload_to_s3_flow_cmd += image_cmds
         s3_sensor_flow_cmd += image_cmds
 
-    run_and_wait_process = run(
-        s3_sensor_flow_cmd,
-        universal_newlines=True,
-        stdout=PIPE,
-        shell=True,
-    )
-    # force s3_sensor to wait for file to arrive to do a real test
-    time.sleep(30)
-    run_and_wait_process = run(
+    upload_file_run_and_wait_process = run(
         upload_to_s3_flow_cmd,
         universal_newlines=True,
         stdout=PIPE,
         shell=True,
     )
+    s3_sensor_run_and_wait_process = run(
+        s3_sensor_flow_cmd,
+        universal_newlines=True,
+        stdout=PIPE,
+        shell=True,
+    )
+
+    assert s3_sensor_run_and_wait_process.returncode == 0
+
+    return
 
 
 # this test ensures the integration tests fail correctly
-# def test_raise_failure_flow(pytestconfig) -> None:
-#     test_cmd = (
-#         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
-#         f"--wait-for-completion --workflow-timeout 1800 "
-#         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
-#     )
-#     if pytestconfig.getoption("image"):
-#         test_cmd += (
-#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-#         )
+def test_raise_failure_flow(pytestconfig) -> None:
+    test_cmd = (
+        f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
+        f"--wait-for-completion --workflow-timeout 1800 "
+        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+    )
+    if pytestconfig.getoption("image"):
+        test_cmd += (
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+        )
 
-#     run_and_wait_process = run(
-#         test_cmd,
-#         universal_newlines=True,
-#         stdout=PIPE,
-#         shell=True,
-#     )
-#     # this ensures the integration testing framework correctly catches a failing flow
-#     # and reports the error
-#     assert run_and_wait_process.returncode == 1
+    run_and_wait_process = run(
+        test_cmd,
+        universal_newlines=True,
+        stdout=PIPE,
+        shell=True,
+    )
+    # this ensures the integration testing framework correctly catches a failing flow
+    # and reports the error
+    assert run_and_wait_process.returncode == 1
 
-#     return
+    return
 
 
 def exists_nvidia_accelerator(node_selector_term: Dict) -> bool:
@@ -150,78 +152,78 @@ def is_nvidia_accelerator_noschedule(toleration: Dict) -> bool:
     return False
 
 
-# def test_compile_only_accelerator_test() -> None:
-#     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
-#         yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
+def test_compile_only_accelerator_test() -> None:
+    with tempfile.TemporaryDirectory() as yaml_tmp_dir:
+        yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
 
-#         compile_to_yaml_cmd = (
-#             f"{_python()} flows/accelerator_flow.py --datastore=s3 kfp run "
-#             f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
-#         )
+        compile_to_yaml_cmd = (
+            f"{_python()} flows/accelerator_flow.py --datastore=s3 kfp run "
+            f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
+        )
 
-#         compile_to_yaml_process = run(
-#             compile_to_yaml_cmd,
-#             universal_newlines=True,
-#             stdout=PIPE,
-#             shell=True,
-#         )
-#         assert compile_to_yaml_process.returncode == 0
+        compile_to_yaml_process = run(
+            compile_to_yaml_cmd,
+            universal_newlines=True,
+            stdout=PIPE,
+            shell=True,
+        )
+        assert compile_to_yaml_process.returncode == 0
 
-#         with open(f"{yaml_file_path}", "r") as stream:
-#             try:
-#                 flow_yaml = yaml.safe_load(stream)
-#             except yaml.YAMLError as exc:
-#                 print(exc)
+        with open(f"{yaml_file_path}", "r") as stream:
+            try:
+                flow_yaml = yaml.safe_load(stream)
+            except yaml.YAMLError as exc:
+                print(exc)
 
-#         for step in flow_yaml["spec"]["templates"]:
-#             if step["name"] == "start":
-#                 start_step = step
-#                 break
+        for step in flow_yaml["spec"]["templates"]:
+            if step["name"] == "start":
+                start_step = step
+                break
 
-#     affinity_found = False
-#     for node_selector_term in start_step["affinity"]["nodeAffinity"][
-#         "requiredDuringSchedulingIgnoredDuringExecution"
-#     ]["nodeSelectorTerms"]:
-#         if exists_nvidia_accelerator(node_selector_term):
-#             affinity_found = True
-#             break
-#     assert affinity_found
+    affinity_found = False
+    for node_selector_term in start_step["affinity"]["nodeAffinity"][
+        "requiredDuringSchedulingIgnoredDuringExecution"
+    ]["nodeSelectorTerms"]:
+        if exists_nvidia_accelerator(node_selector_term):
+            affinity_found = True
+            break
+    assert affinity_found
 
-#     toleration_found = False
-#     for toleration in start_step["tolerations"]:
-#         if is_nvidia_accelerator_noschedule(toleration):
-#             toleration_found = True
-#             break
-#     assert toleration_found
+    toleration_found = False
+    for toleration in start_step["tolerations"]:
+        if is_nvidia_accelerator_noschedule(toleration):
+            toleration_found = True
+            break
+    assert toleration_found
 
 
-# @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
-# def test_flows(pytestconfig, flow_file_path: str) -> None:
-#     full_path = join("flows", flow_file_path)
-#     # In the process below, stdout=PIPE because we only want to capture stdout.
-#     # The reason is that the click echo function prints to stderr, and contains
-#     # the main logs (run link, graph validation, package uploading, etc). We
-#     # want to ensure these logs are visible to users and not captured.
-#     # We use the print function in kfp_cli.py to print a magic token containing the
-#     # run id and capture this to correctly test logging. See the
-#     # `check_valid_logs_process` process.
+@pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
+def test_flows(pytestconfig, flow_file_path: str) -> None:
+    full_path = join("flows", flow_file_path)
+    # In the process below, stdout=PIPE because we only want to capture stdout.
+    # The reason is that the click echo function prints to stderr, and contains
+    # the main logs (run link, graph validation, package uploading, etc). We
+    # want to ensure these logs are visible to users and not captured.
+    # We use the print function in kfp_cli.py to print a magic token containing the
+    # run id and capture this to correctly test logging. See the
+    # `check_valid_logs_process` process.
 
-#     test_cmd = (
-#         f"{_python()} {full_path} --datastore=s3 kfp run "
-#         f"--wait-for-completion --workflow-timeout 1800 "
-#         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
-#     )
-#     if pytestconfig.getoption("image"):
-#         test_cmd += (
-#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-#         )
+    test_cmd = (
+        f"{_python()} {full_path} --datastore=s3 kfp run "
+        f"--wait-for-completion --workflow-timeout 1800 "
+        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+    )
+    if pytestconfig.getoption("image"):
+        test_cmd += (
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+        )
 
-#     run_and_wait_process = run(
-#         test_cmd,
-#         universal_newlines=True,
-#         stdout=PIPE,
-#         shell=True,
-#     )
-#     assert run_and_wait_process.returncode == 0
+    run_and_wait_process = run(
+        test_cmd,
+        universal_newlines=True,
+        stdout=PIPE,
+        shell=True,
+    )
+    assert run_and_wait_process.returncode == 0
 
-#     return
+    return

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -16,8 +16,7 @@ import tempfile
 
 import time
 
-import random
-import string
+import uuid
 
 """
 To run these tests from your terminal, go to the tests directory and run: 
@@ -50,24 +49,23 @@ def _python():
         return "python"
 
 
+non_standard_test_flows = ["raise_error_flow.py", "accelerator_flow.py", "s3_sensor_flow.py", "upload_to_s3_flow.py"]
+
+
 def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
     file_paths = [
         file_name
         for file_name in listdir(flow_dir_path)
         if isfile(join(flow_dir_path, file_name))
         and not file_name.startswith(".")
-        and not "raise_error_flow" in file_name
-        and not "accelerator_flow" in file_name
-        and not "s3_sensor_flow" in file_name
-        and not "upload_to_s3_flow" in file_name
+        and not file_name in non_standard_test_flows
     ]
     return file_paths
 
 
 def test_s3_sensor_flow(pytestconfig) -> None:
     # ensure the s3_sensor waits for some time before the key exists
-    random_string = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(15))
-    file_name = f"{random_string}.txt"
+    file_name = f"{uuid.uuid1()}.txt"
 
     upload_to_s3_flow_cmd = f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
     s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "

--- a/metaflow/plugins/kfp/tests/test_kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/tests/test_kfp_s3_sensor.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from metaflow.plugins.kfp.kfp_s3_sensor import wait_for_s3_path
 
 from unittest.mock import call, Mock, patch, PropertyMock
@@ -5,9 +6,14 @@ import pytest
 
 import boto3
 from botocore.exceptions import ClientError
+from moto import mock_s3
+
+import tempfile
 
 import base64
 import marshal
+
+import os
 
 """
 To run these tests from your terminal, go to the root directory and run:
@@ -22,6 +28,68 @@ for the integration tests.
 
 def identity_formatter(path: str, flow_parameters: dict) -> str:
     return path
+
+
+@mock_s3
+@pytest.mark.parametrize(
+    "upload_bucket, upload_key, upload_path, processed_path, flow_parameters_json, os_vars",
+    [
+        (
+            "sample_bucket",
+            "sample_prefix/sample_file.txt",
+            "s3://sample_bucket/sample_prefix/sample_file.txt",
+            "s3://sample_bucket/sample_prefix/sample_file.txt",
+            '{"key": "value"}',
+            False,
+        ),
+        (
+            "sample_bucket",
+            "sample_prefix/date=07-02-2021/sample.txt",
+            "s3://sample_bucket/sample_prefix/date={date}/sample.txt",
+            "s3://sample_bucket/sample_prefix/date=07-02-2021/sample.txt",
+            '{"date": "07-02-2021"}',
+            False,
+        ),
+        (
+            "sample_bucket",
+            "sample_prefix/date=08-03-2022/sample.txt",
+            "s3://sample_bucket/sample_prefix/date=$DATE/sample.txt",
+            "s3://sample_bucket/sample_prefix/date=08-03-2022/sample.txt",
+            '{"key": "value"}',
+            True,
+        ),
+    ],
+)
+def test_wait_for_s3_path_no_exception(
+    upload_bucket: str,
+    upload_key: str,
+    upload_path: str,
+    processed_path: str,
+    flow_parameters_json: str,
+    os_vars: bool,
+):
+    os.environ["DATE"] = "08-03-2022"
+
+    identity_formatter_code_encoded = base64.b64encode(
+        marshal.dumps(identity_formatter.__code__)
+    ).decode("ascii")
+
+    upload_file = tempfile.NamedTemporaryFile()
+
+    s3 = boto3.resource("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=upload_bucket)
+    s3.meta.client.upload_file(upload_file.name, upload_bucket, upload_key)
+
+    path = wait_for_s3_path(
+        path=upload_path,
+        timeout_seconds=1,
+        polling_interval_seconds=1,
+        path_formatter_code_encoded=identity_formatter_code_encoded,
+        flow_parameters_json=flow_parameters_json,
+        os_vars=os_vars,
+    )
+
+    assert path == processed_path
 
 
 # This test ensures a timeout exception is raised when wait_for_s3_path
@@ -39,4 +107,5 @@ def test_wait_for_s3_path_timeout_exception():
             polling_interval_seconds=1,
             path_formatter_code_encoded=identity_formatter_code_encoded,
             flow_parameters_json='{"key": "value"}',
+            os_vars=False,
         )

--- a/metaflow/plugins/kfp/tests/test_kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/tests/test_kfp_s3_sensor.py
@@ -32,7 +32,7 @@ def identity_formatter(path: str, flow_parameters: dict) -> str:
 
 @mock_s3
 @pytest.mark.parametrize(
-    "upload_bucket, upload_key, upload_path, processed_path, flow_parameters_json, os_vars",
+    "upload_bucket, upload_key, upload_path, processed_path, flow_parameters_json, os_expandvars",
     [
         (
             "sample_bucket",
@@ -60,13 +60,13 @@ def identity_formatter(path: str, flow_parameters: dict) -> str:
         ),
     ],
 )
-def test_wait_for_s3_path_no_exception(
+def test_wait_for_s3_path(
     upload_bucket: str,
     upload_key: str,
     upload_path: str,
     processed_path: str,
     flow_parameters_json: str,
-    os_vars: bool,
+    os_expandvars: bool,
 ):
     os.environ["DATE"] = "08-03-2022"
 
@@ -86,7 +86,7 @@ def test_wait_for_s3_path_no_exception(
         polling_interval_seconds=1,
         path_formatter_code_encoded=identity_formatter_code_encoded,
         flow_parameters_json=flow_parameters_json,
-        os_vars=os_vars,
+        os_expandvars=os_expandvars,
     )
 
     assert path == processed_path
@@ -107,5 +107,5 @@ def test_wait_for_s3_path_timeout_exception():
             polling_interval_seconds=1,
             path_formatter_code_encoded=identity_formatter_code_encoded,
             flow_parameters_json='{"key": "value"}',
-            os_vars=False,
+            os_expandvars=False,
         )

--- a/metaflow/plugins/kfp/tests/test_kfp_s3_sensor.py
+++ b/metaflow/plugins/kfp/tests/test_kfp_s3_sensor.py
@@ -1,0 +1,42 @@
+from metaflow.plugins.kfp.kfp_s3_sensor import wait_for_s3_path
+
+from unittest.mock import call, Mock, patch, PropertyMock
+import pytest
+
+import boto3
+from botocore.exceptions import ClientError
+
+import base64
+import marshal
+
+"""
+To run these tests from your terminal, go to the root directory and run:
+
+`python -m pytest metaflow/plugins/kfp/tests/test_kfp_s3_sensor.py -c /dev/null`
+
+The `-c` flag above tells PyTest to ignore the setup.cfg config file which is used
+for the integration tests.
+
+"""
+
+
+def identity_formatter(path: str, flow_parameters: dict) -> str:
+    return path
+
+
+# This test ensures a timeout exception is raised when wait_for_s3_path
+# looks for a nonexistent S3 path. This ensures we don't have an idle
+# pod using up resources continuously.
+def test_wait_for_s3_path_timeout_exception():
+    identity_formatter_code_encoded = base64.b64encode(
+        marshal.dumps(identity_formatter.__code__)
+    ).decode("ascii")
+
+    with pytest.raises(TimeoutError):
+        wait_for_s3_path(
+            path="s3://sample_bucket/sample_prefix/sample_key",
+            timeout_seconds=1,
+            polling_interval_seconds=1,
+            path_formatter_code_encoded=identity_formatter_code_encoded,
+            flow_parameters_json='{"key": "value"}',
+        )


### PR DESCRIPTION
`@s3_sensor` is implemented as a flow decorator that's used by customers to ensure a workflow only begins after a key in S3 has been written to.

The customer provides an S3 `path`, a `timeout` parameter to govern how long to wait for the path, a `polling_interval` to determine how often to check for the path, and a `formatter` function which takes as parameters `path` and `flow_parameters_json` to modify the path to their needs.

`path` must be in the format `s3://[S3_bucket]/[S3_key]`.