### PR TITLE
Chris/aip 6554 extract wait from trigger method

### DIFF
--- a/metaflow/plugins/argo/argo_live_run.py
+++ b/metaflow/plugins/argo/argo_live_run.py
@@ -118,7 +118,7 @@ class ArgoLiveRun(LiveRun):
         print(
             f"Attempting to trigger a run of a Metaflow flow:\n"
             f"    - Metaflow run id: {live_run._metaflow_run_id}\n"
-            f"    - k8s namespace: {run_kubernetes_namespace}"
+            f"    - k8s namespace: {run_kubernetes_namespace}\n"
         )
 
         wait_to_trigger = 20  # wait time is 20 seconds
@@ -147,34 +147,31 @@ class ArgoLiveRun(LiveRun):
 
         # optional wait for argo workflow to finish running
         if wait:
-            print("Now we will wait for the flow to finish")
-
-            start_time = time.time()
-            loop_counter = 0
-            while wait_timeout * 60 > time.time() - start_time:
-                if not live_run.is_running:
-                    break
-                if loop_counter % 12 == 0:
-                    print(
-                        f"Time waited: {int((time.time() - start_time)/60)}"
-                        f" minutes out of a possible {wait_timeout}"
-                    )
-                loop_counter += 1
-                time.sleep(5)
-            else:
-                raise TimeoutError(
-                    f"Failed to begin running within {wait_timeout} minutes"
-                )
-
-            success_statement = (
-                "successfully!!!" if live_run.successful else "unsuccessfully."
-            )
-            print(f"\nRun completed {success_statement}")
-
+            print("\nWaiting for run to finish...")
+            live_run._wait(wait_timeout)
         else:
             print("\nNot waiting for run to finish")
 
         return live_run
+
+    def _wait(self, wait_timeout) -> None:
+        start_time = time.time()
+        loop_counter = 0
+        while wait_timeout * 60 > time.time() - start_time:
+            if not self.is_running:
+                break
+            if loop_counter % 12 == 0:
+                print(
+                    f"Time waited: {int((time.time() - start_time) / 60)}"
+                    f" minutes out of a possible {wait_timeout}"
+                )
+            loop_counter += 1
+            time.sleep(5)
+        else:
+            raise TimeoutError(f"Failed to begin running within {wait_timeout} minutes")
+
+        success_statement = "successfully!!!" if self.successful else "unsuccessfully."
+        print(f"\nRun completed {success_statement}")
 
     @property
     def _status(self) -> str:

--- a/metaflow/plugins/argo/test/hello_jsontype.py
+++ b/metaflow/plugins/argo/test/hello_jsontype.py
@@ -15,8 +15,14 @@ class HelloJSONType(FlowSpec):
     dict_param = Parameter(
         "dict_param", type=JSONType, default='{"one": 1, "two": 2, "nine": 9}'
     )
-    # TODO: Add params for testing and check in hello step:
-    #           types: str, int, bool, float
+    # TODO: Add below params for testing and check them in hello step
+    """
+    "reg_str": "this is a string",
+    "date_key": "2020-01-01",
+    "integer": 1,
+    "boolean": True,
+    "float": 123.456,
+    """
 
     @step
     def start(self):

--- a/metaflow/plugins/argo/test/test_run.py
+++ b/metaflow/plugins/argo/test/test_run.py
@@ -1,6 +1,8 @@
 from metaflow.client.trigger_live_run import trigger_live_run  # trigger
 import time
 
+
+start_time = time.time()
 flow_name = None  # "HelloArgoFlowTwo", "FailureFlow", "MissingFlow", None
 template_name = (
     "helloargoflowtwo"  # "helloargoflowtwo", "failureflow", "missingflow", None
@@ -10,11 +12,10 @@ run = trigger_live_run(
     flow_name=flow_name,
     template_name=template_name,
     parameters=None,
-    wait=False,
+    wait=True,
 )
 
 print(f"\nRunning flow {run.flow_name}")
-start_time = time.time()
 while run.is_running:
     print(
         f"Status (Argo-only): '{run._status}' after {int((time.time()-start_time)//1)} seconds"

--- a/metaflow/plugins/argo/test/test_run_jsontype.py
+++ b/metaflow/plugins/argo/test/test_run_jsontype.py
@@ -2,6 +2,7 @@ from metaflow.client.trigger_live_run import trigger_live_run  # trigger
 import time
 
 
+start_time = time.time()
 flow_name = None  # "HelloArgoFlowTwo", "HelloJSONType", None
 template_name = "hellojsontype"  # "helloargoflowtwo", "hellojsontype", None
 
@@ -15,7 +16,7 @@ parameters_valid = {
     "integer": 1,
     "boolean": True,
     "float": 123.456,
-    # TODO: Add params to Flow for types: str, int, bool, float
+    # TODO: Add all params for testing into HelloJSONType flow
 }
 # NOTE: Metaflow Parameter objects only support complex data types in JSON formats.
 parameters_invalid = {
@@ -33,7 +34,6 @@ run = trigger_live_run(
 )
 
 print(f"\nRunning flow {run.flow_name}")
-start_time = time.time()
 while run.is_running:
     print(
         f"Status (Argo-only): '{run._status}' after {int((time.time()-start_time)//1)} seconds"


### PR DESCRIPTION
In the FTF feature, wait is a parameter that is passed in by user, and it determines whether the triggering function waits for the flow to complete before returning. Currently, this functionality is housed within the trigger method. However, it would be cleaner to separate this out from the trigger method.

**Changes made:**
Wait functionality is moved to a new method in the ArgoLiveRun class and the trigger method calls this method to achieve wait functionality.