### PR TITLE
Raise value error on tags that are too long

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -596,6 +596,11 @@ class KubeflowPipelines(object):
             container_op.add_pod_annotation(f"{prefix}/experiment", self.experiment)
         if self.tags and len(self.tags) > 0:
             for tag in self.tags:
+                tag_name = f"{prefix}/tag_{tag}"
+                if len(tag_name) > 63:
+                    raise ValueError(
+                        f"Tag name {tag_name} must be no more than 63 characters"
+                    )
                 container_op.add_pod_annotation(f"{prefix}/tag_{tag}", "true")
 
         # TODO(talebz): A Metaflow plugin framework to customize tags, labels, etc.


### PR DESCRIPTION
Previously when tag is too long, the error happens only when `start` step is being executed in integration test. Specifically `start` step will immediately fail without any log. We had to go to Datadog to look for pod events. 

Tag can be long when customer use a very long feature branch name and project name.

This change make alert happens early, so that customer know what breaks their code. 