### PR TITLE
AIP-4521 (sub branch) - Removing hardcoded @resources

### DIFF
--- a/metaflow/plugins/kfp/tests/flows/accelerator_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/accelerator_flow.py
@@ -5,25 +5,11 @@ from metaflow import FlowSpec, step, resources, accelerator
 
 class AcceleratorFlow(FlowSpec):
     @accelerator(type="nvidia-tesla-v100")
-    @resources(
-        local_storage="100",
-        local_storage_limit="242",
-        cpu="0.1",
-        cpu_limit="0.6",
-        memory="1G",
-        memory_limit="2G",
-    )
     @step
     def start(self):
         print("This step simulates usage of a nvidia-tesla-v100 GPU.")
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def end(self):
         print("All done.")

--- a/metaflow/plugins/kfp/tests/flows/failure_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/failure_flow.py
@@ -7,12 +7,6 @@ from metaflow.exception import MetaflowExceptionWrapper
 
 
 class FailureFlow(FlowSpec):
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @retry
     @step
     def start(self):
@@ -23,12 +17,6 @@ class FailureFlow(FlowSpec):
             print("let's succeed")
         self.next(self.no_retry)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @retry(times=0)
     @step
     def no_retry(self):
@@ -37,12 +25,6 @@ class FailureFlow(FlowSpec):
         assert self.retry_count == 1
         self.next(self.compute)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @catch(var="compute_failed")
     @retry(times=0)
     @step
@@ -50,12 +32,6 @@ class FailureFlow(FlowSpec):
         self.x = 1 / 0
         self.next(self.platform_exception)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @catch(var="platform_exception_failed")
     @retry(times=1)
     @step
@@ -67,12 +43,6 @@ class FailureFlow(FlowSpec):
         os.kill(os.getpid(), signal.SIGKILL)
         self.next(self.timeout)
     
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @catch(print_exception=False, var="timeout_exception")
     @timeout(seconds=3)
     @step
@@ -96,12 +66,6 @@ class FailureFlow(FlowSpec):
             time.sleep(1)
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def end(self):
         assert (

--- a/metaflow/plugins/kfp/tests/flows/foreach_linear_foreach.py
+++ b/metaflow/plugins/kfp/tests/flows/foreach_linear_foreach.py
@@ -6,94 +6,40 @@ class ForeachLinearForeach(FlowSpec):
     foreach -> linear -> linear -> foreach -> linear -> linear -> join
     """
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def start(self):
         self.x = "ab"
         self.next(self.linear_1, foreach="x")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def linear_1(self):
         self.next(self.linear_2)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def linear_2(self):
         self.next(self.foreach_split_z)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_split_z(self):
         self.z = "ef"
         self.next(self.linear_3, foreach="z")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def linear_3(self):
         self.next(self.linear_4)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def linear_4(self):
         self.next(self.foreach_join_z)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_z(self, inputs):
         self.next(self.foreach_join_start)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_start(self, inputs):
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def end(self):
         pass

--- a/metaflow/plugins/kfp/tests/flows/foreach_linear_split.py
+++ b/metaflow/plugins/kfp/tests/flows/foreach_linear_split.py
@@ -6,145 +6,61 @@ class ForeachLinearSplit(FlowSpec):
     foreach -> linear -> split -> linear -> foreach -> join
     """
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def start(self):
         self.x = "ab"
         self.next(self.linear_1, foreach="x")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def linear_1(self):
         self.next(self.split_a_and_b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def split_a_and_b(self):
         self.next(self.a, self.b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def a(self):
         self.next(self.foreach_split_a)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def b(self):
         self.next(self.foreach_split_b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_split_a(self):
         self.z = "ef"
         self.next(self.linear_2, foreach="z")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_split_b(self):
         self.z = "ef"
         self.next(self.linear_3, foreach="z")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def linear_2(self):
         self.next(self.foreach_join_a)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def linear_3(self):
         self.next(self.foreach_join_b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_a(self, inputs):
         self.next(self.join_a_and_b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_b(self, inputs):
         self.next(self.join_a_and_b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def join_a_and_b(self, inputs):
         self.next(self.foreach_join_start)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_start(self, inputs):
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def end(self):
         pass

--- a/metaflow/plugins/kfp/tests/flows/foreach_split_linear.py
+++ b/metaflow/plugins/kfp/tests/flows/foreach_split_linear.py
@@ -6,115 +6,49 @@ class ForeachSplitLinear(FlowSpec):
     foreach -> split -> linear -> foreach -> linear -> join
     """
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def start(self):
         self.x = "ab"
         self.next(self.split_a_b, foreach="x")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def split_a_b(self):
         self.next(self.a, self.b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def a(self):
         self.z = "aa"
         self.next(self.linear_1, foreach="z")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def b(self):
         self.z = "bb"
         self.next(self.linear_2, foreach="z")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def linear_1(self):
         self.next(self.foreach_join_a)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def linear_2(self):
         self.next(self.foreach_join_b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_a(self, inputs):
         self.next(self.foreach_join_a_and_b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_b(self, inputs):
         self.next(self.foreach_join_a_and_b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_a_and_b(self, inputs):
         self.next(self.foreach_join_start)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_start(self, inputs):
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def end(self):
         pass

--- a/metaflow/plugins/kfp/tests/flows/kfp_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/kfp_flow.py
@@ -28,12 +28,6 @@ class KfpFlow(FlowSpec):
         self.divisor = 7
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @kfp(
         preceding_component=div_mod,
         preceding_component_inputs="dividend divisor",

--- a/metaflow/plugins/kfp/tests/flows/merge_artifacts.py
+++ b/metaflow/plugins/kfp/tests/flows/merge_artifacts.py
@@ -8,23 +8,11 @@ class MergeArtifacts(FlowSpec):
     split -> join -> split -> join
     """
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def start(self):
         self.pass_down = "a"
         self.next(self.a, self.b)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def a(self):
         assert self.pass_down == "a"
@@ -35,12 +23,6 @@ class MergeArtifacts(FlowSpec):
         self.from_a = 6
         self.next(self.join)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def b(self):
         assert self.pass_down == "a"
@@ -50,12 +32,6 @@ class MergeArtifacts(FlowSpec):
         self.y = 4
         self.next(self.join)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def join(self, inputs):
         # Ensuring conflicting artifacts must be resolved
@@ -72,44 +48,20 @@ class MergeArtifacts(FlowSpec):
         assert self.from_a == 6
         self.next(self.c)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def c(self):
         self.next(self.d, self.e)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def d(self):
         self.conflicting = 7
         self.next(self.join2)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def e(self):
         self.conflicting = 8
         self.next(self.join2)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def join2(self, inputs):
         assert inputs.d.conflicting == 7
@@ -124,12 +76,6 @@ class MergeArtifacts(FlowSpec):
         assert self.common == 5
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def end(self):
         pass

--- a/metaflow/plugins/kfp/tests/flows/metadata_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/metadata_flow.py
@@ -7,12 +7,6 @@ from random import random
 class MetadataFlow(FlowSpec):
     start_message = "MetadataFlow is starting."
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def start(self):
         print(self.start_message)
@@ -20,12 +14,6 @@ class MetadataFlow(FlowSpec):
         print("self.x", self.x)
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def end(self):
         start_step: Step = Step(f"{current.flow_name}/{current.run_id}/start")

--- a/metaflow/plugins/kfp/tests/flows/nested_foreach_with_branching.py
+++ b/metaflow/plugins/kfp/tests/flows/nested_foreach_with_branching.py
@@ -7,100 +7,46 @@ class NestedForeachWithBranching(FlowSpec):
           -> split -> join  (with above split)
     """
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def start(self):
         self.next(self.foreach_split_x, self.split_w)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_split_x(self):
         self.x = "ab"
         self.next(self.foreach_split_y, foreach="x")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def split_w(self):
         self.var1 = 100
         self.next(self.w1, self.w2)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def w1(self):
         self.var1 = 150
         self.next(self.join_w)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def w2(self):
         self.var1 = 250
         self.next(self.join_w)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def join_w(self, w_inp):
         self.var1 = w_inp.w1.var1
         assert self.var1 == 150
         self.next(self.foreach_join_w_x)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_split_y(self):
         self.y = "cd"
         self.next(self.foreach_split_z, foreach="y")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_split_z(self):
         self.z = "ef"
         self.next(self.foreach_inner, foreach="z")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_inner(self):
         [x, y, z] = self.foreach_stack()
@@ -118,64 +64,29 @@ class NestedForeachWithBranching(FlowSpec):
         self.combo = x[2] + y[2] + z[2]
         self.next(self.foreach_inner_2)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_inner_2(self):
         assert self.input in "ef"
         self.next(self.foreach_join_z)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_z(self, inputs):
         self.next(self.foreach_join_y)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_y(self, inputs):
         self.next(self.foreach_join_start)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def foreach_join_start(self, inputs):
         self.next(self.foreach_join_w_x)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
+
     @step
     def foreach_join_w_x(self, input):
         assert input.join_w.var1 == 150
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def end(self):
         pass

--- a/metaflow/plugins/kfp/tests/flows/raise_error_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/raise_error_flow.py
@@ -9,34 +9,16 @@ class RaiseErrorFlow(FlowSpec):
     to fail, and we ensure the integration test detects that.
     """
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def start(self):
         print("This step should complete successfuly!")
         self.next(self.error_step)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def error_step(self):
         raise Exception("This exception is intended to test the integration test!")
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M"
-    )
     @step
     def end(self):
         print("This step should not be reachable!")

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -136,13 +136,6 @@ class ResourcesFlow(FlowSpec):
         self.items = [1, 2]
         self.next(self.split_step, foreach="items")
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M",
-        volume="11G"
-    )
     @step
     def split_step(self):
         output = subprocess.check_output(
@@ -151,13 +144,6 @@ class ResourcesFlow(FlowSpec):
         assert "11G" in str(output)
         self.next(self.join_step)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M",
-        volume="12G"
-    )
     @step
     def join_step(self, inputs):
         output = subprocess.check_output(
@@ -167,13 +153,6 @@ class ResourcesFlow(FlowSpec):
 
         self.next(self.end)
 
-    @resources(
-        cpu="0.1",
-        cpu_limit="0.5",
-        memory="10M",
-        memory_limit="500M",
-        volume="11G"
-    )
     @step
     def end(self):
         print("All done.")

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -136,6 +136,7 @@ class ResourcesFlow(FlowSpec):
         self.items = [1, 2]
         self.next(self.split_step, foreach="items")
 
+    @resources(volume="11G")
     @step
     def split_step(self):
         output = subprocess.check_output(
@@ -144,6 +145,7 @@ class ResourcesFlow(FlowSpec):
         assert "11G" in str(output)
         self.next(self.join_step)
 
+    @resources(volume="12G")
     @step
     def join_step(self, inputs):
         output = subprocess.check_output(


### PR DESCRIPTION
It turns out that the default limit range for the Kubeflow clusters already help resolve resources issues.

Removing these hardcoded @resources decorator additions and the tests still pass: https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-workflow/aip-metaflow-integration-testing/-/jobs/6907535