### PR TITLE
AIP-6522 IAM role per workflow

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -4,6 +4,7 @@ import json
 import marshal
 import os
 import sys
+import yaml
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -51,6 +52,7 @@ from ..aws.batch.batch_decorator import BatchDecorator
 from ..aws.step_functions.schedule_decorator import ScheduleDecorator
 from .accelerator_decorator import AcceleratorDecorator
 from .kfp_foreach_splits import KfpForEachSplits, graph_to_task_ids
+from .kfp_utils import get_notebook_metaflow_sa
 
 # TODO: @schedule
 UNSUPPORTED_DECORATORS = (
@@ -201,6 +203,7 @@ class KubeflowPipelines(object):
             experiment_name=self.experiment,
             run_name=run_name,
             namespace=self.kfp_namespace,
+            service_account=get_notebook_metaflow_sa()
         )
 
     def create_kfp_pipeline_yaml(self, pipeline_file_path) -> str:
@@ -214,6 +217,18 @@ class KubeflowPipelines(object):
             pipeline_file_path,
             pipeline_conf=pipeline_conf,
         )
+
+        # use kfp client extract yaml method so we do not recreate logic that accounts
+        # for various extensions supported by kfp
+        workflow_yaml = self._client._extract_pipeline_yaml(pipeline_file_path)
+
+        workflow_yaml['spec']['serviceAccountName'] = get_notebook_metaflow_sa()
+    
+        # use internal kfp static method to write the modified yaml back to the
+        # pipeline_file_path so we do not have to recreates kfp support for the
+        # various extensions it supports
+        kfp.compiler.Compiler()._write_workflow(workflow_yaml, pipeline_file_path)
+        
         return os.path.abspath(pipeline_file_path)
 
     @staticmethod

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -182,11 +182,7 @@ class KubeflowPipelines(object):
         self.notify_on_success = notify_on_success
         self._client = None
 
-    def create_run_on_kfp(self, run_name: str, flow_parameters: dict):
-        """
-        Creates a new run on KFP using the `kfp.Client()`.
-        """
-        # TODO: first create KFP Pipeline, then an experiment if provided else default experiment.
+    def set_kfp_client(self):
         # kfp userid needs to have the user domain
         kfp_client_user_email = self.username
         if KFP_USER_DOMAIN:
@@ -195,6 +191,13 @@ class KubeflowPipelines(object):
         self._client = kfp.Client(
             namespace=self.api_namespace, userid=kfp_client_user_email
         )
+
+    def create_run_on_kfp(self, run_name: str, flow_parameters: dict):
+        """
+        Creates a new run on KFP using the `kfp.Client()`.
+        """
+        # TODO: first create KFP Pipeline, then an experiment if provided else default experiment.
+        self.set_kfp_client()
         pipeline_func, _ = self.create_kfp_pipeline_from_flow_graph()
         return self._client.create_run_from_pipeline_func(
             pipeline_func=pipeline_func,
@@ -219,6 +222,7 @@ class KubeflowPipelines(object):
 
         # use kfp client extract yaml method so we do not recreate logic that accounts
         # for various extensions supported by kfp
+        self.set_kfp_client()
         workflow_yaml = self._client._extract_pipeline_yaml(pipeline_file_path)
 
         workflow_yaml["spec"]["serviceAccountName"] = get_notebook_metaflow_sa()

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -4,7 +4,6 @@ import json
 import marshal
 import os
 import sys
-import yaml
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -227,9 +227,7 @@ class KubeflowPipelines(object):
             # use kfp client extract yaml method so we do not recreate logic that accounts
             # for various extensions supported by kfp
             workflow_yaml = self._client._extract_pipeline_yaml(pipeline_file_path)
-            workflow_yaml["spec"][
-                "serviceAccountName"
-            ] = KUBERNETES_SERVICE_ACCOUNT
+            workflow_yaml["spec"]["serviceAccountName"] = KUBERNETES_SERVICE_ACCOUNT
             # use internal kfp static method to write the modified yaml back to the
             # pipeline_file_path so we do not have to recreate kfp support for the
             # various extensions it supports

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -203,7 +203,7 @@ class KubeflowPipelines(object):
             experiment_name=self.experiment,
             run_name=run_name,
             namespace=self.kfp_namespace,
-            service_account=get_notebook_metaflow_sa()
+            service_account=get_notebook_metaflow_sa(),
         )
 
     def create_kfp_pipeline_yaml(self, pipeline_file_path) -> str:
@@ -222,13 +222,13 @@ class KubeflowPipelines(object):
         # for various extensions supported by kfp
         workflow_yaml = self._client._extract_pipeline_yaml(pipeline_file_path)
 
-        workflow_yaml['spec']['serviceAccountName'] = get_notebook_metaflow_sa()
-    
+        workflow_yaml["spec"]["serviceAccountName"] = get_notebook_metaflow_sa()
+
         # use internal kfp static method to write the modified yaml back to the
-        # pipeline_file_path so we do not have to recreates kfp support for the
+        # pipeline_file_path so we do not have to recreate kfp support for the
         # various extensions it supports
         kfp.compiler.Compiler()._write_workflow(workflow_yaml, pipeline_file_path)
-        
+
         return os.path.abspath(pipeline_file_path)
 
     @staticmethod

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -182,13 +182,6 @@ class KubeflowPipelines(object):
         self.notify_on_success = notify_on_success
         self._client = None
 
-    def get_kubernetes_service_account(self) -> str:
-        """Returns the service account from an individual profile notebook if a user
-        inputs an IAM role for their notebook. If no ServiceAccount is set by the user,
-        default to the`deafult-editor` ServiceAccount.
-        """
-        return KUBERNETES_SERVICE_ACCOUNT if not None else "default-editor"
-
     def set_kfp_client(self):
         # kfp userid needs to have the user domain
         kfp_client_user_email = self.username
@@ -212,7 +205,7 @@ class KubeflowPipelines(object):
             experiment_name=self.experiment,
             run_name=run_name,
             namespace=self.kfp_namespace,
-            service_account=self.get_kubernetes_service_account(),
+            service_account=KUBERNETES_SERVICE_ACCOUNT,
         )
 
     def create_kfp_pipeline_yaml(self, pipeline_file_path) -> str:
@@ -227,19 +220,20 @@ class KubeflowPipelines(object):
             pipeline_conf=pipeline_conf,
         )
 
-        # use kfp client extract yaml method so we do not recreate logic that accounts
-        # for various extensions supported by kfp
-        self.set_kfp_client()
-        workflow_yaml = self._client._extract_pipeline_yaml(pipeline_file_path)
-
-        workflow_yaml["spec"][
-            "serviceAccountName"
-        ] = self.get_kubernetes_service_account()
-
-        # use internal kfp static method to write the modified yaml back to the
-        # pipeline_file_path so we do not have to recreate kfp support for the
-        # various extensions it supports
-        kfp.compiler.Compiler()._write_workflow(workflow_yaml, pipeline_file_path)
+        # re-write the workflow serviceAccountName if metaflow KUBERNETES_SERVICE_ACCOUNT
+        # is set.
+        if KUBERNETES_SERVICE_ACCOUNT:
+            self.set_kfp_client()
+            # use kfp client extract yaml method so we do not recreate logic that accounts
+            # for various extensions supported by kfp
+            workflow_yaml = self._client._extract_pipeline_yaml(pipeline_file_path)
+            workflow_yaml["spec"][
+                "serviceAccountName"
+            ] = KUBERNETES_SERVICE_ACCOUNT
+            # use internal kfp static method to write the modified yaml back to the
+            # pipeline_file_path so we do not have to recreate kfp support for the
+            # various extensions it supports
+            kfp.compiler.Compiler()._write_workflow(workflow_yaml, pipeline_file_path)
 
         return os.path.abspath(pipeline_file_path)
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -37,6 +37,7 @@ from metaflow.metaflow_config import (
     DATASTORE_SYSROOT_S3,
     KFP_TTL_SECONDS_AFTER_FINISHED,
     KFP_USER_DOMAIN,
+    KUBERNETES_SERVICE_ACCOUNT,
     METAFLOW_USER,
     from_conf,
 )
@@ -51,7 +52,6 @@ from ..aws.batch.batch_decorator import BatchDecorator
 from ..aws.step_functions.schedule_decorator import ScheduleDecorator
 from .accelerator_decorator import AcceleratorDecorator
 from .kfp_foreach_splits import KfpForEachSplits, graph_to_task_ids
-from .kfp_utils import get_notebook_metaflow_sa
 
 # TODO: @schedule
 UNSUPPORTED_DECORATORS = (
@@ -182,6 +182,13 @@ class KubeflowPipelines(object):
         self.notify_on_success = notify_on_success
         self._client = None
 
+    def get_kubernetes_service_account(self) -> str:
+        """Returns the service account from an individual profile notebook if a user
+        inputs an IAM role for their notebook. If no ServiceAccount is set by the user,
+        default to the`deafult-editor` ServiceAccount.
+        """
+        return KUBERNETES_SERVICE_ACCOUNT if not None else "default-editor"
+
     def set_kfp_client(self):
         # kfp userid needs to have the user domain
         kfp_client_user_email = self.username
@@ -205,7 +212,7 @@ class KubeflowPipelines(object):
             experiment_name=self.experiment,
             run_name=run_name,
             namespace=self.kfp_namespace,
-            service_account=get_notebook_metaflow_sa(),
+            service_account=self.get_kubernetes_service_account(),
         )
 
     def create_kfp_pipeline_yaml(self, pipeline_file_path) -> str:
@@ -225,7 +232,9 @@ class KubeflowPipelines(object):
         self.set_kfp_client()
         workflow_yaml = self._client._extract_pipeline_yaml(pipeline_file_path)
 
-        workflow_yaml["spec"]["serviceAccountName"] = get_notebook_metaflow_sa()
+        workflow_yaml["spec"][
+            "serviceAccountName"
+        ] = self.get_kubernetes_service_account()
 
         # use internal kfp static method to write the modified yaml back to the
         # pipeline_file_path so we do not have to recreate kfp support for the

--- a/metaflow/plugins/kfp/kfp_utils.py
+++ b/metaflow/plugins/kfp/kfp_utils.py
@@ -335,8 +335,8 @@ def _upload_pipeline(
 
 
 def get_notebook_metaflow_sa() -> str:
-    """ Returns the notebook service account from individual profiles if a user
-        inputs an IAM role for their notebook. If no ServiceAccount set in the notebook,
-        return the `deafult-editor` ServiceAccount which is default in all profiles.
+    """Returns the notebook service account from individual profiles if a user
+    inputs an IAM role for their notebook. If no ServiceAccount is set in the notebook
+    return the `deafult-editor` ServiceAccount which is default in all profiles.
     """
-    return os.environ.get('METAFLOW_KUBERNETES_SERVICE_ACCOUNT', 'default-editor')
+    return os.environ.get("METAFLOW_KUBERNETES_SERVICE_ACCOUNT", "default-editor")

--- a/metaflow/plugins/kfp/kfp_utils.py
+++ b/metaflow/plugins/kfp/kfp_utils.py
@@ -332,3 +332,10 @@ def _upload_pipeline(
         print(f"Uploaded test pipeline {pipeline_id} version {version_id}.")
 
     return pipeline_id, version_id
+
+
+def get_notebook_metaflow_sa() -> str:
+    """ Returns the notebook service account from individual profiles if a user
+        inputs an IAM role for their notebook.
+    """
+    return os.environ.get('METAFLOW_KUBERNETES_SERVICE_ACCOUNT', 'default-editor')

--- a/metaflow/plugins/kfp/kfp_utils.py
+++ b/metaflow/plugins/kfp/kfp_utils.py
@@ -332,11 +332,3 @@ def _upload_pipeline(
         print(f"Uploaded test pipeline {pipeline_id} version {version_id}.")
 
     return pipeline_id, version_id
-
-
-def get_notebook_metaflow_sa() -> str:
-    """Returns the notebook service account from individual profiles if a user
-    inputs an IAM role for their notebook. If no ServiceAccount is set in the notebook
-    return the `deafult-editor` ServiceAccount which is default in all profiles.
-    """
-    return os.environ.get("METAFLOW_KUBERNETES_SERVICE_ACCOUNT", "default-editor")

--- a/metaflow/plugins/kfp/kfp_utils.py
+++ b/metaflow/plugins/kfp/kfp_utils.py
@@ -336,6 +336,7 @@ def _upload_pipeline(
 
 def get_notebook_metaflow_sa() -> str:
     """ Returns the notebook service account from individual profiles if a user
-        inputs an IAM role for their notebook.
+        inputs an IAM role for their notebook. If no ServiceAccount set in the notebook,
+        return the `deafult-editor` ServiceAccount which is default in all profiles.
     """
     return os.environ.get('METAFLOW_KUBERNETES_SERVICE_ACCOUNT', 'default-editor')

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -326,7 +326,7 @@ def test_kubernetes_service_account_compile_only() -> None:
             f" --yaml-only --pipeline-path {yaml_file_path}"
         )
 
-    flow_yaml = get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path)
+        flow_yaml = get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path)
 
     assert flow_yaml["spec"]["serviceAccountName"] == service_account
 

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -297,6 +297,42 @@ def has_node_toleration(
     )
 
 
+def get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path) -> Dict[str, str]:
+    compile_to_yaml_process: CompletedProcess = run(
+        compile_to_yaml_cmd,
+        universal_newlines=True,
+        shell=True,
+    )
+
+    assert compile_to_yaml_process.returncode == 0
+
+    with open(f"{yaml_file_path}", "r") as stream:
+        try:
+            flow_yaml: dict = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    return flow_yaml
+
+
+def test_kubernetes_service_account_compile_only() -> None:
+    service_account = "test-service-account"
+    with tempfile.TemporaryDirectory() as yaml_tmp_dir:
+        yaml_file_path: str = join(yaml_tmp_dir, "kubernetes_service_account.yaml")
+
+        compile_to_yaml_cmd: str = (
+            f"export METAFLOW_KUBERNETES_SERVICE_ACCOUNT={service_account};"
+            f"{_python()} flows/toleration_and_affinity_flow.py kfp run"
+            f"--yaml-only --pipeline-path {yaml_file_path}"
+        )
+
+    flow_yaml = get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path)
+
+    print(flow_yaml)
+
+    assert flow_yaml["spec"]["serviceAccountName"] == service_account
+
+
 def test_toleration_and_affinity_compile_only() -> None:
     step_templates: Dict[str, str] = {}
     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
@@ -307,18 +343,7 @@ def test_toleration_and_affinity_compile_only() -> None:
             f" --no-s3-code-package --yaml-only --pipeline-path {yaml_file_path}"
         )
 
-        compile_to_yaml_process: CompletedProcess = run(
-            compile_to_yaml_cmd,
-            universal_newlines=True,
-            shell=True,
-        )
-        assert compile_to_yaml_process.returncode == 0
-
-        with open(f"{yaml_file_path}", "r") as stream:
-            try:
-                flow_yaml: dict = yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
-                print(exc)
+        flow_yaml = get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path)
 
         for step in flow_yaml["spec"]["templates"]:
             # step name in yaml use "-" in place of "_"

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -328,8 +328,6 @@ def test_kubernetes_service_account_compile_only() -> None:
 
     flow_yaml = get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path)
 
-    print(flow_yaml)
-
     assert flow_yaml["spec"]["serviceAccountName"] == service_account
 
 

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -322,8 +322,8 @@ def test_kubernetes_service_account_compile_only() -> None:
 
         compile_to_yaml_cmd: str = (
             f"export METAFLOW_KUBERNETES_SERVICE_ACCOUNT={service_account};"
-            f"{_python()} flows/toleration_and_affinity_flow.py kfp run"
-            f"--yaml-only --pipeline-path {yaml_file_path}"
+            f" {_python()} flows/toleration_and_affinity_flow.py kfp run"
+            f" --yaml-only --pipeline-path {yaml_file_path}"
         )
 
     flow_yaml = get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path)


### PR DESCRIPTION
In order to support IAM roles for individual profiles we also need to support IAM roles per workflow from the workflow SDK. This change pulls in an environment variable set in the host notebook pod and launches the underlying Argo workflow with the configured role from the user.