### PR TITLE
AIP-5874 update failure flow assertion

### DIFF
--- a/metaflow/plugins/kfp/tests/flows/failure_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/failure_flow.py
@@ -33,7 +33,7 @@ class FailureFlow(FlowSpec):
             )
             print(f"{command=}")
             output = subprocess.check_output(command, shell=True)
-            assert "pod deleted during operation" in str(output)
+            assert "pod deleted" in str(output)
             print("let's succeed")
 
         self.next(self.user_failure)


### PR DESCRIPTION
Update assertion for failure_flow as Argo changed the workflow message failure_flow uses to continue. This was the only run that failed during [integration testing](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/aip-k8s-manifests/-/jobs/14264555) in internal, all other metaflow runs and integration tests passed.

In the old version of Argo, the workflow sdk failure_flow [test](https://github.com/zillow/metaflow/blob/f150287e9d37bf66e7977a8945be1e16d687005c/metaflow/plugins/kfp/tests/flows/failure_flow.py#L36) looked for this message  in the workflow

```
parameters:
        - name: flow_parameters_json
          value: '{}'
      message: pod deleted during operation
```
but now the message was changed to

```
parameters:
        - name: flow_parameters_json
          value: '{}'
      message: pod deleted
```

Here is what the [message](https://github.com/argoproj/argo-workflows/blob/e5dc961b7846efe0fe36ab3a0964180eaedd2672/workflow/controller/operator.go#L1069) looks like in the version of argo we are trying to upgrade to. [here ](https://github.com/argoproj/argo-workflows/blob/737905345d70ba1ebd566ce1230e4f971993dfd0/workflow/controller/operator.go#L1095)is what it looked like in the previous version. it looks like argo got rid of the old message and chopped it down to pod deleted .