### PR TITLE
Handle None value of COVERAGE_OMIT

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -474,7 +474,7 @@ def step(ctx,
         cov = Coverage(data_suffix=True,
                        auto_data=True,
                        source=METAFLOW_COVERAGE_SOURCE.split(","),
-                       omit=METAFLOW_COVERAGE_OMIT.split(","),
+                       omit=METAFLOW_COVERAGE_OMIT.split(",") if METAFLOW_COVERAGE_OMIT else None,
                        branch=True)
         cov.start()
 


### PR DESCRIPTION
Without this fix customers report error for calling `split()` on NoneType