### PR TITLE
Find version using zillow-metaflow package instead

### DIFF
--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -186,7 +186,7 @@ del globals()["_n"]
 import pkg_resources
 
 try:
-    __version__ = pkg_resources.get_distribution("metaflow").version
+    __version__ = pkg_resources.get_distribution("zillow-metaflow").version
 except:
     # this happens on remote environments since the job package
     # does not have a version


### PR DESCRIPTION
When running Metaflow cards seems like I'm getting this error in the outputted HTML:

```
Card of type default is unable to be rendered with arguments None.
Stack trace :  Traceback (most recent call last):
  File "/opt/zillow/.venv/lib/python3.9/site-packages/metaflow/plugins/cards/card_cli.py", line 503, in create
    rendered_info = render_card(mf_card, task, timeout_value=timeout)
  File "/opt/zillow/.venv/lib/python3.9/site-packages/metaflow/plugins/cards/card_cli.py", line 384, in render_card
    rendered_info = mf_card.render(task)
  File "/opt/zillow/.venv/lib/python3.9/site-packages/metaflow/plugins/cards/card_modules/basic.py", line 587, in render
    final_component_dict = TaskInfoComponent(
  File "/opt/zillow/.venv/lib/python3.9/site-packages/metaflow/plugins/cards/card_modules/basic.py", line 341, in render
    mf_version = [
IndexError: list index out of range
```

My guess is the `tag` that it's searching for isn't injected because the `value` of that `tag` is `None` because we use the "package" name `zillow-metaflow` and NOT `metaflow`. 

You can also see this subtle problem in the output of the `doit compile_pipeline` task (and any `run` task actually) where it outputs `None` as the `version` (see [here](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/aip-usage-report/-/jobs/11604590#L78)):

```
Metaflow None executing AipUsageReport for user:cicd_compile
```