### PR TITLE
AIP-6005 Use PVC as tmp path in S3()

### DIFF
--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -11,7 +11,7 @@ from tempfile import mkdtemp, NamedTemporaryFile
 
 from .. import FlowSpec
 from ..current import current
-from ..metaflow_config import DATATOOLS_S3ROOT, S3_RETRY_COUNT
+from ..metaflow_config import DATATOOLS_S3ROOT, S3_RETRY_COUNT, from_conf
 from ..util import (
     namedtuple_with_defaults,
     is_stringish,
@@ -287,7 +287,7 @@ class S3(object):
         return DATATOOLS_S3ROOT
 
     def __init__(
-        self, tmproot=".", bucket=None, prefix=None, run=None, s3root=None, **kwargs
+        self, tmproot=None, bucket=None, prefix=None, run=None, s3root=None, **kwargs
     ):
         """
         Initialize a new context for S3 operations. This object is used as
@@ -309,6 +309,10 @@ class S3(object):
 
         if not boto_found:
             raise MetaflowException("You need to install 'boto3' in order to use S3.")
+        
+        if tmproot is None:
+            artifact_localroot = from_conf("METAFLOW_ARTIFACT_LOCALROOT")
+            tmproot = artifact_localroot if artifact_localroot else "."
 
         if run:
             # 1. use a (current) run ID with optional customizations

--- a/metaflow/datatools/s3.py
+++ b/metaflow/datatools/s3.py
@@ -304,12 +304,13 @@ class S3(object):
             s3root: (optional) An S3 root URL for all operations. If this is
                     not specified, all operations require a full S3 URL.
         These options are supported in both the modes:
-            tmproot: (optional) Root path for temporary files (default: '.')
+            tmproot: (optional) Root path for temporary files
+                     (default: METAFLOW_ARTIFACT_LOCALROOT else '.')
         """
 
         if not boto_found:
             raise MetaflowException("You need to install 'boto3' in order to use S3.")
-        
+
         if tmproot is None:
             artifact_localroot = from_conf("METAFLOW_ARTIFACT_LOCALROOT")
             tmproot = artifact_localroot if artifact_localroot else "."

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -13,6 +13,7 @@ from kubernetes.client import (
 
 from metaflow import FlowSpec, Parameter, current, environment, resources, step
 from metaflow._vendor import click
+from metaflow.datatools.s3 import S3
 
 
 def get_env_vars(env_resources: Dict[str, str]) -> List[V1EnvVar]:
@@ -168,6 +169,13 @@ class ResourcesFlow(FlowSpec):
     def foreach_step(self):
         # test simple environment var
         assert os.environ.get("MY_ENV") == "value"
+
+        with S3(run=self) as s3:
+            value = "123"
+            s3.put("foo", value)
+            assert s3.get("foo").text == value
+            print(f"{s3._tmpdir=}")
+            assert "/opt/metaflow_volume" in s3._tmpdir
 
         output = subprocess.check_output(
             "df -h | grep /opt/metaflow_volume", shell=True


### PR DESCRIPTION
* depends on KF Profiles addition of `METAFLOW_ARTIFACT_LOCALROOT` env variable in https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/kubeflow-k8s-profiles/-/merge_requests/530