### PR TITLE
AIP-4600: Refactor Gitlab CI pipeline to include publishing lib to Artifactory

### DIFF
--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 include:
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
-    ref: &include_ref 'alexla/AIP-4600'  # TODO AIP-4600 Replace with v2
+    ref: &include_ref 'v2'
     file: 'environments/devex.yml'
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
     ref: *include_ref

--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -1,135 +1,67 @@
-# Barebones template to ensure pipeline is triggered
 include:
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
-    ref: '6a257a61866f39ee2c8d81e1eafcc19cf9b5d617'
+    ref: &include_ref 'alexla/AIP-4600'  # TODO AIP-4600 Replace with v2
     file: 'environments/devex.yml'
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
-    ref: '6a257a61866f39ee2c8d81e1eafcc19cf9b5d617'
-    file: 'blocks/docker.yml'
+    ref: *include_ref
+    file: '/blocks/python.yml'
 
 variables:
-  ARTIFACT_NAME: "metaflow_integration_testing"
-  ARTIFACT_MAJOR_VERSION: "1"
-  ARTIFACT_MINOR_VERSION: "0"
-  ARTIFACTORY_WEB_APP_URL: https://artifactory.zgtools.net/artifactory/webapp/#/packages/docker
-  _SHARED_ENV_FILE: 'shared.env'
-  _IMAGE_TAG_FILE: 'image_tag_file.txt'
-  # run on internal cluster only (to avoid interfering with customer workloads on nonprod/prod)
+  PY_LIBRARY_NAME: "zillow-metaflow"
+  MAJOR_VERSION: "1"
+  MINOR_VERSION: "0"
+  METAFLOW_VERSION_PATH: "setup.py"
+  IMAGE_REPOSITORY_TAG_PATH: 'image_tag_file.txt'
+  # Run on the Internal cluster only on commit.
+  # We run the tests via the integration test framework for Non-Prod/Prod.
   DEPLOY_INTERNAL: "true"
   DEPLOY_NONPROD: "false"
   DEPLOY_PROD: "false"
 
-.base:job-with-artifacts:
-  artifacts:
-    paths:
-      - ${_SHARED_ENV_FILE}
+stages:
+  - build
+  - test
 
-.init_docker_variables:
-  extends: .base:job-with-artifacts
-  script: &init-docker-variables
-    - 'touch ${_SHARED_ENV_FILE}'
-    - 'export _USER_ID=$(echo ${GITLAB_USER_EMAIL} | sed "s/@.*//")'
-    - 'echo "export _USER_ID=${_USER_ID}" >> ${_SHARED_ENV_FILE}; source ${_SHARED_ENV_FILE}'
-
-    # Setup required environment-variables
-    - 'echo "export _ARTIFACT_VERSION=${ARTIFACT_MAJOR_VERSION}.${ARTIFACT_MINOR_VERSION}" >> ${_SHARED_ENV_FILE}; source ${_SHARED_ENV_FILE}'
-    - 'echo "export _LOCAL_DOCKER_TAG=${ARTIFACT_NAME}:${_ARTIFACT_VERSION}" >> ${_SHARED_ENV_FILE}; source ${_SHARED_ENV_FILE}'
-
-    # Tag: major.minor.commit-sha.branch-name
-    - 'echo "export _EXPANDED_VERSION_DOCKER_IMAGE_NAME=${CI_PROJECT_NAMESPACE}/${ARTIFACT_NAME}" >> ${_SHARED_ENV_FILE}; source ${_SHARED_ENV_FILE}'
-    - 'echo "export _EXPANDED_VERSION_DOCKER_IMAGE_TAG=${_ARTIFACT_VERSION}.${CI_COMMIT_SHORT_SHA}.${CI_COMMIT_REF_SLUG}" >> ${_SHARED_ENV_FILE}; source ${_SHARED_ENV_FILE}'
-
-    # Tag: major.minor.branch-name
-    - 'echo "export _NAMED_VERSION_PROJECT_NAMESPACE=$(echo ${CI_PROJECT_NAMESPACE} | cut -d "/" -f 1)/docker-images/$(echo ${CI_PROJECT_NAMESPACE} | cut -d "/" -f 2-)" >> ${_SHARED_ENV_FILE}; source ${_SHARED_ENV_FILE}'
-    - 'echo "export _NAMED_VERSION_DOCKER_IMAGE_NAME=${_NAMED_VERSION_PROJECT_NAMESPACE}/${ARTIFACT_NAME}" >> ${_SHARED_ENV_FILE}; source ${_SHARED_ENV_FILE}'
-    - 'echo "export _NAMED_VERSION_DOCKER_IMAGE_TAG=${_ARTIFACT_VERSION}.${CI_COMMIT_REF_SLUG}" >> ${_SHARED_ENV_FILE}; source ${_SHARED_ENV_FILE}'
-
-.build_and_push_docker_image:
-  script: &build-and-push-docker-image
-    # Source the artifact from the init job to enable access to shared-env-variables
-    - 'source ${_SHARED_ENV_FILE}'
-    - 'cat ${_SHARED_ENV_FILE}'
-
-    # Build Artifact (i.e: Docker Image) in Gitlab current pipeline-job-container
-    - 'docker build --no-cache -f metaflow/plugins/kfp/tests/Dockerfile -t ${_LOCAL_DOCKER_TAG} .'
-
-    # Function definitions for logging and uploading to docker repository
-    - 'function log_upload_path {
-        DOCKER_IMAGE_NAME=$1;
-        DOCKER_IMAGE_TAG=$2;
-        echo "Project Image Repository -" $(echo ${ARTIFACTORY_WEB_APP_URL}/$(echo "${DOCKER_IMAGE_NAME}" | sed "s/\//~2F/g" | xargs -0 printf "%b"));
-      }'
-
-    - 'function docker_push {
-           LOCAL_DOCKER_TAG=$1;
-           DOCKER_IMAGE_NAME=$2;
-           DOCKER_IMAGE_TAG=$3;
-           export DOCKER_REPO_UPLOAD_PATH=${DOCKER_REPO_URL}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG};
-
-           docker tag ${LOCAL_DOCKER_TAG} ${DOCKER_REPO_UPLOAD_PATH};
-           docker push ${DOCKER_REPO_UPLOAD_PATH};
-           log_upload_path ${DOCKER_IMAGE_NAME} ${DOCKER_IMAGE_TAG};
-       }'
-
-    # Login to docker
-    - 'echo ${DOCKER_API_KEY} | docker login -u ${DOCKER_USERNAME} --password-stdin ${DOCKER_REPO_URL}'
-
-    # Push to artifactory repo (overwrites are NOT allowed to docker-images in this repo)
-    - 'echo "Will run docker push" ${_LOCAL_DOCKER_TAG} ${_EXPANDED_VERSION_DOCKER_IMAGE_NAME} ${_EXPANDED_VERSION_DOCKER_IMAGE_TAG}'
-    - STDERR=$(docker_push ${_LOCAL_DOCKER_TAG} ${_EXPANDED_VERSION_DOCKER_IMAGE_NAME} ${_EXPANDED_VERSION_DOCKER_IMAGE_TAG} 2>&1 >/dev/null) || true
-    - echo $STDERR
-    - |
-      if [ -z "$STDERR" ] || [[ $STDERR == *"manifest invalid"* ]]; then
-        echo "Successful!"
-      else
-        echo "Error in pushing image to Artifactory."
-        exit 1
-      fi
-  
-    - 'echo "built-image-url: ${DOCKER_REPO_URL}/${_EXPANDED_VERSION_DOCKER_IMAGE_NAME}:${_EXPANDED_VERSION_DOCKER_IMAGE_TAG}"'
-   
 .path_to_host_file_directory: # obtains the path to file on the host machine, which is needed to mount a Docker on Docker
   script: &path-to-host-file-directory
   - export CONTAINER_ID=$(docker ps -q -f "label=com.gitlab.gitlab-runner.job.id=$CI_JOB_ID" -f "label=com.gitlab.gitlab-runner.type=build")
   - export MOUNT_NAME=$(docker inspect $CONTAINER_ID -f "{{ range .Mounts }}{{ if eq .Destination \"/builds\" }}{{ .Source }}{{end}}{{end}}")
   - export SHARED_PATH=$MOUNT_NAME/$CI_PROJECT_PATH
-  
-build:
-  stage: build
-  script:
-    - *init-docker-variables
-    - *build-and-push-docker-image
-    - export BUILT_IMAGE_FULL_PATH=${DOCKER_REPO_URL}/${_EXPANDED_VERSION_DOCKER_IMAGE_NAME}:${_EXPANDED_VERSION_DOCKER_IMAGE_TAG}
-    - echo ${BUILT_IMAGE_FULL_PATH} > ${_IMAGE_TAG_FILE} # file _IMAGE_TAG_FILE contains the path to the image
-  artifacts:
-    paths:
-      - ${_IMAGE_TAG_FILE} # we pass this file as an artifact to be read in the testing stages
 
-test:internal:
-  extends: 
-    - .devex_internal_eks # sets up AWS environment variables
-    - .generate_kubeconfig # creates the .kube directory for the appropriate cluster
+.version: &version |
+  # Extract the open source Metaflow version as the basis for our forked library version.
+  METAFLOW_VERSION=$(cat $METAFLOW_VERSION_PATH | sed -nr "s/^version = ['\"]([^'\"]*)['\"]$/\1/p")
+
+  if [ "${CI_COMMIT_BRANCH}" = "${CI_DEFAULT_BRANCH}" ]; then
+    PY_LIBRARY_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}.${METAFLOW_VERSION}"
+  else
+    PY_LIBRARY_VERSION="0.0.${CI_PIPELINE_IID}.${METAFLOW_VERSION}"
+  fi
+  IMAGE_TAG="${PY_LIBRARY_VERSION}"
+
+.test:
+  extends: .generate_kubeconfig
+  stage: test
   variables:
     GIT_STRATEGY: none
     PIPELINE_VERSION: "1.0"
-  stage: test
   script:
-    - *path-to-host-file-directory
-    - export BUILT_IMAGE_FULL_PATH=$( cat ${_IMAGE_TAG_FILE} ) # reading the path to the Docker image on Artifactory
+    - *path-to-host-file-directory  
+    - export BUILT_IMAGE_FULL_PATH=$( cat ${IMAGE_REPOSITORY_TAG_PATH} )
     - cp -r /root/.kube .
     - docker run
         --rm
         -v ${SHARED_PATH}/.kube:/home/zservice/.kube
-        -v ${SHARED_PATH}/public:/home/zservice/public 
+        -v ${SHARED_PATH}/public:/home/zservice/public  
         -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID 
         -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY 
         -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN 
         -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION 
+        -e KFP_RUN_URL_PREFIX=$KFP_RUN_URL_PREFIX 
+        -e KFP_SDK_NAMESPACE=$KFP_SDK_NAMESPACE 
+        -e USER=$GITLAB_USER_EMAIL
         ${BUILT_IMAGE_FULL_PATH}
         bash -c "
-          export KFP_RUN_URL_PREFIX=https://kubeflow.corp.dev-k8s.zg-aip.net/ && 
-          export KFP_SDK_NAMESPACE=metaflow-integration-testing-internal && 
-          export USER=${GITLAB_USER_EMAIL} &&
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
           python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg
         "
@@ -137,75 +69,76 @@ test:internal:
     when: always
     paths:
       - public
+  
+
+build:docker:
+  stage: build
+  script:
+    - *version
+    - export IMAGE_REPOSITORY_TAG=${DOCKER_REPO_URL}/${CI_PROJECT_NAMESPACE}/${PY_LIBRARY_NAME}:${IMAGE_TAG}
+    - 'docker build --no-cache -f metaflow/plugins/kfp/tests/Dockerfile -t ${IMAGE_REPOSITORY_TAG} .'
+    - 'echo ${DOCKER_API_KEY} | docker login -u ${DOCKER_USERNAME} --password-stdin ${DOCKER_REPO_URL}'
+    - STDERR=$(docker push ${IMAGE_REPOSITORY_TAG} 2>&1 >/dev/null) || true
+    - echo $STDERR
+    - |
+      if [ -z "$STDERR" ] || [[ $STDERR == *"manifest invalid"* ]]; then
+        echo "Successful!"
+      else
+        echo "Error in pushing image to Artifactory." >&2
+        exit 1
+      fi
+    - echo ${IMAGE_REPOSITORY_TAG} > ${IMAGE_REPOSITORY_TAG_PATH}
+  artifacts:
+    paths:
+      - ${IMAGE_REPOSITORY_TAG_PATH}
+
+build:publish:
+  extends: .aip_python_debian_image
+  stage: build
+  script:
+  - *version
+  # Now write back the zillow-kfp version back to the original location we found the original so
+  # python package managers can reference it as they need the version stored internally.
+  - sed -i "s/\(version = ['\"]\)[^'\"]*\(['\"]\)/\1${PY_LIBRARY_VERSION}\2/" $METAFLOW_VERSION_PATH
+  - python setup.py sdist
+  # Set up the configuration for Artifactory to publish the python package internally.
+  - |
+    cat >~/.pypirc <<EOL
+    [distutils]
+    index-servers = local
+    [local]
+    repository: ${ANALYTICS_PYPI_REPOSITORY}
+    username: ${PYPI_USERNAME}
+    password: ${PYPI_PASSWORD}
+    EOL
+  - python setup.py sdist upload --repository "${ANALYTICS_PYPI_REPOSITORY}"
+
+test:internal:
+  extends: 
+    - .devex_internal_eks
+    - .test
+  variables:
+    KFP_RUN_URL_PREFIX: "https://kubeflow.corp.dev-k8s.zg-aip.net/"
+    KFP_SDK_NAMESPACE: "metaflow-integration-testing-internal"
   rules:
     - if: '$DEPLOY_INTERNAL == "true"'
 
 test:nonprod:
   extends: 
     - .devex_nonprod_eks
-    - .generate_kubeconfig
+    - .test
   variables:
-    GIT_STRATEGY: none
-    PIPELINE_VERSION: "1.0"
-  stage: test
-  script:
-    - *path-to-host-file-directory  
-    - export BUILT_IMAGE_FULL_PATH=$( cat ${_IMAGE_TAG_FILE} )
-    - cp -r /root/.kube .
-    - docker run
-        --rm
-        -v ${SHARED_PATH}/.kube:/home/zservice/.kube
-        -v ${SHARED_PATH}/public:/home/zservice/public  
-        -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID 
-        -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY 
-        -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN 
-        -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION 
-        ${BUILT_IMAGE_FULL_PATH}
-        bash -c "
-          export KFP_RUN_URL_PREFIX=https://kubeflow.corp.stage-k8s.zg-aip.net/ &&
-          export KFP_SDK_NAMESPACE=metaflow-integration-testing-stage &&
-          export USER=${GITLAB_USER_EMAIL} &&
-          cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg
-        "
-  artifacts:
-    when: always
-    paths:
-      - public
+    KFP_RUN_URL_PREFIX: "https://kubeflow.corp.stage-k8s.zg-aip.net/"
+    KFP_SDK_NAMESPACE: "metaflow-integration-testing-stage"
   rules:
     - if: '$DEPLOY_NONPROD == "true"'
 
 test:prod:
   extends: 
-    - .devex_prod_eks
-    - .generate_kubeconfig
+  - .devex_prod_eks
+  - .test
   variables:
-    GIT_STRATEGY: none
-    PIPELINE_VERSION: "1.0"
-  stage: test
-  script:
-    - *path-to-host-file-directory
-    - export BUILT_IMAGE_FULL_PATH=$( cat ${_IMAGE_TAG_FILE} )
-    - cp -r /root/.kube .
-    - docker run
-        --rm
-        -v ${SHARED_PATH}/.kube:/home/zservice/.kube
-        -v ${SHARED_PATH}/public:/home/zservice/public  
-        -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID 
-        -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY 
-        -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN 
-        -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION  
-        ${BUILT_IMAGE_FULL_PATH}
-        bash -c "
-          export KFP_RUN_URL_PREFIX=https://kubeflow.corp.prod-k8s.zg-aip.net/ && 
-          export KFP_SDK_NAMESPACE=metaflow-integration-testing-prod && 
-          export USER=${GITLAB_USER_EMAIL} &&
-          cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg
-        "
-  artifacts:
-    when: always
-    paths:
-      - public
+    KFP_RUN_URL_PREFIX: "https://kubeflow.corp.prod-k8s.zg-aip.net/"
+    KFP_SDK_NAMESPACE: "metaflow-integration-testing-prod"
   rules:
     - if: '$DEPLOY_PROD == "true"'

--- a/metaflow/plugins/kfp/tests/Dockerfile
+++ b/metaflow/plugins/kfp/tests/Dockerfile
@@ -1,4 +1,8 @@
-FROM analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py36-cpu-cicd:3.2.25c62576.master
+FROM analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py39-cpu:0.1.1334
 COPY . /home/zservice/metaflow
 RUN pip install --upgrade --no-deps --force-reinstall -e /home/zservice/metaflow
-RUN pip install pytest==6.1.2 pytest-xdist==2.1.0 pytest-cov==2.10.1 subprocess-tee==0.3.2
+RUN pip install \
+    pytest==6.1.2 \
+    pytest-xdist==2.1.0 \
+    pytest-cov==2.10.1 \
+    subprocess-tee==0.3.2

--- a/metaflow/plugins/kfp/tests/Dockerfile
+++ b/metaflow/plugins/kfp/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py39-cpu:0.1.1334
+FROM analytics-docker.artifactory.zgtools.net/artificial-intelligence/ai-platform/aip-py39-cpu:4.0.1380
 COPY . /home/zservice/metaflow
 RUN pip install --upgrade --no-deps --force-reinstall -e /home/zservice/metaflow
 RUN pip install \

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,9 @@
 import os
-
 from setuptools import setup, find_packages
 
-version = '2.3.2+zg1.1'
+version = '2.2.5'
 
-# TODO: once this branch is merged or in pip use, remove this
-os.system(
-    "pip3 install 'git+https://github.com/zillow/pipelines@feature/zg#egg=kfp&subdirectory=sdk/python'"
-)
-
-setup(name='metaflow',
+setup(name='zillow-metaflow',
       version=version,
       description='Metaflow: More Data Science, Less Engineering',
       author='Machine Learning Infrastructure Team at Netflix',
@@ -23,12 +17,14 @@ setup(name='metaflow',
         metaflow=metaflow.main_cli:main
       ''',
       install_requires = [
-        'click>=7.0',
+        'click>=7.0,<8',
         'requests',
         'boto3',
-        'kfp',
-        'pylint',
+        'pylint<2.5.0'
       ],
       tests_require = [
         'coverage'
-      ])
+      ],
+      extras_require = {
+        'kfp': 'zillow-kfp'
+      })

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(name='zillow-metaflow',
         'coverage'
       ],
       extras_require = {
-        'kfp': 'zillow-kfp>=1.0'
+        'kfp': 'zillow-kfp'
       })

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(name='zillow-metaflow',
         'coverage'
       ],
       extras_require = {
-        'kfp': 'zillow-kfp'
+        'kfp': 'zillow-kfp>=1.0'
       })


### PR DESCRIPTION
To do:
- [x] Update `setup.py` to depend on new `zillow-kfp` forked package as an optional `extra` - See [this PR](https://github.com/zillow/pipelines/pull/8).
    - We do this as an optional `extra` so the normal `metaflow` tests, run via Github Actions, can remain intact (and also because the `kfp` really is an optional package too!).
- [x] Add in publishing to Artifactory from the Gitlab pipeline.
    - Update `setup.py` to accept `PY_LIBRARY_NAME` and `PY_LIBRARY_VERSION` env vars.
    - Refactor `.gitlab-ci.yml` to improve readability.
    - [x] Remove `when: manual` debug code.
- [ ] ~~Move `.gitlab-ci.yml` to root of repo to improve legibility.~~ - Keep as is, intentional decision to put under `metaflow/plugns/kfp`.
- [ ] ~~Rename `aip-metaflow-integration-testing` mirrored Gitlab repo to `zillow-metaflow` to be consistent with naming convention agreed.~~ - Deferred to https://zbrt.atl.zillow.net/browse/AIP-5066
    - [ ] ~~Update `kubeflow.v1.1` to replace reference in integration tests - Updated via [this PR](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/kubeflow.v1.1/-/merge_requests/175)~~ - Deferred to https://zbrt.atl.zillow.net/browse/AIP-5066