### PR TITLE
Update black run to use python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
         python3 -m pip install --upgrade pip
         python3 -m pip install tox numpy black
 
+    - name: Python Code Format Check
+      run: black --target-version py39 --diff --check ./metaflow/plugins/kfp/*.py
+
     - name: Execute Python tests
       if: matrix.lang == 'python'
       run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,6 @@ jobs:
         python3 -m pip install --upgrade pip
         python3 -m pip install tox numpy black
 
-    - name: Python Code Format Check
-      run: black --target-version py27 --diff --check ./metaflow/plugins/kfp/*.py
-
     - name: Execute Python tests
       if: matrix.lang == 'python'
       run: tox


### PR DESCRIPTION
New release of black 22.1.0 dropped support for python 2. See https://pypi.org/project/black/

Update the black to run against py39. Needed to resolve the following error in test:
```
Run black --target-version py27 --diff --check ./metaflow/plugins/kfp/*.py
Usage: black [OPTIONS] SRC ...
Try 'black -h' for help.

Error: Invalid value for '-t' / '--target-version': 'py27' is not one of 'py33', 'py34', 'py35', 'py36', 'py37', 'py38', 'py39', 'py310'.
```