### PR TITLE
AIP-5103: Swap over feature branches to use dev releases versioning scheme

### DIFF
--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -38,7 +38,7 @@ stages:
     PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}-dev.${CI_PIPELINE_IID}"
     # Ensure the image tag is compliant with PEP-440,
     IMAGE_TAG="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"
-  else:
+  else
     IMAGE_TAG="${PY_LIBRARY_VERSION}"
   fi
   # Only apply the Metaflow version to the python library as Docker versions do not have the concept of


### PR DESCRIPTION
To do:
- [x] Test out with new `zillow-kfp` version that deprecates the `--api-namespace` and `--namespace` flags on some KFP CLI entrypoints, see changes [here](https://github.com/zillow/pipelines/pull/10).
- [x] Swap over feature branches to use dev releases versioning scheme.