### PR TITLE
Adding sys_tag as parameters

### DIFF
--- a/metaflow/cli.py
+++ b/metaflow/cli.py
@@ -449,6 +449,14 @@ def logs(obj, input_path, stdout=None, stderr=None, both=None, timestamps=False)
     "the task.",
 )
 @click.option(
+    "--sys-tag",
+    "opt_sys_tag",
+    multiple=True,
+    default=None,
+    help="Annotate this run with the given system tag. You can specify "
+    "this option multiple times to attach multiple tags in the task.",
+)
+@click.option(
     "--namespace",
     "opt_namespace",
     default=None,
@@ -500,6 +508,7 @@ def step(
     ctx,
     step_name,
     opt_tag=None,
+    opt_sys_tag=None,
     run_id=None,
     task_id=None,
     input_paths=None,
@@ -552,7 +561,7 @@ def step(
     )
     cli_args._set_step_kwargs(step_kwargs)
 
-    ctx.obj.metadata.add_sticky_tags(tags=opt_tag)
+    ctx.obj.metadata.add_sticky_tags(tags=opt_tag, sys_tags=opt_sys_tag)
     paths = decompress_list(input_paths) if input_paths else []
 
     task = MetaflowTask(
@@ -603,8 +612,15 @@ def step(
     default=None,
     help="Tags for this instance of the step.",
 )
+@click.option(
+    "--sys-tag",
+    "sys_tags",
+    multiple=True,
+    default=None,
+    help="System tags for this instance of the step.",
+)
 @click.pass_obj
-def init(obj, run_id=None, task_id=None, tags=None, **kwargs):
+def init(obj, run_id=None, task_id=None, tags=None, sys_tags=None, **kwargs):
     # init is a separate command instead of an option in 'step'
     # since we need to capture user-specified parameters with
     # @add_custom_parameters. Adding custom parameters to 'step'
@@ -613,7 +629,7 @@ def init(obj, run_id=None, task_id=None, tags=None, **kwargs):
     # user-specified parameters are often defined as environment
     # variables.
 
-    obj.metadata.add_sticky_tags(tags=tags)
+    obj.metadata.add_sticky_tags(tags=tags, sys_tags=sys_tags)
 
     runtime = NativeRuntime(
         obj.flow,

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -596,7 +596,8 @@ class KubeflowPipelines(object):
             container_op.add_pod_annotation(f"{prefix}/experiment", self.experiment)
         if self.tags and len(self.tags) > 0:
             for tag in self.tags:
-                tag_name = f"{prefix}/tag_{tag}"
+                # <key>:<value> is common metaflow tag pattern but : is not accepted in pod tag.
+                tag_name = f"{prefix}/tag_{tag.replace(':', '-')}"
                 if len(tag_name) > 63:
                     raise ValueError(
                         f"Tag name {tag_name} must be no more than 63 characters"

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -65,6 +65,7 @@ class FlowVariables:
     monitor: str
     namespace: str
     tags: List[str]
+    sys_tags: List[str]
     package_commands: str
 
 
@@ -134,6 +135,7 @@ class KubeflowPipelines(object):
         base_image=None,
         s3_code_package=True,
         tags=None,
+        sys_tags=None,
         experiment=None,
         namespace=None,
         kfp_namespace=None,
@@ -160,6 +162,7 @@ class KubeflowPipelines(object):
         self.event_logger = event_logger
         self.monitor = monitor
         self.tags = tags
+        self.sys_tags = sys_tags
         self.experiment = experiment
         self.namespace = namespace
         self.kfp_namespace = kfp_namespace
@@ -283,6 +286,7 @@ class KubeflowPipelines(object):
             monitor=self.monitor.monitor_type,
             namespace=self.namespace,
             tags=list(self.tags),
+            sys_tags=list(self.sys_tags),
             package_commands=self._get_package_commands(
                 code_package_url=self.code_package_url,
                 environment=self.environment,
@@ -594,15 +598,17 @@ class KubeflowPipelines(object):
         container_op.add_pod_annotation(f"{prefix}/run_id", metaflow_run_id)
         if self.experiment:
             container_op.add_pod_annotation(f"{prefix}/experiment", self.experiment)
-        if self.tags and len(self.tags) > 0:
-            for tag in self.tags:
-                # <key>:<value> is common metaflow tag pattern but : is not accepted in pod tag.
-                tag_name = f"{prefix}/tag_{tag.replace(':', '-')}"
-                if len(tag_name) > 63:
-                    raise ValueError(
-                        f"Tag name {tag_name} must be no more than 63 characters"
-                    )
-                container_op.add_pod_annotation(f"{prefix}/tag_{tag}", "true")
+        all_tags = list()
+        all_tags += self.tags if self.tags else []
+        all_tags += self.sys_tags if self.sys_tags else []
+        for tag in all_tags:
+            # <key>:<value> is common metaflow tag pattern but ":" is not accepted in pod annotation.
+            tag_name = f"{prefix}/tag_{tag.replace(':', '-')}"
+            if len(tag_name) > 63:
+                raise ValueError(
+                    f"Tag name {tag_name} must be no more than 63 characters"
+                )
+            container_op.add_pod_annotation(f"{prefix}/tag_{tag}", "true")
 
         # TODO(talebz): A Metaflow plugin framework to customize tags, labels, etc.
         container_op.add_pod_label("aip.zillowgroup.net/kfp-pod-default", "true")
@@ -938,6 +944,7 @@ class KubeflowPipelines(object):
             f" --script_name {os.path.basename(sys.argv[0])}"
             f" --step_name {step_variables.step_name}"
             f" --tags_json {json.dumps(json.dumps(flow_variables.tags))}"
+            f" --sys_tags_json {json.dumps(json.dumps(flow_variables.sys_tags))}"
             f" --task_id {step_variables.task_id}"
             f" --user_code_retries {step_variables.user_code_retries}"
             " --workflow_name {{workflow.name}}"

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -94,6 +94,15 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
     "times to attach multiple tags.",
 )
 @click.option(
+    "--sys-tag",
+    "sys_tags",
+    multiple=True,
+    default=None,
+    help="Annotate all Metaflow objects produced by KFP Metaflow runs "
+    "with the given system tag. You can specify this option multiple "
+    "times to attach multiple tags.",
+)
+@click.option(
     "--namespace",
     "namespace",
     default=None,
@@ -222,6 +231,7 @@ def run(
     experiment=None,
     run_name=None,
     tags=None,
+    sys_tags=None,
     namespace=None,
     kfp_namespace=KFP_SDK_NAMESPACE,
     api_namespace=KFP_SDK_API_NAMESPACE,
@@ -264,6 +274,7 @@ def run(
         obj=obj,
         name=pipeline_name if pipeline_name else obj.flow.name,
         tags=tags,
+        sys_tags=sys_tags,
         experiment=experiment,
         namespace=namespace,
         kfp_namespace=kfp_namespace,
@@ -349,6 +360,7 @@ def make_flow(
     obj,
     name,
     tags,
+    sys_tags,
     experiment,
     namespace,
     kfp_namespace,
@@ -405,6 +417,7 @@ def make_flow(
         base_image=base_image,
         s3_code_package=s3_code_package,
         tags=tags,
+        sys_tags=sys_tags,
         experiment=experiment,
         namespace=namespace,
         kfp_namespace=kfp_namespace,

--- a/metaflow/plugins/kfp/kfp_decorator.py
+++ b/metaflow/plugins/kfp/kfp_decorator.py
@@ -128,8 +128,8 @@ class KfpInternalDecorator(StepDecorator):
         # TODO: any other KFP environment variables to get and register to Metadata service?
         meta = {
             "kfp-execution": run_id,
-            "pod_name": os.environ.get("MF_POD_NAME"),
-            "argo_workflow": os.environ.get("MF_ARGO_WORKFLOW_NAME"),
+            "pod-name": os.environ.get("MF_POD_NAME"),
+            "argo-workflow": os.environ.get("MF_ARGO_WORKFLOW_NAME"),
         }
 
         entries = [

--- a/metaflow/plugins/kfp/kfp_metaflow_step.py
+++ b/metaflow/plugins/kfp/kfp_metaflow_step.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import pathlib
-import subprocess
 from subprocess import Popen
 from typing import Dict, List
 
@@ -58,16 +57,6 @@ def _step_cli(
     input_paths = None
 
     tags_extended: List[str] = []
-
-    # Add git commit hash as system tag
-    try:
-        git_dir = os.path.dirname(os.path.realpath(script_name))
-        git_hash = subprocess.check_output(
-            f'git -C {git_dir} log -1 --format="%H"'.split(" ")
-        )
-        tags_extended.append(f"--tag git:{git_hash}")
-    except Exception as e:
-        print("Failed to add git commit hash as tag", e)
 
     if tags:
         tags_extended.extend("--tag %s" % tag for tag in tags)

--- a/metaflow/plugins/kfp/kfp_metaflow_step.py
+++ b/metaflow/plugins/kfp/kfp_metaflow_step.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import pathlib
+import subprocess
 from subprocess import Popen
 from typing import Dict, List
 
@@ -57,6 +58,17 @@ def _step_cli(
     input_paths = None
 
     tags_extended: List[str] = []
+
+    # Add git commit hash as system tag
+    try:
+        git_dir = os.path.dirname(os.path.realpath(script_name))
+        git_hash = subprocess.check_output(
+            f'git -C {git_dir} log -1 --format="%H"'.split(" ")
+        )
+        tags_extended.append(f"--tag git:{git_hash}")
+    except Exception as e:
+        print("Failed to add git commit hash as tag", e)
+
     if tags:
         tags_extended.extend("--tag %s" % tag for tag in tags)
 

--- a/metaflow/plugins/kfp/kfp_metaflow_step.py
+++ b/metaflow/plugins/kfp/kfp_metaflow_step.py
@@ -33,6 +33,7 @@ def _step_cli(
     run_id: str,
     namespace: str,
     tags: List[str],
+    sys_tags: List[str],
     is_split_index: bool,
     environment: str,
     event_logger: str,
@@ -60,6 +61,7 @@ def _step_cli(
 
     if tags:
         tags_extended.extend("--tag %s" % tag for tag in tags)
+        tags_extended.extend("--sys-tag %s" % tag for tag in sys_tags)
 
     if step_name == "start":
         # We need a separate unique ID for the special _parameters task
@@ -237,6 +239,7 @@ def _command(
 @click.option("--script_name")
 @click.option("--step_name")
 @click.option("--tags_json")
+@click.option("--sys_tags_json")
 @click.option("--task_id")
 @click.option("--user_code_retries", type=int)
 @click.option("--workflow_name")
@@ -259,6 +262,7 @@ def kfp_metaflow_step(
     script_name: str,
     step_name: str,
     tags_json: str,
+    sys_tags_json: str,
     task_id: str,
     user_code_retries: int,
     workflow_name: str,
@@ -270,6 +274,7 @@ def kfp_metaflow_step(
     """
     metaflow_configs: Dict[str, str] = json.loads(metaflow_configs_json)
     tags: List[str] = json.loads(tags_json)
+    sys_tags: List[str] = json.loads(sys_tags_json)
     preceding_component_inputs: List[str] = json.loads(preceding_component_inputs_json)
     preceding_component_outputs: List[str] = json.loads(
         preceding_component_outputs_json
@@ -284,6 +289,7 @@ def kfp_metaflow_step(
         metaflow_run_id,
         namespace,
         tags,
+        sys_tags,
         is_split_index,
         environment,
         event_logger,

--- a/metaflow/plugins/kfp/tests/flows/metadata_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/metadata_flow.py
@@ -34,6 +34,7 @@ class MetadataFlow(FlowSpec):
         start_step_tags: frozenset = start_step.tags
         print("start_step_tags", start_step_tags)
         assert "test_t1" in start_step_tags
+        assert "test_sys_t1" in start_step_tags
         assert "metaflow_test" in start_step_tags
         assert f"zodiac_service:{os.environ['ZODIAC_SERVICE']}" in start_step_tags
         assert f"zodiac_team:{os.environ['ZODIAC_TEAM']}" in start_step_tags

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -62,6 +62,7 @@ annotations = {
     "metaflow.org/experiment": "MF_EXPERIMENT",
     "metaflow.org/tag_metaflow_test": "MF_TAG_METAFLOW_TEST",
     "metaflow.org/tag_test_t1": "MF_TAG_TEST_T1",
+    "metaflow.org/tag_sys_test_t1": "MF_SYS_TAG_TEST_T1",
 }
 for annotation, env_name in annotations.items():
     kubernetes_vars.append(
@@ -153,6 +154,7 @@ class ResourcesFlow(FlowSpec):
         assert os.environ.get("MF_EXPERIMENT") == "metaflow_test"
         assert os.environ.get("MF_TAG_METAFLOW_TEST") == "true"
         assert os.environ.get("MF_TAG_TEST_T1") == "true"
+        assert os.environ.get("MF_SYS_TAG_TEST_T1") == "true"
 
         assert os.environ.get("KF_POD_DEFAULT") == "true"
 

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -62,7 +62,7 @@ annotations = {
     "metaflow.org/experiment": "MF_EXPERIMENT",
     "metaflow.org/tag_metaflow_test": "MF_TAG_METAFLOW_TEST",
     "metaflow.org/tag_test_t1": "MF_TAG_TEST_T1",
-    "metaflow.org/tag_sys_test_t1": "MF_SYS_TAG_TEST_T1",
+    "metaflow.org/tag_test_sys_t1": "MF_SYS_TAG_TEST_T1",
 }
 for annotation, env_name in annotations.items():
     kubernetes_vars.append(

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -211,7 +211,7 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
     test_cmd: str = (
         f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
-        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 --sys-tag test_sys_t1 "
     )
     if pytestconfig.getoption("image"):
         test_cmd += (

--- a/metaflow/plugins/kfp/tests/test_kfp_metaflow_step.py
+++ b/metaflow/plugins/kfp/tests/test_kfp_metaflow_step.py
@@ -51,10 +51,10 @@ def export_mflog_env_vars():
             "nullSidecarLogger",
             "nullSidecarMonitor",
             3,
-            "sample_workflow",
+            "sample-workflow",
             "sample_script",
             [
-                "argo_workflow:sample_workflow",
+                "argo-workflow:sample-workflow",
                 "metaflow.plugins.aws.step_functions.set_batch_environment",
                 "sample_script",
                 "--environment=local",
@@ -80,7 +80,7 @@ def export_mflog_env_vars():
             "nullSidecarLogger",
             "nullSidecarMonitor",
             3,
-            "sample_workflow",
+            "sample-workflow",
             "sample_script",
             [],
             [


### PR DESCRIPTION
This allows us change default tags by changing out internal `ci-cd-template`, without forcing upgrades on customers.

Main changes:
* Add --sys-tags to kfp cli and step cli
* If tag has `:`, a char not accepted in pod annotation, replace it with `-` before annotating the pod
* Update unit test to test for sys_tags