### PR TITLE
Support shared memory in KFP plug-in

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -17,6 +17,7 @@ from kubernetes.client import (
     V1Affinity,
     V1EnvVar,
     V1EnvVarSource,
+    V1EmptyDirVolumeSource,
     V1NodeAffinity,
     V1NodeSelector,
     V1NodeSelectorRequirement,
@@ -28,6 +29,7 @@ from kubernetes.client import (
     V1PersistentVolumeClaimSpec,
     V1ResourceRequirements,
     V1Toleration,
+    V1Volume,
 )
 
 from metaflow.decorators import FlowDecorator
@@ -492,6 +494,17 @@ class KubeflowPipelines(object):
                     mode=mode,
                 )
                 container_op.add_pvolumes({volume_dir: volume})
+        if "shared_memory" in resource_requirements:
+            memory_volume = PipelineVolume(
+                volume=V1Volume(
+                    name=f"{kfp_component.step_name}-shm",
+                    empty_dir=V1EmptyDirVolumeSource(
+                        medium="Memory",
+                        size_limit=resource_requirements["shared_memory"],
+                    ),
+                )
+            )
+            container_op.add_pvolumes({"dev/shm": memory_volume})
 
         if kfp_component.accelerator_decorator:
             accelerator_type: str = kfp_component.accelerator_decorator.attributes[

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -497,7 +497,10 @@ class KubeflowPipelines(object):
         if "shared_memory" in resource_requirements:
             memory_volume = PipelineVolume(
                 volume=V1Volume(
-                    name=f"{kfp_component.step_name}-shm",
+                    # k8s volume name must consist of lower case alphanumeric characters or '-',
+                    # and must start and end with an alphanumeric character,
+                    # but step name is python function name that tends to be alphanumeric chars with '_'
+                    name=f"{kfp_component.step_name.lower().replace('_', '-')}-shm",
                     empty_dir=V1EmptyDirVolumeSource(
                         medium="Memory",
                         size_limit=resource_requirements["shared_memory"],

--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -94,7 +94,6 @@ class ResourcesDecorator(StepDecorator):
         "cpu": None,
         "gpu": None,
         "memory": None,
-        # Only AWS Batch supported attributes
         "shared_memory": None,
         # Only KFP supported attributes
         "gpu_vendor": None,


### PR DESCRIPTION
Docker containers are allocated 64 MB of shared memory by default. This is sometimes not enough for Torch Dataloader with multiple workers.

Changes:
- Support shared volume configs (to support Torch Data Loader) using [emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) mount
  - Shared memory counts towards total memory limit (TODO: find the reference again)
  - "An emptyDir volume is first created when a Pod is assigned to a node, and exists as long as that Pod is running on that node." [[Volumes | Kubernetes]](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)

Example:
``` py
  @resources(memory="128G", shared_memory="2G")
  @step
  def hello(self):
      """
      A step for metaflow to introduce itself.

      """
      print("Metaflow says: Hi!")
      self.next(self.end)
```
adds the following to container of `hello` step
``` yaml
spec:
  entrypoint: helloflow
  templates:
  <other steps omitted>
  - name: hello
    container:
      <other configs not changed thus omitted>
      volumeMounts:
      - {mountPath: dev/shm, name: hello-shm}
    volumes:
    - emptyDir: {medium: Memory, sizeLimit: 2G}
      name: hello-shm
```

TODO:

- [x] Add testing
- [ ] Add documentation (can do after merging)
  - [ ] Update AIP Metaflow support table
  - [ ] Update AIP customer docs
