### PR TITLE
Adding Gitlab CI - build and publish only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,66 @@
+include:
+  - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
+    ref: &include_ref 'v3'
+    file: 'environments/devex.yml'
+  - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
+    ref: *include_ref
+    file: '/blocks/python.yml'
+
+variables:
+  PY_LIBRARY_NAME: "zillow-metaflow"
+  MAJOR_VERSION: "2"
+  MINOR_VERSION: "0"
+  BUILD_VERSION: "0"
+  METAFLOW_VERSION_PATH: "setup.py"
+  PUBLISH: "true"
+
+
+stages:
+  - build
+
+
+.version: &version |
+  # Extract the open source Metaflow version as the basis for our forked library version.
+  METAFLOW_VERSION=$(cat $METAFLOW_VERSION_PATH | sed -nr "s/^version = ['\"]([^'\"]*)['\"]$/\1/p")
+
+  PY_LIBRARY_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_VERSION}"
+
+  # Only publishing dev version until a release is ready
+  PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}-dev.${CI_PIPELINE_IID}"
+  IMAGE_TAG="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"
+
+  #if [ "${CI_COMMIT_BRANCH}" != "${CI_DEFAULT_BRANCH}" ]; then
+  #  PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}-dev.${CI_PIPELINE_IID}"
+  #  # Ensure the image tag is compliant with PEP-440,
+  #  IMAGE_TAG="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"
+  #else
+  #  IMAGE_TAG="${PY_LIBRARY_VERSION}"
+  #fi
+  
+  # Only apply the Metaflow version to the python library as Docker versions do not have the concept of
+  # build metadata and the "+" character causes errors.
+  PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}+${METAFLOW_VERSION}"
+
+
+build:publish:
+  extends: .aip_python_debian_image
+  stage: build
+  script:
+  - *version
+  # Now write back the zillow-kfp version back to the original location we found the original so
+  # python package managers can reference it as they need the version stored internally.
+  - sed -i "s/\(version = ['\"]\)[^'\"]*\(['\"]\)/\1${PY_LIBRARY_VERSION}\2/" $METAFLOW_VERSION_PATH
+  - python setup.py sdist
+  # Set up the configuration for Artifactory to publish the python package internally.
+  - |
+    cat >~/.pypirc <<EOL
+    [distutils]
+    index-servers = local
+    [local]
+    repository: ${ANALYTICS_PYPI_REPOSITORY}
+    username: ${PYPI_USERNAME}
+    password: ${PYPI_PASSWORD}
+    EOL
+  - python setup.py sdist upload --repository "${ANALYTICS_PYPI_REPOSITORY}"
+  rules:
+    - if: '$PUBLISH == "true"'


### PR DESCRIPTION
Context: 
We build and test this package using zg gitlab mirror to allow integration testing on zg infra.

Changes: 
- Add .gitlab-ci.yml for building and publishing zillow-metaflow.

Future TODOs:
- Add testing scripts - pending on zillow plug-in testing strategy and a test folder path