### PR TITLE
Use common image config in KFP

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -54,19 +54,6 @@ DEFAULT_AWS_CLIENT_PROVIDER = from_conf("METAFLOW_DEFAULT_AWS_CLIENT_PROVIDER", 
 
 METAFLOW_USER = from_conf("METAFLOW_USER")
 
-##
-# KFP configuration
-###
-KFP_SDK_NAMESPACE = from_conf("KFP_SDK_NAMESPACE", "kubeflow")
-KFP_SDK_API_NAMESPACE = from_conf("KFP_SDK_API_NAMESPACE", "kubeflow")
-KFP_TTL_SECONDS_AFTER_FINISHED = from_conf("KFP_TTL_SECONDS_AFTER_FINISHED", None)
-KFP_USER_DOMAIN = from_conf("KFP_USER_DOMAIN", "")
-# Note: `KFP_RUN_URL_PREFIX` is the URL prefix for KFP runs on your KFP cluster. The prefix includes
-# all parts of the URL except the run_id at the end which we append once the run is created.
-# For eg, this would look like: "https://<your-kf-cluster-url>/pipeline/#/runs/details/"
-KFP_RUN_URL_PREFIX = from_conf("KFP_RUN_URL_PREFIX", "")
-KFP_MAX_PARALLELISM = int(from_conf("KFP_MAX_PARALLELISM", 10))
-
 ###
 # Datastore configuration
 ###
@@ -148,6 +135,27 @@ if METADATA_SERVICE_AUTH_KEY is not None:
 DEFAULT_CONTAINER_IMAGE = from_conf("METAFLOW_DEFAULT_CONTAINER_IMAGE")
 # Default container registry
 DEFAULT_CONTAINER_REGISTRY = from_conf("METAFLOW_DEFAULT_CONTAINER_REGISTRY")
+
+##
+# KFP configuration
+###
+# Link to image package:
+# https://github.com/zillow/metaflow/pkgs/container/metaflow%2Fmetaflow-zillow
+if DEFAULT_CONTAINER_REGISTRY and DEFAULT_CONTAINER_IMAGE:
+    KFP_CONTAINER_IMAGE = (
+        f"{DEFAULT_CONTAINER_REGISTRY.rstrip('/')}/{DEFAULT_CONTAINER_IMAGE}"
+    )
+else:
+    KFP_CONTAINER_IMAGE = "ghcr.io/zillow/metaflow/metaflow-zillow:2.2"
+KFP_SDK_NAMESPACE = from_conf("KFP_SDK_NAMESPACE", "kubeflow")
+KFP_SDK_API_NAMESPACE = from_conf("KFP_SDK_API_NAMESPACE", "kubeflow")
+KFP_TTL_SECONDS_AFTER_FINISHED = from_conf("KFP_TTL_SECONDS_AFTER_FINISHED", None)
+KFP_USER_DOMAIN = from_conf("KFP_USER_DOMAIN", "")
+# Note: `KFP_RUN_URL_PREFIX` is the URL prefix for KFP runs on your KFP cluster. The prefix includes
+# all parts of the URL except the run_id at the end which we append once the run is created.
+# For eg, this would look like: "https://<your-kf-cluster-url>/pipeline/#/runs/details/"
+KFP_RUN_URL_PREFIX = from_conf("KFP_RUN_URL_PREFIX", "")
+KFP_MAX_PARALLELISM = int(from_conf("KFP_MAX_PARALLELISM", 10))
 
 ###
 # AWS Batch configuration

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -6,6 +6,7 @@ from metaflow import JSONType, current, decorators, parameters
 from metaflow._vendor import click
 from metaflow.exception import CommandException, MetaflowException
 from metaflow.metaflow_config import (
+    KFP_CONTAINER_IMAGE,
     KFP_MAX_PARALLELISM,
     KFP_SDK_API_NAMESPACE,
     KFP_SDK_NAMESPACE,
@@ -15,7 +16,6 @@ from metaflow.package import MetaflowPackage
 from metaflow.plugins.aws.step_functions.step_functions_cli import (
     check_metadata_service_version,
 )
-from metaflow.plugins.kfp.kfp_constants import BASE_IMAGE
 from metaflow.plugins.kfp.kfp_step_init import save_step_environment_variables
 from metaflow.plugins.kfp.kfp_utils import run_id_to_url
 from metaflow.util import get_username
@@ -139,7 +139,7 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
 @click.option(
     "--base-image",
     "base_image",
-    default=BASE_IMAGE,
+    default=KFP_CONTAINER_IMAGE,
     help="Base docker image used in Kubeflow Pipelines.",
     show_default=True,
 )
@@ -228,7 +228,7 @@ def run(
     yaml_only=False,
     pipeline_path=None,
     s3_code_package=True,
-    base_image=BASE_IMAGE,
+    base_image=None,
     pipeline_name=None,
     max_parallelism=None,
     workflow_timeout=None,

--- a/metaflow/plugins/kfp/kfp_constants.py
+++ b/metaflow/plugins/kfp/kfp_constants.py
@@ -3,10 +3,6 @@
 # Defaults for running MF on KFP
 import os
 
-# Link to package:
-# https://github.com/zillow/metaflow/pkgs/container/metaflow%2Fmetaflow-zillow
-BASE_IMAGE = "ghcr.io/zillow/metaflow/metaflow-zillow:2.2"
-
 KFP_METAFLOW_FOREACH_SPLITS_PATH = "/tmp/kfp_metaflow_foreach_splits_dict.json"
 PRECEDING_COMPONENT_INPUTS_PATH = "/tmp/preceding_component_inputs.json"
 

--- a/metaflow/plugins/kfp/kfp_decorator.py
+++ b/metaflow/plugins/kfp/kfp_decorator.py
@@ -40,12 +40,10 @@ class KfpInternalDecorator(StepDecorator):
       state within task_pre_step.
 
     image: str
-      Defaults to None, which means default to either the container image
-      specified with --base-image by the user running a flow with
-      python sample_flow.py kfp run --base-image tensorflow/tensorflow:latest-devel
-      OR the container image specified as BASE_IMAGE in
-      metaflow/plugins/kfp/kfp_constants.py.
-
+      Defaults to None, where default is determined in the following order:
+      1. specified with --base-image by the user running a flow with
+        python <flow_name>.py kfp run --base-image <image-url>
+      2. KFP_CONTAINER_IMAGE defined in metaflow_config.py
 
     @step
     @kfp(


### PR DESCRIPTION
This change is mostly for `zillow-metaflow` dev, for a smooth dev experience swapping between argo plug-in and KFP plug-in. 

Change:
- Adopt common image config https://github.com/Netflix/metaflow/pull/813 in KFP plug-in, while keeping kfp cli usage unchanged