### PR TITLE
Bugfix: Colon can be used in tags now.

### DIFF
--- a/metaflow/plugins/kfp/tests/flows/metadata_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/metadata_flow.py
@@ -34,7 +34,7 @@ class MetadataFlow(FlowSpec):
         start_step_tags: frozenset = start_step.tags
         print("start_step_tags", start_step_tags)
         assert "test_t1" in start_step_tags
-        assert "test_sys_t1" in start_step_tags
+        assert "test_sys_t1:sys_tag_value" in start_step_tags
         assert "metaflow_test" in start_step_tags
         assert f"zodiac_service:{os.environ['ZODIAC_SERVICE']}" in start_step_tags
         assert f"zodiac_team:{os.environ['ZODIAC_TEAM']}" in start_step_tags

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -154,7 +154,7 @@ class ResourcesFlow(FlowSpec):
         assert os.environ.get("MF_EXPERIMENT") == "metaflow_test"
         assert os.environ.get("MF_TAG_METAFLOW_TEST") == "true"
         assert os.environ.get("MF_TAG_TEST_T1") == "true"
-        assert os.environ.get("MF_SYS_TAG_TEST_T1") == "true"
+        assert os.environ.get("MF_SYS_TAG_TEST_T1") == "sys_tag_value"
 
         assert os.environ.get("KF_POD_DEFAULT") == "true"
 

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -211,7 +211,8 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
     test_cmd: str = (
         f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
         f"--wait-for-completion --workflow-timeout 1800 "
-        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 --sys-tag test_sys_t1 "
+        f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
+        f"--sys-tag test_sys_t1:sys_tag_value "
     )
     if pytestconfig.getoption("image"):
         test_cmd += (


### PR DESCRIPTION
Had a bug that `:` in tags triggers invalid name error for k8s annotations. 

In metaflow it's common to have tag in form of `<name>:<value>`, thus also parsing tag in this form into name and value part to allow more info in tag, working around length limit of k8s annotation name length of 63. 