### PR TITLE
AIP-4801 - Integration Test for Email on Failure and OpsGenie Alerting

### DIFF
--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -131,7 +131,7 @@ test:internal:
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-internal && 
           export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
+          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg
         "
   artifacts:
     when: always
@@ -166,7 +166,7 @@ test:nonprod:
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-stage &&
           export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
+          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg
         "
   artifacts:
     when: always
@@ -201,7 +201,7 @@ test:prod:
           export KFP_SDK_NAMESPACE=metaflow-integration-testing-prod && 
           export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --cov-config=setup.cfg
+          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg
         "
   artifacts:
     when: always

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -4,3 +4,4 @@ def pytest_addoption(parser):
     committed Metaflow version.
     """
     parser.addoption("--image", action="store", default=None)
+    parser.addoption("--opsgenie-api-token", dest="opsgenie_api_token", action="store", default=None)

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -1,6 +1,9 @@
 from os import listdir
 from os.path import isfile, join
 from subprocess_tee import run
+import json
+import re
+import requests
 from typing import List, Dict
 
 from .... import R
@@ -70,49 +73,80 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
     return file_paths
 
 
-def test_s3_sensor_flow(pytestconfig) -> None:
-    # ensure the s3_sensor waits for some time before the key exists
-    file_name = f"s3-sensor-file-{uuid.uuid1()}.txt"
+# def test_s3_sensor_flow(pytestconfig) -> None:
+#     # ensure the s3_sensor waits for some time before the key exists
+#     file_name = f"s3-sensor-file-{uuid.uuid1()}.txt"
 
-    upload_to_s3_flow_cmd = (
-        f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
-    )
-    s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
+#     upload_to_s3_flow_cmd = (
+#         f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
+#     )
+#     s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
 
-    main_config_cmds = (
-        f"--workflow-timeout 1800 "
-        f"--experiment metaflow_test --tag test_t1 "
-        f"--file_name {file_name} "
-    )
-    upload_to_s3_flow_cmd += main_config_cmds
-    s3_sensor_flow_cmd += main_config_cmds
+#     main_config_cmds = (
+#         f"--workflow-timeout 1800 "
+#         f"--experiment metaflow_test --tag test_t1 "
+#         f"--file_name {file_name} "
+#     )
+#     upload_to_s3_flow_cmd += main_config_cmds
+#     s3_sensor_flow_cmd += main_config_cmds
 
-    if pytestconfig.getoption("image"):
-        image_cmds = (
-            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')} "
-        )
-        upload_to_s3_flow_cmd += image_cmds
-        s3_sensor_flow_cmd += image_cmds
+#     if pytestconfig.getoption("image"):
+#         image_cmds = (
+#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')} "
+#         )
+#         upload_to_s3_flow_cmd += image_cmds
+#         s3_sensor_flow_cmd += image_cmds
 
-    exponential_backoff_from_platform_errors(upload_to_s3_flow_cmd, 0)
-    exponential_backoff_from_platform_errors(s3_sensor_flow_cmd, 0)
+#     exponential_backoff_from_platform_errors(upload_to_s3_flow_cmd, 0)
+#     exponential_backoff_from_platform_errors(s3_sensor_flow_cmd, 0)
 
-    return
+#     return
 
 
 # this test ensures the integration tests fail correctly
-def test_raise_failure_flow(pytestconfig) -> None:
+def test_error_and_opgenie_alert(pytestconfig) -> None:
     test_cmd = (
         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
-        f"--experiment metaflow_test --tag test_t1 "
+        f"--experiment metaflow_test --tag test_t1 --notify "
     )
     if pytestconfig.getoption("image"):
         test_cmd += (
             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
         )
 
-    exponential_backoff_from_platform_errors(test_cmd, 1)
+    kfp_run_id = exponential_backoff_from_platform_errors(test_cmd, 1)
+    # TODO use @secret (when it's released) to store this API key
+    opsgenie_auth_headers = {
+        "Content-Type": "application/json",
+        "Authorization": "GenieKey 21bda224-d719-42e5-aceb-35616eb26a6c"
+    }
+
+    list_alerts_endpoint = (
+        f"https://api.opsgenie.com/v2/alerts?query=description:{kfp_run_id}&limit=1&sort=createdAt&order=des"
+    )
+    list_alerts_response = requests.get(list_alerts_endpoint, headers=opsgenie_auth_headers)
+    assert list_alerts_endpoint.status_code == 200
+
+    list_alerts_response_json = json.loads(list_alerts_response.text)
+    # assert we have found the alert
+    assert len(list_alerts_response_json["data"]) == 1
+    alert_alias = list_alerts_response_json["data"][0]["alias"]
+
+    close_alert_data = {
+        "user": "AIP Integration Testing Service",
+        "source": "AIP Integration Testing Service",
+        "note": "Closing ticket because the test is complete."
+    }
+    close_alert_endpoint = (
+        f"https://api.opsgenie.com/v2/alerts/{alert_alias}/close?identifierType=alias"
+    )
+    close_alert_response = requests.get(
+        close_alert_endpoint,
+        data=json.dumps(close_alert_data),
+        headers=opsgenie_auth_headers
+    )
+    assert close_alert_response.status_code == 200
 
     return
 
@@ -139,72 +173,72 @@ def is_nvidia_accelerator_noschedule(toleration: Dict) -> bool:
     return False
 
 
-def test_compile_only_accelerator_test() -> None:
-    with tempfile.TemporaryDirectory() as yaml_tmp_dir:
-        yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
+# def test_compile_only_accelerator_test() -> None:
+#     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
+#         yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
 
-        compile_to_yaml_cmd = (
-            f"{_python()} flows/accelerator_flow.py --datastore=s3 --with retry kfp run "
-            f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
-        )
+#         compile_to_yaml_cmd = (
+#             f"{_python()} flows/accelerator_flow.py --datastore=s3 --with retry kfp run "
+#             f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
+#         )
 
-        compile_to_yaml_process = run(
-            compile_to_yaml_cmd,
-            universal_newlines=True,
-            shell=True,
-        )
-        assert compile_to_yaml_process.returncode == 0
+#         compile_to_yaml_process = run(
+#             compile_to_yaml_cmd,
+#             universal_newlines=True,
+#             shell=True,
+#         )
+#         assert compile_to_yaml_process.returncode == 0
 
-        with open(f"{yaml_file_path}", "r") as stream:
-            try:
-                flow_yaml = yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
-                print(exc)
+#         with open(f"{yaml_file_path}", "r") as stream:
+#             try:
+#                 flow_yaml = yaml.safe_load(stream)
+#             except yaml.YAMLError as exc:
+#                 print(exc)
 
-        for step in flow_yaml["spec"]["templates"]:
-            if step["name"] == "start":
-                start_step = step
-                break
+#         for step in flow_yaml["spec"]["templates"]:
+#             if step["name"] == "start":
+#                 start_step = step
+#                 break
 
-    affinity_found = False
-    for node_selector_term in start_step["affinity"]["nodeAffinity"][
-        "requiredDuringSchedulingIgnoredDuringExecution"
-    ]["nodeSelectorTerms"]:
-        if exists_nvidia_accelerator(node_selector_term):
-            affinity_found = True
-            break
-    assert affinity_found
+#     affinity_found = False
+#     for node_selector_term in start_step["affinity"]["nodeAffinity"][
+#         "requiredDuringSchedulingIgnoredDuringExecution"
+#     ]["nodeSelectorTerms"]:
+#         if exists_nvidia_accelerator(node_selector_term):
+#             affinity_found = True
+#             break
+#     assert affinity_found
 
-    toleration_found = False
-    for toleration in start_step["tolerations"]:
-        if is_nvidia_accelerator_noschedule(toleration):
-            toleration_found = True
-            break
-    assert toleration_found
+#     toleration_found = False
+#     for toleration in start_step["tolerations"]:
+#         if is_nvidia_accelerator_noschedule(toleration):
+#             toleration_found = True
+#             break
+#     assert toleration_found
 
 
-@pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
-def test_flows(pytestconfig, flow_file_path: str) -> None:
-    full_path = join("flows", flow_file_path)
+# @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
+# def test_flows(pytestconfig, flow_file_path: str) -> None:
+#     full_path = join("flows", flow_file_path)
 
-    test_cmd = (
-        f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
-        f"--wait-for-completion --workflow-timeout 1800 "
-        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
-    )
-    if pytestconfig.getoption("image"):
-        test_cmd += (
-            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-        )
+#     test_cmd = (
+#         f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
+#         f"--wait-for-completion --workflow-timeout 1800 "
+#         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+#     )
+#     if pytestconfig.getoption("image"):
+#         test_cmd += (
+#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+#         )
 
-    exponential_backoff_from_platform_errors(test_cmd, 0)
+#     exponential_backoff_from_platform_errors(test_cmd, 0)
 
-    return
+#     return
 
 
 def exponential_backoff_from_platform_errors(
     kfp_run_cmd: str, correct_return_code: int
-) -> None:
+) -> str:
     # Within this function, we use the special feature of subprocess_tee which allows us
     # to capture both stdout and stderr (akin to stdout=PIPE, stderr=PIPE in the regular subprocess.run)
     # as well as output to stdout and stderr (which users can see on the Gitlab logs). We check
@@ -240,3 +274,5 @@ def exponential_backoff_from_platform_errors(
         raise MetaflowException(
             "KFAM issues not resolved after successive backoff attempts."
         )
+    kfp_run_id = re.search('Metaflow run_id=(.*)\n', run_and_wait_process.stderr).group(1)
+    return kfp_run_id

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -104,7 +104,7 @@ def test_s3_sensor_flow(pytestconfig) -> None:
 
 
 # This test ensures that a flow fails correctly,
-# and when it fails, and OpsGenie email is sent.
+# and when it fails, an OpsGenie email is sent.
 def test_error_and_opsgenie_alert(pytestconfig) -> None:
     test_cmd = (
         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -126,8 +126,6 @@ def test_error_and_opsgenie_alert(pytestconfig) -> None:
         "Authorization": f"GenieKey {pytestconfig.getoption('opsgenie_api_token')}",
     }
 
-    print("opsgenie_auth_headers: ", opsgenie_auth_headers)
-
     # Look for the alert with the correct kfp_run_id in the description.
     list_alerts_endpoint = f"https://api.opsgenie.com/v2/alerts?query=description:{kfp_run_id}&limit=1&sort=createdAt&order=des"
     list_alerts_response = requests.get(

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -123,8 +123,10 @@ def test_error_and_opsgenie_alert(pytestconfig) -> None:
     # TODO use @secret (when it's released) to store this API key
     opsgenie_auth_headers = {
         "Content-Type": "application/json",
-        "Authorization": "GenieKey 21bda224-d719-42e5-aceb-35616eb26a6c",
+        "Authorization": f"GenieKey {pytestconfig.getoption('opsgenie_api_token')}",
     }
+
+    print("opsgenie_auth_headers: ", opsgenie_auth_headers)
 
     # Look for the alert with the correct kfp_run_id in the description.
     list_alerts_endpoint = f"https://api.opsgenie.com/v2/alerts?query=description:{kfp_run_id}&limit=1&sort=createdAt&order=des"

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -120,7 +120,6 @@ def test_error_and_opsgenie_alert(pytestconfig) -> None:
         )
 
     kfp_run_id = exponential_backoff_from_platform_errors(test_cmd, 1)
-    # TODO use @secret (when it's released) to store this API key
     opsgenie_auth_headers = {
         "Content-Type": "application/json",
         "Authorization": f"GenieKey {pytestconfig.getoption('opsgenie_api_token')}",

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -73,39 +73,41 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
     return file_paths
 
 
-# def test_s3_sensor_flow(pytestconfig) -> None:
-#     # ensure the s3_sensor waits for some time before the key exists
-#     file_name = f"s3-sensor-file-{uuid.uuid1()}.txt"
+def test_s3_sensor_flow(pytestconfig) -> None:
+    # ensure the s3_sensor waits for some time before the key exists
+    file_name = f"s3-sensor-file-{uuid.uuid1()}.txt"
 
-#     upload_to_s3_flow_cmd = (
-#         f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
-#     )
-#     s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
+    upload_to_s3_flow_cmd = (
+        f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
+    )
+    s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
 
-#     main_config_cmds = (
-#         f"--workflow-timeout 1800 "
-#         f"--experiment metaflow_test --tag test_t1 "
-#         f"--file_name {file_name} "
-#     )
-#     upload_to_s3_flow_cmd += main_config_cmds
-#     s3_sensor_flow_cmd += main_config_cmds
+    main_config_cmds = (
+        f"--workflow-timeout 1800 "
+        f"--experiment metaflow_test --tag test_t1 "
+        f"--file_name {file_name} "
+    )
+    upload_to_s3_flow_cmd += main_config_cmds
+    s3_sensor_flow_cmd += main_config_cmds
 
-#     if pytestconfig.getoption("image"):
-#         image_cmds = (
-#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')} "
-#         )
-#         upload_to_s3_flow_cmd += image_cmds
-#         s3_sensor_flow_cmd += image_cmds
+    if pytestconfig.getoption("image"):
+        image_cmds = (
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')} "
+        )
+        upload_to_s3_flow_cmd += image_cmds
+        s3_sensor_flow_cmd += image_cmds
 
-#     exponential_backoff_from_platform_errors(upload_to_s3_flow_cmd, 0)
-#     exponential_backoff_from_platform_errors(s3_sensor_flow_cmd, 0)
+    exponential_backoff_from_platform_errors(upload_to_s3_flow_cmd, 0)
+    exponential_backoff_from_platform_errors(s3_sensor_flow_cmd, 0)
 
-#     return
+    return
 
 
-# this test ensures the integration tests fail correctly
-# and that when the test fails, and OpsGenie email is sent
-# and thus an OpsGenie alert arrives correctly.
+# This test ensures the integration tests fail correctly
+# and that when a test fails, an OpsGenie email is sent.
+# It verifies the OpsGenie email has been sent by querying
+# the OpsGenie API to look for the corresponding alert
+# and then closes that alert.
 def test_error_and_opsgenie_alert(pytestconfig) -> None:
     test_cmd = (
         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
@@ -121,34 +123,40 @@ def test_error_and_opsgenie_alert(pytestconfig) -> None:
     # TODO use @secret (when it's released) to store this API key
     opsgenie_auth_headers = {
         "Content-Type": "application/json",
-        "Authorization": "GenieKey 21bda224-d719-42e5-aceb-35616eb26a6c"
+        "Authorization": "GenieKey 21bda224-d719-42e5-aceb-35616eb26a6c",
     }
 
-    list_alerts_endpoint = (
-        f"https://api.opsgenie.com/v2/alerts?query=description:{kfp_run_id}&limit=1&sort=createdAt&order=des"
+    # Look for the alert with the correct kfp_run_id in the description.
+    list_alerts_endpoint = f"https://api.opsgenie.com/v2/alerts?query=description:{kfp_run_id}&limit=1&sort=createdAt&order=des"
+    list_alerts_response = requests.get(
+        list_alerts_endpoint, headers=opsgenie_auth_headers
     )
-    list_alerts_response = requests.get(list_alerts_endpoint, headers=opsgenie_auth_headers)
     assert list_alerts_response.status_code == 200
 
     list_alerts_response_json = json.loads(list_alerts_response.text)
-    # assert we have found the alert
+    # assert we have found the alert (there should only be one alert with that kfp_run_id)
     assert len(list_alerts_response_json["data"]) == 1
     alert_alias = list_alerts_response_json["data"][0]["alias"]
 
     close_alert_data = {
         "user": "AIP Integration Testing Service",
         "source": "AIP Integration Testing Service",
-        "note": "Closing ticket because the test is complete."
+        "note": "Closing ticket because the test is complete.",
     }
     close_alert_endpoint = (
         f"https://api.opsgenie.com/v2/alerts/{alert_alias}/close?identifierType=alias"
     )
-    close_alert_response = requests.get(
+    close_alert_response = requests.post(
         close_alert_endpoint,
         data=json.dumps(close_alert_data),
-        headers=opsgenie_auth_headers
+        headers=opsgenie_auth_headers,
     )
-    assert close_alert_response.status_code == 200
+    # Sometimes the response status code is 202, signaling
+    # the request has been accepted and is being queued for processing.
+    assert (
+        close_alert_response.status_code == 200
+        or close_alert_response.status_code == 202
+    )
 
     return
 
@@ -175,67 +183,67 @@ def is_nvidia_accelerator_noschedule(toleration: Dict) -> bool:
     return False
 
 
-# def test_compile_only_accelerator_test() -> None:
-#     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
-#         yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
+def test_compile_only_accelerator_test() -> None:
+    with tempfile.TemporaryDirectory() as yaml_tmp_dir:
+        yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
 
-#         compile_to_yaml_cmd = (
-#             f"{_python()} flows/accelerator_flow.py --datastore=s3 --with retry kfp run "
-#             f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
-#         )
+        compile_to_yaml_cmd = (
+            f"{_python()} flows/accelerator_flow.py --datastore=s3 --with retry kfp run "
+            f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
+        )
 
-#         compile_to_yaml_process = run(
-#             compile_to_yaml_cmd,
-#             universal_newlines=True,
-#             shell=True,
-#         )
-#         assert compile_to_yaml_process.returncode == 0
+        compile_to_yaml_process = run(
+            compile_to_yaml_cmd,
+            universal_newlines=True,
+            shell=True,
+        )
+        assert compile_to_yaml_process.returncode == 0
 
-#         with open(f"{yaml_file_path}", "r") as stream:
-#             try:
-#                 flow_yaml = yaml.safe_load(stream)
-#             except yaml.YAMLError as exc:
-#                 print(exc)
+        with open(f"{yaml_file_path}", "r") as stream:
+            try:
+                flow_yaml = yaml.safe_load(stream)
+            except yaml.YAMLError as exc:
+                print(exc)
 
-#         for step in flow_yaml["spec"]["templates"]:
-#             if step["name"] == "start":
-#                 start_step = step
-#                 break
+        for step in flow_yaml["spec"]["templates"]:
+            if step["name"] == "start":
+                start_step = step
+                break
 
-#     affinity_found = False
-#     for node_selector_term in start_step["affinity"]["nodeAffinity"][
-#         "requiredDuringSchedulingIgnoredDuringExecution"
-#     ]["nodeSelectorTerms"]:
-#         if exists_nvidia_accelerator(node_selector_term):
-#             affinity_found = True
-#             break
-#     assert affinity_found
+    affinity_found = False
+    for node_selector_term in start_step["affinity"]["nodeAffinity"][
+        "requiredDuringSchedulingIgnoredDuringExecution"
+    ]["nodeSelectorTerms"]:
+        if exists_nvidia_accelerator(node_selector_term):
+            affinity_found = True
+            break
+    assert affinity_found
 
-#     toleration_found = False
-#     for toleration in start_step["tolerations"]:
-#         if is_nvidia_accelerator_noschedule(toleration):
-#             toleration_found = True
-#             break
-#     assert toleration_found
+    toleration_found = False
+    for toleration in start_step["tolerations"]:
+        if is_nvidia_accelerator_noschedule(toleration):
+            toleration_found = True
+            break
+    assert toleration_found
 
 
-# @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
-# def test_flows(pytestconfig, flow_file_path: str) -> None:
-#     full_path = join("flows", flow_file_path)
+@pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
+def test_flows(pytestconfig, flow_file_path: str) -> None:
+    full_path = join("flows", flow_file_path)
 
-#     test_cmd = (
-#         f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
-#         f"--wait-for-completion --workflow-timeout 1800 "
-#         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
-#     )
-#     if pytestconfig.getoption("image"):
-#         test_cmd += (
-#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-#         )
+    test_cmd = (
+        f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
+        f"--wait-for-completion --workflow-timeout 1800 "
+        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+    )
+    if pytestconfig.getoption("image"):
+        test_cmd += (
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+        )
 
-#     exponential_backoff_from_platform_errors(test_cmd, 0)
+    exponential_backoff_from_platform_errors(test_cmd, 0)
 
-#     return
+    return
 
 
 def exponential_backoff_from_platform_errors(
@@ -276,5 +284,7 @@ def exponential_backoff_from_platform_errors(
         raise MetaflowException(
             "KFAM issues not resolved after successive backoff attempts."
         )
-    kfp_run_id = re.search('Metaflow run_id=(.*)\n', run_and_wait_process.stderr).group(1)
+    kfp_run_id = re.search("Metaflow run_id=(.*)\n", run_and_wait_process.stderr).group(
+        1
+    )
     return kfp_run_id

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -104,7 +104,9 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
 
 
 # this test ensures the integration tests fail correctly
-def test_error_and_opgenie_alert(pytestconfig) -> None:
+# and that when the test fails, and OpsGenie email is sent
+# and thus an OpsGenie alert arrives correctly.
+def test_error_and_opsgenie_alert(pytestconfig) -> None:
     test_cmd = (
         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
@@ -126,7 +128,7 @@ def test_error_and_opgenie_alert(pytestconfig) -> None:
         f"https://api.opsgenie.com/v2/alerts?query=description:{kfp_run_id}&limit=1&sort=createdAt&order=des"
     )
     list_alerts_response = requests.get(list_alerts_endpoint, headers=opsgenie_auth_headers)
-    assert list_alerts_endpoint.status_code == 200
+    assert list_alerts_response.status_code == 200
 
     list_alerts_response_json = json.loads(list_alerts_response.text)
     # assert we have found the alert

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -103,11 +103,8 @@ def test_s3_sensor_flow(pytestconfig) -> None:
     return
 
 
-# This test ensures the integration tests fail correctly
-# and that when a test fails, an OpsGenie email is sent.
-# It verifies the OpsGenie email has been sent by querying
-# the OpsGenie API to look for the corresponding alert
-# and then closes that alert.
+# This test ensures that a flow fails correctly,
+# and when it fails, and OpsGenie email is sent.
 def test_error_and_opsgenie_alert(pytestconfig) -> None:
     test_cmd = (
         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "


### PR DESCRIPTION
In this PR, we add some functionality to the `raise_error_flow.py` test, which intentionally fails to ensure the Integration Testing suite itself is working.

In particular, we add `--notify` when launching the test so that when it fails, it sends an email to an OpsGenie email (`aip-workflow-sdk-email-notify-test@zillowgroup.opsgenie.net`). We then use the OpsGenie API to verify an OpsGenie alert was created, and then close that alert.