### PR TITLE
Fix env var name for argo wf name

### DIFF
--- a/metaflow/plugins/kfp/kfp_exit_handler.py
+++ b/metaflow/plugins/kfp/kfp_exit_handler.py
@@ -23,7 +23,7 @@ def exit_handler(
         METAFLOW_NOTIFY_EMAIL_FROM
         K8S_CLUSTER_ENV
         POD_NAMESPACE
-        ARGO_WORKFLOW_NAME
+        MF_ARGO_WORKFLOW_NAME
         METAFLOW_NOTIFY_EMAIL_BODY
     """
     import json
@@ -59,7 +59,7 @@ def exit_handler(
         )
 
         pod_namespace = get_env("POD_NAMESPACE", "")
-        argo_workflow_name = get_env("ARGO_WORKFLOW_NAME", "")
+        argo_workflow_name = get_env("MF_ARGO_WORKFLOW_NAME", "")
         email_body = get_env("METAFLOW_NOTIFY_EMAIL_BODY", "")
         body = (
             f"status = {status} <br/>\n"

--- a/metaflow/plugins/kfp/tests/flows/failure_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/failure_flow.py
@@ -28,7 +28,7 @@ class FailureFlow(FlowSpec):
             print(str(output))
         else:
             command = (
-                f"./kubectl get workflow {os.environ.get('ARGO_WORKFLOW_NAME')} "
+                f"./kubectl get workflow {os.environ.get('MF_ARGO_WORKFLOW_NAME')} "
                 f"--namespace {os.environ.get('POD_NAMESPACE')} -o yaml"
             )
             print(f"{command=}")


### PR DESCRIPTION
ARGO_WORKFLOW_NAME is added in two places: all-pods-default and new argo code. This issue is reported in https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/kubeflow-k8s-profiles/-/merge_requests/531

Meanwhile `ARGO_WORKFLOW_NAME` and `MF_ARGO_WORKFLOW_NAME` are duplicate of each other since they both have reference to `workflows.argoproj.io/workflow`. Switch to use MF_ARGO_WORKFLOW_NAME solves the problem.

Note on roll out:
- By removing `ARGO_WORKFLOW_NAME`` from all-pods-default we are forcing an upgrade on zillow-metaflow code to customer teams. This PR is thus a blocking one for argo upgrade.