### PR TITLE
AIP-5283 - Fix @s3_sensor usage with @resources(volume=...) and --notify

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -904,7 +904,7 @@ class KubeflowPipelines(object):
 
         s3_sensor_op = func_to_container_op(
             wait_for_s3_path,
-            base_image="hsezhiyan/metaflow-zillow:2.1",
+            base_image="hsezhiyan/metaflow-zillow:2.0",
         )(
             path=path,
             timeout_seconds=timeout_seconds,
@@ -1114,19 +1114,6 @@ class KubeflowPipelines(object):
                                 shared_volumes=shared_volumes,
                             )
 
-            workflow_uid_op: ContainerOp = None
-            if any(
-                "volume" in s.resource_requirements
-                for s in step_to_kfp_component_map.values()
-            ):
-                workflow_uid_op = func_to_container_op(
-                    get_workflow_uid,
-                    base_image="gcr.io/cloud-builders/kubectl",
-                )(work_flow_name="{{workflow.name}}").set_display_name(
-                    "get_workflow_uid"
-                )
-                KubeflowPipelines._set_minimal_container_resources(workflow_uid_op)
-
             def create_s3_sensor_op():
                 s3_sensor_deco = self.flow._flow_decorators.get("s3_sensor")
                 if s3_sensor_deco:
@@ -1137,7 +1124,27 @@ class KubeflowPipelines(object):
                 else:
                     return None
 
-            def call_build_kfp_dag():
+            def create_workflow_uid_op(s3_sensor_path: str):
+                workflow_uid_op: ContainerOp = None
+                if any(
+                    "volume" in s.resource_requirements
+                    for s in step_to_kfp_component_map.values()
+                ):
+                    workflow_uid_op = func_to_container_op(
+                        get_workflow_uid,
+                        base_image="gcr.io/cloud-builders/kubectl",
+                    )(
+                        work_flow_name="{{workflow.name}}",
+                        s3_sensor_path=s3_sensor_path,
+                    ).set_display_name(
+                        "get_workflow_uid"
+                    )
+                    KubeflowPipelines._set_minimal_container_resources(workflow_uid_op)
+                    return workflow_uid_op
+                else:
+                    return None
+
+            def call_build_kfp_dag(workflow_uid_op: ContainerOp):
                 build_kfp_dag(
                     self.graph["start"],
                     workflow_uid=workflow_uid_op.output if workflow_uid_op else None,
@@ -1148,11 +1155,17 @@ class KubeflowPipelines(object):
 
             if self.notify:
                 with dsl.ExitHandler(self._create_exit_handler_op()):
-                    call_build_kfp_dag()
                     s3_sensor_op = create_s3_sensor_op()
+                    workflow_uid_op = create_workflow_uid_op(
+                        s3_sensor_op.output if s3_sensor_op else ""
+                    )
+                    call_build_kfp_dag(workflow_uid_op)
             else:
-                call_build_kfp_dag()
                 s3_sensor_op = create_s3_sensor_op()
+                workflow_uid_op = create_workflow_uid_op(
+                    s3_sensor_op.output if s3_sensor_op else ""
+                )
+                call_build_kfp_dag(workflow_uid_op)
 
             # Instruct KFP of the DAG order by iterating over the Metaflow
             # graph nodes.  Each Metaflow graph node has in_funcs (nodes that
@@ -1165,12 +1178,8 @@ class KubeflowPipelines(object):
                 for parent_step in node.in_funcs:
                     visited[node.name].after(visited[parent_step])
 
-            # ensure the start step only begins after the s3_sensor step completes
             if s3_sensor_op:
                 visited["start"].after(s3_sensor_op)
-                # ensure volume creation also happens after the s3_sensor step completes
-                if workflow_uid_op:
-                    workflow_uid_op.after(s3_sensor_op)
 
             dsl.get_pipeline_conf().add_op_transformer(pipeline_transform)
             dsl.get_pipeline_conf().set_parallelism(self.max_parallelism)

--- a/metaflow/plugins/kfp/kfp_get_workflow_uid.py
+++ b/metaflow/plugins/kfp/kfp_get_workflow_uid.py
@@ -1,5 +1,6 @@
 def get_workflow_uid(
     work_flow_name: str,
+    s3_sensor_path: str,
 ) -> str:
     """
     The environment variables that this depends on:

--- a/metaflow/plugins/kfp/tests/flows/s3_sensor_with_formatter_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/s3_sensor_with_formatter_flow.py
@@ -6,7 +6,9 @@ from typing import Dict
 """
 This test flow ensures that @s3_sensor properly waits for path to be written
 to in S3. In particular, this test ensures `path_formatter` works and users are
-able to format their S3 paths with runtime parameters.
+able to format their S3 paths with runtime parameters. The test also tests the usage
+of @s3_sensor with volumes and shared volumes while using --notify.
+See https://zbrt.atl.zillow.net/browse/AIP-5283.
 """
 
 
@@ -28,9 +30,20 @@ def formatter(path: str, flow_parameters: Dict[str, str]) -> str:
 class S3SensorWithFormatterFlow(FlowSpec):
     file_name_for_formatter_test = Parameter("file_name_for_formatter_test")
 
+    @resources(volume="1G")
     @step
     def start(self):
         print("S3SensorWithFormatterFlow is starting.")
+        self.items = [1, 2]
+        self.next(self.shared_volume_foreach_step, foreach="items")
+
+    @resources(volume="13G", volume_mode="ReadWriteMany")
+    @step
+    def shared_volume_foreach_step(self):
+        self.next(self.shared_volume_join_step)
+
+    @step
+    def shared_volume_join_step(self, inputs):
         self.next(self.end)
 
     @step


### PR DESCRIPTION
Please see [AIP-5283](https://zbrt.atl.zillow.net/browse/AIP-5283) for full details on this bug.
This bug manifests when `@s3_sensor` is used with both `@resources(volume=...)` and `--notify`. Specifically, the resulting DAG has a cycle between the `get_workflow_uid` and `exit-handler-1` ops. This remedies this by adding an explicit DAG dependency between `s3_sensor_op` and `workflow_uid_op` by having the `workflow_uid_op` consume an output from `s3_sensor_op`.
To ensure this type of bug doesn't happen again, I've modified the `s3_sensor` test to include `volumes` and `shared_volumes`.