### PR TITLE
AIP-5183 - Fixing regression in @s3_sensor

### DIFF
--- a/metaflow/plugins/kfp/Dockerfile
+++ b/metaflow/plugins/kfp/Dockerfile
@@ -1,0 +1,56 @@
+# Used to create the hsezhiyan/metaflow-zillow:2.1 image.
+# The image is used in two places:
+#   1. In metaflow/plugins/kfp/kfp_constants.py, where it is used as a base image
+#      when the user does not provide their own base image with python flow.py kfp run --base-image...
+#   2. In metaflow/plugins/kfp/kfp.py, where it is used as the base image of the 
+#      s3_sensor_op.
+
+FROM python:3.9.0
+
+WORKDIR /opt/zillow
+
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+        apt-transport-https \
+        apt-utils \
+        bash \
+        build-essential \
+        ca-certificates \
+        curl \
+        dialog \
+        git \
+        isomd5sum \
+        libffi-dev \
+        libmpdec-dev \
+        libssl-dev \
+        sudo \
+        vim \
+        wget \
+        zip \
+        zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip & install poetry
+RUN pip install -U pip==20.0.2 poetry==1.0.10
+ENV POETRY_VIRTUALENVS_CREATE=False
+
+RUN pip install awscli click requests boto3 pytest pytest-xdist
+
+# Create Z_USER with UID=1000 and in the 'users' group
+ARG Z_USER="zservice"
+ARG Z_UID="1000"
+ARG Z_GID="100"
+
+# Configure environment
+ENV SHELL=/bin/bash \
+    Z_USER=$Z_USER \
+    Z_UID=$Z_UID \
+    Z_GID=$Z_GID \
+    HOME=/home/$Z_USER
+
+# Enable users to install packages as root
+RUN echo "%users ALL=(ALL) NOPASSWD:/usr/local/bin/pip" >> /etc/sudoers && \
+    echo "%users ALL=(ALL) NOPASSWD:/usr/local/bin/pip3" >> /etc/sudoers && \
+    echo "%users ALL=(ALL) NOPASSWD:/usr/local/bin/python" >> /etc/sudoers && \
+    echo "%users ALL=(ALL) NOPASSWD:/usr/bin/apt-get" >> /etc/sudoers && \
+    echo "%users ALL=(ALL) NOPASSWD:/usr/bin/apt" >> /etc/sudoers

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -847,8 +847,6 @@ class KubeflowPipelines(object):
 
         s3_sensor_op = func_to_container_op(
             wait_for_s3_path,
-            # We plan to add the Dockerfile of image hsezhiyan/metaflow-zillow:2.0 to this repo
-            # https://zbrt.atl.zillow.net/browse/AIP-4571
             base_image="hsezhiyan/metaflow-zillow:2.1",
         )(
             path=path,

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -849,7 +849,7 @@ class KubeflowPipelines(object):
             wait_for_s3_path,
             # We plan to add the Dockerfile of image hsezhiyan/metaflow-zillow:2.0 to this repo
             # https://zbrt.atl.zillow.net/browse/AIP-4571
-            base_image="hsezhiyan/metaflow-zillow:2.0",
+            base_image="hsezhiyan/metaflow-zillow:2.1",
         )(
             path=path,
             timeout_seconds=timeout_seconds,

--- a/metaflow/plugins/kfp/kfp_constants.py
+++ b/metaflow/plugins/kfp/kfp_constants.py
@@ -3,7 +3,7 @@
 # Defaults for running MF on KFP
 import os
 
-BASE_IMAGE = "hsezhiyan/metaflow-zillow:2.0"
+BASE_IMAGE = "hsezhiyan/metaflow-zillow:2.1"
 
 KFP_METAFLOW_FOREACH_SPLITS_PATH = "/tmp/kfp_metaflow_foreach_splits_dict.json"
 preceding_component_inputs_PATH = "/tmp/preceding_component_inputs.json"

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -15,7 +15,6 @@ into the user provided S3 path.
     os_expandvars=True,
 )
 class S3SensorFlow(FlowSpec):
-
     file_name = Parameter(
         "file_name",
     )

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -4,11 +4,9 @@ from os.path import join
 
 """
 This test flow ensures that @s3_sensor properly waits for path to be written
-to in S3. In run_integration_tests.py, we have a special test just for this flow.
-The test creates a random file and uploads it to S3, and this flow waits on the creation
-of that file.
+to in S3. In particular, this test ensures OS variables are correctly substituted 
+into the user provided S3 path.
 """
-
 
 @s3_sensor(
     path=join("$METAFLOW_DATASTORE_SYSROOT_S3", "{file_name}"),

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -4,7 +4,7 @@ from os.path import join
 
 """
 This test flow ensures that @s3_sensor properly waits for path to be written
-to in S3. In particular, this test ensures OS variables are correctly substituted 
+to in S3. In particular, this test ensures environment variables are correctly substituted 
 into the user provided S3 path.
 """
 

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_flow.py
@@ -8,6 +8,7 @@ to in S3. In particular, this test ensures environment variables are correctly s
 into the user provided S3 path.
 """
 
+
 @s3_sensor(
     path=join("$METAFLOW_DATASTORE_SYSROOT_S3", "{file_name}"),
     timeout_seconds=600,

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_with_formatter_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_with_formatter_flow.py
@@ -1,0 +1,41 @@
+from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
+
+import os
+from os.path import join
+from typing import Dict
+
+"""
+This test flow ensures that @s3_sensor properly waits for path to be written
+to in S3. In particular, this test ensures `path_formatter` works and users are
+able to format their S3 paths with runtime parameters.
+"""
+
+def formatter(path: str, flow_parameters: Dict[str, str]) -> str:
+    return path.format(
+        datastore=os.environ["METAFLOW_DATASTORE_SYSROOT_S3"],
+        file_name_for_formatter_test=flow_parameters["file_name_for_formatter_test"]
+    )
+
+@s3_sensor(
+    path=join("{datastore}", "{file_name_for_formatter_test}"),
+    timeout_seconds=600,
+    polling_interval_seconds=5,
+    path_formatter=formatter,
+)
+class S3SensorWithFormatterFlow(FlowSpec):
+    file_name_for_formatter_test = Parameter(
+        "file_name_for_formatter_test"
+    )
+
+    @step
+    def start(self):
+        print("S3SensorWithFormatterFlow is starting.")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print("S3SensorWithFormatterFlow is all done.")
+
+
+if __name__ == "__main__":
+    S3SensorWithFormatterFlow()

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_with_formatter_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_with_formatter_flow.py
@@ -9,12 +9,15 @@ to in S3. In particular, this test ensures `path_formatter` works and users are
 able to format their S3 paths with runtime parameters.
 """
 
+
 def formatter(path: str, flow_parameters: Dict[str, str]) -> str:
     import os
+
     return path.format(
         datastore=os.environ["METAFLOW_DATASTORE_SYSROOT_S3"],
-        file_name_for_formatter_test=flow_parameters["file_name_for_formatter_test"]
+        file_name_for_formatter_test=flow_parameters["file_name_for_formatter_test"],
     )
+
 
 @s3_sensor(
     path=join("{datastore}", "{file_name_for_formatter_test}"),
@@ -23,9 +26,7 @@ def formatter(path: str, flow_parameters: Dict[str, str]) -> str:
     path_formatter=formatter,
 )
 class S3SensorWithFormatterFlow(FlowSpec):
-    file_name_for_formatter_test = Parameter(
-        "file_name_for_formatter_test"
-    )
+    file_name_for_formatter_test = Parameter("file_name_for_formatter_test")
 
     @step
     def start(self):

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_with_formatter_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_with_formatter_flow.py
@@ -1,6 +1,5 @@
 from metaflow import FlowSpec, step, resources, s3_sensor, Parameter
 
-import os
 from os.path import join
 from typing import Dict
 
@@ -11,6 +10,7 @@ able to format their S3 paths with runtime parameters.
 """
 
 def formatter(path: str, flow_parameters: Dict[str, str]) -> str:
+    import os
     return path.format(
         datastore=os.environ["METAFLOW_DATASTORE_SYSROOT_S3"],
         file_name_for_formatter_test=flow_parameters["file_name_for_formatter_test"]

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -28,7 +28,6 @@ def upload_file_to_s3(file_name: str) -> None:
     )
 
 class UploadToS3Flow(FlowSpec):
-
     file_name = Parameter(
         "file_name",
     )

--- a/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/upload_to_s3_flow.py
@@ -9,11 +9,31 @@ from os.path import join
 
 from urllib.parse import urlparse
 
+"""
+This test flow uploads a file at a particular S3 location. The test flows s3_sensor_flow.py
+and s3_sensor_flow_with_formatter.py then wait for this file to appear in S3 through the use
+of the @s3_sensor, after which the flows proceed.
+"""
+
+def upload_file_to_s3(file_name: str) -> None:
+    run(f"touch {file_name}", universal_newlines=True, stdout=PIPE, shell=True)
+    # using environ with METAFLOW_DATASTORE_SYSROOT_S3 env var
+    # since it is available at run time in the pods on Kubeflow
+    root = urlparse(environ["METAFLOW_DATASTORE_SYSROOT_S3"])
+    bucket, key = root.netloc, root.path.lstrip("/")
+
+    s3 = boto3.resource("s3")
+    s3.meta.client.upload_file(
+        f"./{file_name}", bucket, join(key, file_name)
+    )
 
 class UploadToS3Flow(FlowSpec):
 
     file_name = Parameter(
         "file_name",
+    )
+    file_name_for_formatter_test = Parameter(
+        "file_name_for_formatter_test"
     )
 
     @step
@@ -21,17 +41,13 @@ class UploadToS3Flow(FlowSpec):
         print("Waiting to upload file...")
         time.sleep(100)
         print(f"Uploading {self.file_name} to S3...")
+        upload_file_to_s3(self.file_name)
 
-        run(f"touch {self.file_name}", universal_newlines=True, stdout=PIPE, shell=True)
-        # using environ with METAFLOW_DATASTORE_SYSROOT_S3 env var
-        # since it is available at run time in the pods on Kubeflow
-        root = urlparse(environ["METAFLOW_DATASTORE_SYSROOT_S3"])
-        bucket, key = root.netloc, root.path.lstrip("/")
+        print("Waiting to upload file for formatter test...")
+        time.sleep(100)
+        print(f"Uploading {self.file_name_for_formatter_test} to S3...")
+        upload_file_to_s3(self.file_name_for_formatter_test)
 
-        s3 = boto3.resource("s3")
-        s3.meta.client.upload_file(
-            f"./{self.file_name}", bucket, join(key, self.file_name)
-        )
         self.next(self.end)
 
     @step

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -91,8 +91,7 @@ def test_s3_sensor_flow(pytestconfig) -> None:
     )
 
     main_config_cmds = (
-        f"--workflow-timeout 1800 "
-        f"--experiment metaflow_test --tag test_t1 "
+        f"--workflow-timeout 1800 " f"--experiment metaflow_test --tag test_t1 "
     )
 
     upload_to_s3_flow_cmd += main_config_cmds

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -56,6 +56,7 @@ non_standard_test_flows = [
     "check_error_handling_flow.py",
     "raise_error_flow.py",
     "s3_sensor_flow.py",
+    "s3_sensor_with_formatter_flow.py",
     "upload_to_s3_flow.py",
 ]
 
@@ -74,19 +75,23 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
 def test_s3_sensor_flow(pytestconfig) -> None:
     # ensure the s3_sensor waits for some time before the key exists
     file_name = f"s3-sensor-file-{uuid.uuid1()}.txt"
+    file_name_for_formatter_test = f"s3-sensor-file-{uuid.uuid1()}.txt"
 
     upload_to_s3_flow_cmd = (
         f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
     )
     s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
+    s3_sensor_with_formatter_flow_cmd = f"{_python()} flows/s3_sensor_with_formatter_flow.py --datastore=s3 kfp run --wait-for-completion "
 
     main_config_cmds = (
         f"--workflow-timeout 1800 "
         f"--experiment metaflow_test --tag test_t1 "
         f"--file_name {file_name} "
+        f"--file_name_for_formatter_test {file_name_for_formatter_test} "
     )
     upload_to_s3_flow_cmd += main_config_cmds
     s3_sensor_flow_cmd += main_config_cmds
+    s3_sensor_with_formatter_flow_cmd += main_config_cmds
 
     if pytestconfig.getoption("image"):
         image_cmds = (
@@ -94,164 +99,166 @@ def test_s3_sensor_flow(pytestconfig) -> None:
         )
         upload_to_s3_flow_cmd += image_cmds
         s3_sensor_flow_cmd += image_cmds
+        s3_sensor_with_formatter_flow_cmd += image_cmds
 
     exponential_backoff_from_platform_errors(upload_to_s3_flow_cmd, 0)
     exponential_backoff_from_platform_errors(s3_sensor_flow_cmd, 0)
+    exponential_backoff_from_platform_errors(s3_sensor_with_formatter_flow_cmd, 0)
 
     return
 
 
 # This test ensures that a flow fails correctly,
 # and when it fails, an OpsGenie email is sent.
-def test_error_and_opsgenie_alert(pytestconfig) -> None:
-    test_cmd = (
-        f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
-        f"--wait-for-completion --workflow-timeout 1800 "
-        f"--experiment metaflow_test --tag test_t1 --notify "
-    )
-    if pytestconfig.getoption("image"):
-        test_cmd += (
-            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-        )
+# def test_error_and_opsgenie_alert(pytestconfig) -> None:
+#     test_cmd = (
+#         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
+#         f"--wait-for-completion --workflow-timeout 1800 "
+#         f"--experiment metaflow_test --tag test_t1 --notify "
+#     )
+#     if pytestconfig.getoption("image"):
+#         test_cmd += (
+#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+#         )
 
-    error_flow_id = exponential_backoff_from_platform_errors(test_cmd, 1)
-    opsgenie_auth_headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"GenieKey {pytestconfig.getoption('opsgenie_api_token')}",
-    }
+#     error_flow_id = exponential_backoff_from_platform_errors(test_cmd, 1)
+#     opsgenie_auth_headers = {
+#         "Content-Type": "application/json",
+#         "Authorization": f"GenieKey {pytestconfig.getoption('opsgenie_api_token')}",
+#     }
 
-    # Look for the alert with the correct kfp_run_id in the description.
-    list_alerts_endpoint = f"https://api.opsgenie.com/v2/alerts?query=description:{error_flow_id}&limit=1&sort=createdAt&order=des"
-    list_alerts_response = requests.get(
-        list_alerts_endpoint, headers=opsgenie_auth_headers
-    )
-    assert list_alerts_response.status_code == 200
+#     # Look for the alert with the correct kfp_run_id in the description.
+#     list_alerts_endpoint = f"https://api.opsgenie.com/v2/alerts?query=description:{error_flow_id}&limit=1&sort=createdAt&order=des"
+#     list_alerts_response = requests.get(
+#         list_alerts_endpoint, headers=opsgenie_auth_headers
+#     )
+#     assert list_alerts_response.status_code == 200
 
-    list_alerts_response_json = json.loads(list_alerts_response.text)
-    # assert we have found the alert (there should only be one alert with that kfp_run_id)
-    assert len(list_alerts_response_json["data"]) == 1
-    alert_alias = list_alerts_response_json["data"][0]["alias"]
+#     list_alerts_response_json = json.loads(list_alerts_response.text)
+#     # assert we have found the alert (there should only be one alert with that kfp_run_id)
+#     assert len(list_alerts_response_json["data"]) == 1
+#     alert_alias = list_alerts_response_json["data"][0]["alias"]
 
-    close_alert_data = {
-        "user": "AIP Integration Testing Service",
-        "source": "AIP Integration Testing Service",
-        "note": "Closing ticket because the test is complete.",
-    }
-    close_alert_endpoint = (
-        f"https://api.opsgenie.com/v2/alerts/{alert_alias}/close?identifierType=alias"
-    )
-    close_alert_response = requests.post(
-        close_alert_endpoint,
-        data=json.dumps(close_alert_data),
-        headers=opsgenie_auth_headers,
-    )
-    # Sometimes the response status code is 202, signaling
-    # the request has been accepted and is being queued for processing.
-    assert (
-        close_alert_response.status_code == 200
-        or close_alert_response.status_code == 202
-    )
+#     close_alert_data = {
+#         "user": "AIP Integration Testing Service",
+#         "source": "AIP Integration Testing Service",
+#         "note": "Closing ticket because the test is complete.",
+#     }
+#     close_alert_endpoint = (
+#         f"https://api.opsgenie.com/v2/alerts/{alert_alias}/close?identifierType=alias"
+#     )
+#     close_alert_response = requests.post(
+#         close_alert_endpoint,
+#         data=json.dumps(close_alert_data),
+#         headers=opsgenie_auth_headers,
+#     )
+#     # Sometimes the response status code is 202, signaling
+#     # the request has been accepted and is being queued for processing.
+#     assert (
+#         close_alert_response.status_code == 200
+#         or close_alert_response.status_code == 202
+#     )
 
-    # Test logging of raise_error_flow
-    test_cmd = (
-        f"{_python()} flows/check_error_handling_flow.py "
-        f"--datastore=s3 --with retry kfp run "
-        f"--wait-for-completion --workflow-timeout 1800 "
-        f"--experiment metaflow_test --tag test_t1 "
-        f"--error_flow_id={error_flow_id} "
-    )
-    if pytestconfig.getoption("image"):
-        test_cmd += (
-            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-        )
-    exponential_backoff_from_platform_errors(test_cmd, 0)
+#     # Test logging of raise_error_flow
+#     test_cmd = (
+#         f"{_python()} flows/check_error_handling_flow.py "
+#         f"--datastore=s3 --with retry kfp run "
+#         f"--wait-for-completion --workflow-timeout 1800 "
+#         f"--experiment metaflow_test --tag test_t1 "
+#         f"--error_flow_id={error_flow_id} "
+#     )
+#     if pytestconfig.getoption("image"):
+#         test_cmd += (
+#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+#         )
+#     exponential_backoff_from_platform_errors(test_cmd, 0)
 
-    return
-
-
-def exists_nvidia_accelerator(node_selector_term: Dict) -> bool:
-    for affinity_match_expression in node_selector_term["matchExpressions"]:
-        if (
-            affinity_match_expression["key"] == "k8s.amazonaws.com/accelerator"
-            and affinity_match_expression["operator"] == "In"
-            and "nvidia-tesla-v100" in affinity_match_expression["values"]
-        ):
-            return True
-    return False
+#     return
 
 
-def is_nvidia_accelerator_noschedule(toleration: Dict) -> bool:
-    if (
-        toleration["effect"] == "NoSchedule"
-        and toleration["key"] == "k8s.amazonaws.com/accelerator"
-        and toleration["operator"] == "Equal"
-        and toleration["value"] == "nvidia-tesla-v100"
-    ):
-        return True
-    return False
+# def exists_nvidia_accelerator(node_selector_term: Dict) -> bool:
+#     for affinity_match_expression in node_selector_term["matchExpressions"]:
+#         if (
+#             affinity_match_expression["key"] == "k8s.amazonaws.com/accelerator"
+#             and affinity_match_expression["operator"] == "In"
+#             and "nvidia-tesla-v100" in affinity_match_expression["values"]
+#         ):
+#             return True
+#     return False
 
 
-def test_compile_only_accelerator_test() -> None:
-    with tempfile.TemporaryDirectory() as yaml_tmp_dir:
-        yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
-
-        compile_to_yaml_cmd = (
-            f"{_python()} flows/accelerator_flow.py --datastore=s3 --with retry kfp run "
-            f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
-        )
-
-        compile_to_yaml_process = run(
-            compile_to_yaml_cmd,
-            universal_newlines=True,
-            shell=True,
-        )
-        assert compile_to_yaml_process.returncode == 0
-
-        with open(f"{yaml_file_path}", "r") as stream:
-            try:
-                flow_yaml = yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
-                print(exc)
-
-        for step in flow_yaml["spec"]["templates"]:
-            if step["name"] == "start":
-                start_step = step
-                break
-
-    affinity_found = False
-    for node_selector_term in start_step["affinity"]["nodeAffinity"][
-        "requiredDuringSchedulingIgnoredDuringExecution"
-    ]["nodeSelectorTerms"]:
-        if exists_nvidia_accelerator(node_selector_term):
-            affinity_found = True
-            break
-    assert affinity_found
-
-    toleration_found = False
-    for toleration in start_step["tolerations"]:
-        if is_nvidia_accelerator_noschedule(toleration):
-            toleration_found = True
-            break
-    assert toleration_found
+# def is_nvidia_accelerator_noschedule(toleration: Dict) -> bool:
+#     if (
+#         toleration["effect"] == "NoSchedule"
+#         and toleration["key"] == "k8s.amazonaws.com/accelerator"
+#         and toleration["operator"] == "Equal"
+#         and toleration["value"] == "nvidia-tesla-v100"
+#     ):
+#         return True
+#     return False
 
 
-@pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
-def test_flows(pytestconfig, flow_file_path: str) -> None:
-    full_path = join("flows", flow_file_path)
+# def test_compile_only_accelerator_test() -> None:
+#     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
+#         yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
 
-    test_cmd = (
-        f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
-        f"--wait-for-completion --workflow-timeout 1800 "
-        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
-    )
-    if pytestconfig.getoption("image"):
-        test_cmd += (
-            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-        )
+#         compile_to_yaml_cmd = (
+#             f"{_python()} flows/accelerator_flow.py --datastore=s3 --with retry kfp run "
+#             f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
+#         )
 
-    exponential_backoff_from_platform_errors(test_cmd, 0)
+#         compile_to_yaml_process = run(
+#             compile_to_yaml_cmd,
+#             universal_newlines=True,
+#             shell=True,
+#         )
+#         assert compile_to_yaml_process.returncode == 0
 
-    return
+#         with open(f"{yaml_file_path}", "r") as stream:
+#             try:
+#                 flow_yaml = yaml.safe_load(stream)
+#             except yaml.YAMLError as exc:
+#                 print(exc)
+
+#         for step in flow_yaml["spec"]["templates"]:
+#             if step["name"] == "start":
+#                 start_step = step
+#                 break
+
+#     affinity_found = False
+#     for node_selector_term in start_step["affinity"]["nodeAffinity"][
+#         "requiredDuringSchedulingIgnoredDuringExecution"
+#     ]["nodeSelectorTerms"]:
+#         if exists_nvidia_accelerator(node_selector_term):
+#             affinity_found = True
+#             break
+#     assert affinity_found
+
+#     toleration_found = False
+#     for toleration in start_step["tolerations"]:
+#         if is_nvidia_accelerator_noschedule(toleration):
+#             toleration_found = True
+#             break
+#     assert toleration_found
+
+
+# @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
+# def test_flows(pytestconfig, flow_file_path: str) -> None:
+#     full_path = join("flows", flow_file_path)
+
+#     test_cmd = (
+#         f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
+#         f"--wait-for-completion --workflow-timeout 1800 "
+#         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+#     )
+#     if pytestconfig.getoption("image"):
+#         test_cmd += (
+#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+#         )
+
+#     exponential_backoff_from_platform_errors(test_cmd, 0)
+
+#     return
 
 
 def exponential_backoff_from_platform_errors(

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -116,155 +116,155 @@ def test_s3_sensor_flow(pytestconfig) -> None:
 
 # This test ensures that a flow fails correctly,
 # and when it fails, an OpsGenie email is sent.
-# def test_error_and_opsgenie_alert(pytestconfig) -> None:
-#     test_cmd = (
-#         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
-#         f"--wait-for-completion --workflow-timeout 1800 "
-#         f"--experiment metaflow_test --tag test_t1 --notify "
-#     )
-#     if pytestconfig.getoption("image"):
-#         test_cmd += (
-#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-#         )
+def test_error_and_opsgenie_alert(pytestconfig) -> None:
+    test_cmd = (
+        f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
+        f"--wait-for-completion --workflow-timeout 1800 "
+        f"--experiment metaflow_test --tag test_t1 --notify "
+    )
+    if pytestconfig.getoption("image"):
+        test_cmd += (
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+        )
 
-#     error_flow_id = exponential_backoff_from_platform_errors(test_cmd, 1)
-#     opsgenie_auth_headers = {
-#         "Content-Type": "application/json",
-#         "Authorization": f"GenieKey {pytestconfig.getoption('opsgenie_api_token')}",
-#     }
+    error_flow_id = exponential_backoff_from_platform_errors(test_cmd, 1)
+    opsgenie_auth_headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"GenieKey {pytestconfig.getoption('opsgenie_api_token')}",
+    }
 
-#     # Look for the alert with the correct kfp_run_id in the description.
-#     list_alerts_endpoint = f"https://api.opsgenie.com/v2/alerts?query=description:{error_flow_id}&limit=1&sort=createdAt&order=des"
-#     list_alerts_response = requests.get(
-#         list_alerts_endpoint, headers=opsgenie_auth_headers
-#     )
-#     assert list_alerts_response.status_code == 200
+    # Look for the alert with the correct kfp_run_id in the description.
+    list_alerts_endpoint = f"https://api.opsgenie.com/v2/alerts?query=description:{error_flow_id}&limit=1&sort=createdAt&order=des"
+    list_alerts_response = requests.get(
+        list_alerts_endpoint, headers=opsgenie_auth_headers
+    )
+    assert list_alerts_response.status_code == 200
 
-#     list_alerts_response_json = json.loads(list_alerts_response.text)
-#     # assert we have found the alert (there should only be one alert with that kfp_run_id)
-#     assert len(list_alerts_response_json["data"]) == 1
-#     alert_alias = list_alerts_response_json["data"][0]["alias"]
+    list_alerts_response_json = json.loads(list_alerts_response.text)
+    # assert we have found the alert (there should only be one alert with that kfp_run_id)
+    assert len(list_alerts_response_json["data"]) == 1
+    alert_alias = list_alerts_response_json["data"][0]["alias"]
 
-#     close_alert_data = {
-#         "user": "AIP Integration Testing Service",
-#         "source": "AIP Integration Testing Service",
-#         "note": "Closing ticket because the test is complete.",
-#     }
-#     close_alert_endpoint = (
-#         f"https://api.opsgenie.com/v2/alerts/{alert_alias}/close?identifierType=alias"
-#     )
-#     close_alert_response = requests.post(
-#         close_alert_endpoint,
-#         data=json.dumps(close_alert_data),
-#         headers=opsgenie_auth_headers,
-#     )
-#     # Sometimes the response status code is 202, signaling
-#     # the request has been accepted and is being queued for processing.
-#     assert (
-#         close_alert_response.status_code == 200
-#         or close_alert_response.status_code == 202
-#     )
+    close_alert_data = {
+        "user": "AIP Integration Testing Service",
+        "source": "AIP Integration Testing Service",
+        "note": "Closing ticket because the test is complete.",
+    }
+    close_alert_endpoint = (
+        f"https://api.opsgenie.com/v2/alerts/{alert_alias}/close?identifierType=alias"
+    )
+    close_alert_response = requests.post(
+        close_alert_endpoint,
+        data=json.dumps(close_alert_data),
+        headers=opsgenie_auth_headers,
+    )
+    # Sometimes the response status code is 202, signaling
+    # the request has been accepted and is being queued for processing.
+    assert (
+        close_alert_response.status_code == 200
+        or close_alert_response.status_code == 202
+    )
 
-#     # Test logging of raise_error_flow
-#     test_cmd = (
-#         f"{_python()} flows/check_error_handling_flow.py "
-#         f"--datastore=s3 --with retry kfp run "
-#         f"--wait-for-completion --workflow-timeout 1800 "
-#         f"--experiment metaflow_test --tag test_t1 "
-#         f"--error_flow_id={error_flow_id} "
-#     )
-#     if pytestconfig.getoption("image"):
-#         test_cmd += (
-#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-#         )
-#     exponential_backoff_from_platform_errors(test_cmd, 0)
+    # Test logging of raise_error_flow
+    test_cmd = (
+        f"{_python()} flows/check_error_handling_flow.py "
+        f"--datastore=s3 --with retry kfp run "
+        f"--wait-for-completion --workflow-timeout 1800 "
+        f"--experiment metaflow_test --tag test_t1 "
+        f"--error_flow_id={error_flow_id} "
+    )
+    if pytestconfig.getoption("image"):
+        test_cmd += (
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+        )
+    exponential_backoff_from_platform_errors(test_cmd, 0)
 
-#     return
-
-
-# def exists_nvidia_accelerator(node_selector_term: Dict) -> bool:
-#     for affinity_match_expression in node_selector_term["matchExpressions"]:
-#         if (
-#             affinity_match_expression["key"] == "k8s.amazonaws.com/accelerator"
-#             and affinity_match_expression["operator"] == "In"
-#             and "nvidia-tesla-v100" in affinity_match_expression["values"]
-#         ):
-#             return True
-#     return False
+    return
 
 
-# def is_nvidia_accelerator_noschedule(toleration: Dict) -> bool:
-#     if (
-#         toleration["effect"] == "NoSchedule"
-#         and toleration["key"] == "k8s.amazonaws.com/accelerator"
-#         and toleration["operator"] == "Equal"
-#         and toleration["value"] == "nvidia-tesla-v100"
-#     ):
-#         return True
-#     return False
+def exists_nvidia_accelerator(node_selector_term: Dict) -> bool:
+    for affinity_match_expression in node_selector_term["matchExpressions"]:
+        if (
+            affinity_match_expression["key"] == "k8s.amazonaws.com/accelerator"
+            and affinity_match_expression["operator"] == "In"
+            and "nvidia-tesla-v100" in affinity_match_expression["values"]
+        ):
+            return True
+    return False
 
 
-# def test_compile_only_accelerator_test() -> None:
-#     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
-#         yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
-
-#         compile_to_yaml_cmd = (
-#             f"{_python()} flows/accelerator_flow.py --datastore=s3 --with retry kfp run "
-#             f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
-#         )
-
-#         compile_to_yaml_process = run(
-#             compile_to_yaml_cmd,
-#             universal_newlines=True,
-#             shell=True,
-#         )
-#         assert compile_to_yaml_process.returncode == 0
-
-#         with open(f"{yaml_file_path}", "r") as stream:
-#             try:
-#                 flow_yaml = yaml.safe_load(stream)
-#             except yaml.YAMLError as exc:
-#                 print(exc)
-
-#         for step in flow_yaml["spec"]["templates"]:
-#             if step["name"] == "start":
-#                 start_step = step
-#                 break
-
-#     affinity_found = False
-#     for node_selector_term in start_step["affinity"]["nodeAffinity"][
-#         "requiredDuringSchedulingIgnoredDuringExecution"
-#     ]["nodeSelectorTerms"]:
-#         if exists_nvidia_accelerator(node_selector_term):
-#             affinity_found = True
-#             break
-#     assert affinity_found
-
-#     toleration_found = False
-#     for toleration in start_step["tolerations"]:
-#         if is_nvidia_accelerator_noschedule(toleration):
-#             toleration_found = True
-#             break
-#     assert toleration_found
+def is_nvidia_accelerator_noschedule(toleration: Dict) -> bool:
+    if (
+        toleration["effect"] == "NoSchedule"
+        and toleration["key"] == "k8s.amazonaws.com/accelerator"
+        and toleration["operator"] == "Equal"
+        and toleration["value"] == "nvidia-tesla-v100"
+    ):
+        return True
+    return False
 
 
-# @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
-# def test_flows(pytestconfig, flow_file_path: str) -> None:
-#     full_path = join("flows", flow_file_path)
+def test_compile_only_accelerator_test() -> None:
+    with tempfile.TemporaryDirectory() as yaml_tmp_dir:
+        yaml_file_path = join(yaml_tmp_dir, "accelerator_flow.yaml")
 
-#     test_cmd = (
-#         f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
-#         f"--wait-for-completion --workflow-timeout 1800 "
-#         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
-#     )
-#     if pytestconfig.getoption("image"):
-#         test_cmd += (
-#             f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
-#         )
+        compile_to_yaml_cmd = (
+            f"{_python()} flows/accelerator_flow.py --datastore=s3 --with retry kfp run "
+            f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
+        )
 
-#     exponential_backoff_from_platform_errors(test_cmd, 0)
+        compile_to_yaml_process = run(
+            compile_to_yaml_cmd,
+            universal_newlines=True,
+            shell=True,
+        )
+        assert compile_to_yaml_process.returncode == 0
 
-#     return
+        with open(f"{yaml_file_path}", "r") as stream:
+            try:
+                flow_yaml = yaml.safe_load(stream)
+            except yaml.YAMLError as exc:
+                print(exc)
+
+        for step in flow_yaml["spec"]["templates"]:
+            if step["name"] == "start":
+                start_step = step
+                break
+
+    affinity_found = False
+    for node_selector_term in start_step["affinity"]["nodeAffinity"][
+        "requiredDuringSchedulingIgnoredDuringExecution"
+    ]["nodeSelectorTerms"]:
+        if exists_nvidia_accelerator(node_selector_term):
+            affinity_found = True
+            break
+    assert affinity_found
+
+    toleration_found = False
+    for toleration in start_step["tolerations"]:
+        if is_nvidia_accelerator_noschedule(toleration):
+            toleration_found = True
+            break
+    assert toleration_found
+
+
+@pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
+def test_flows(pytestconfig, flow_file_path: str) -> None:
+    full_path = join("flows", flow_file_path)
+
+    test_cmd = (
+        f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
+        f"--wait-for-completion --workflow-timeout 1800 "
+        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+    )
+    if pytestconfig.getoption("image"):
+        test_cmd += (
+            f"--no-s3-code-package --base-image {pytestconfig.getoption('image')}"
+        )
+
+    exponential_backoff_from_platform_errors(test_cmd, 0)
+
+    return
 
 
 def exponential_backoff_from_platform_errors(

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -83,7 +83,7 @@ def test_s3_sensor_flow(pytestconfig) -> None:
     )
     s3_sensor_flow_cmd = (
         f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
-        f"--file_name {file_name}"
+        f"--file_name {file_name} "
     )
     s3_sensor_with_formatter_flow_cmd = (
         f"{_python()} flows/s3_sensor_with_formatter_flow.py --datastore=s3 kfp run --wait-for-completion "

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -79,16 +79,22 @@ def test_s3_sensor_flow(pytestconfig) -> None:
 
     upload_to_s3_flow_cmd = (
         f"{_python()} flows/upload_to_s3_flow.py --datastore=s3 kfp run "
+        f"--file_name {file_name} --file_name_for_formatter_test {file_name_for_formatter_test} "
     )
-    s3_sensor_flow_cmd = f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
-    s3_sensor_with_formatter_flow_cmd = f"{_python()} flows/s3_sensor_with_formatter_flow.py --datastore=s3 kfp run --wait-for-completion "
+    s3_sensor_flow_cmd = (
+        f"{_python()} flows/s3_sensor_flow.py --datastore=s3 kfp run --wait-for-completion "
+        f"--file_name {file_name}"
+    )
+    s3_sensor_with_formatter_flow_cmd = (
+        f"{_python()} flows/s3_sensor_with_formatter_flow.py --datastore=s3 kfp run --wait-for-completion "
+        f"--file_name_for_formatter_test {file_name_for_formatter_test} "
+    )
 
     main_config_cmds = (
         f"--workflow-timeout 1800 "
         f"--experiment metaflow_test --tag test_t1 "
-        f"--file_name {file_name} "
-        f"--file_name_for_formatter_test {file_name_for_formatter_test} "
     )
+
     upload_to_s3_flow_cmd += main_config_cmds
     s3_sensor_flow_cmd += main_config_cmds
     s3_sensor_with_formatter_flow_cmd += main_config_cmds


### PR DESCRIPTION
- `@s3_sensor` now running within a KFP component using an image with Python `v3.9` (`hsezhiyan/metaflow-zillow:2.1`). This ensures the `marshal` done in the environment that flow is launched from (which most customers by now have upgraded to Python `v.3.9`) can be undone (unmarshaled) in the environment the Kubeflow pods run on.
- Addressing AIP-4571 to ensure the Dockerfile used to create the `hsezhiyan/metaflow-zillow` images are provided within the source repo for easier usage by the open source community.