### PR TITLE
Publish now depends on cicd var

### DIFF
--- a/metaflow/plugins/kfp/tests/.gitlab-ci.yml
+++ b/metaflow/plugins/kfp/tests/.gitlab-ci.yml
@@ -18,6 +18,7 @@ variables:
   DEPLOY_INTERNAL: "true"
   DEPLOY_NONPROD: "false"
   DEPLOY_PROD: "false"
+  PUBLISH: "true"
 
 stages:
   - build
@@ -136,6 +137,8 @@ build:publish:
     password: ${PYPI_PASSWORD}
     EOL
   - python setup.py sdist upload --repository "${ANALYTICS_PYPI_REPOSITORY}"
+  rules:
+    - if: '$PUBLISH == "true"'
 
 test:internal:
   extends: 


### PR DESCRIPTION
In integration test we then can turn off publish to avoid multiple copies of zillow-metaflow published without feature change.