### PR TITLE
Use "purpose: high-memory" toleration instead of "instance-type: r5.12xlarge"

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -419,9 +419,11 @@ class KubeflowPipelines(object):
         cpu: number of vCPU requested. Fractions are allowed.
         memory: memory requested in GB (not GiB)
         """
-        # Base on observed resource data Oct. 21, 2021, available resource per c5.4xlarge node:
-        # Memory: 20.24GB = 18.85 GiB = 27.72 GiB (allocatable) - 8.87 GiB (DaemonSet)
-        # CPU: 10.34 vCPU = 15.89 (allocatable) - 5.55 (DaemonSet)
+        # Analysis on Oct. 21, 2021:
+        # c5.4xlarge is the default CPU pods
+        # Base on observed resource data available resource per c5.4xlarge node:
+        #   Memory: 20.24GB = 18.85 GiB = 27.72 GiB (allocatable) - 8.87 GiB (DaemonSet)
+        #   CPU: 10.34 vCPU = 15.89 (allocatable) - 5.55 (DaemonSet)
         # Argo additionally adds a "wait" container to pods per step, taking default resources
 
         # Threshold should leave significant margin below estimated available resource
@@ -435,9 +437,9 @@ class KubeflowPipelines(object):
         if memory >= memory_threshold or cpu >= cpu_threshold:
             return V1Toleration(
                 effect="NoSchedule",
-                key="node.kubernetes.io/instance-type",
+                key="node.k8s.zgtools.net/purpose",
                 operator="Equal",
-                value="r5.12xlarge",
+                value="high-memory",
             )
         else:
             return None

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -308,31 +308,31 @@ def test_toleration_and_affinity_compile_only() -> None:
     # Test toleration generated from resource spec for CPU pods
     assert not has_node_toleration(
         step_template=step_templates["small_default_pod"],
-        key="node.kubernetes.io/instance-type",
-        value="r5.12xlarge",
+        key="node.k8s.zgtools.net/purpose",
+        value="high-memory",
     )
     assert not has_node_toleration(
         step_template=step_templates["small_cpu_pod"],
-        key="node.kubernetes.io/instance-type",
-        value="r5.12xlarge",
+        key="node.k8s.zgtools.net/purpose",
+        value="high-memory",
     )
     assert not has_node_toleration(
         step_template=step_templates["small_memory_pod"],
-        key="node.kubernetes.io/instance-type",
-        value="r5.12xlarge",
+        key="node.k8s.zgtools.net/purpose",
+        value="high-memory",
     )
     assert has_node_toleration(
         step_template=step_templates["large_cpu_pod"],
-        key="node.kubernetes.io/instance-type",
-        value="r5.12xlarge",
+        key="node.k8s.zgtools.net/purpose",
+        value="high-memory",
     )
     assert has_node_toleration(
         step_template=step_templates["large_memory_pod"],
-        key="node.kubernetes.io/instance-type",
-        value="r5.12xlarge",
+        key="node.k8s.zgtools.net/purpose",
+        value="high-memory",
     )
     assert has_node_toleration(
         step_template=step_templates["large_memory_cpu_pod"],
-        key="node.kubernetes.io/instance-type",
-        value="r5.12xlarge",
+        key="node.k8s.zgtools.net/purpose",
+        value="high-memory",
     )


### PR DESCRIPTION
From https://kubernetes.io/docs/reference/labels-annotations-taints/:
> Kubernetes reserves all labels and annotations in the kubernetes.io namespace"

Switching to a safer toleration and taint combination.