### PR TITLE
AIP-6514 local storage deprecation

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -292,8 +292,8 @@ class KubeflowPipelines(object):
             if isinstance(deco, ResourcesDecorator):
                 if deco.attributes.get("local_storage") is not None:
                     raise ValueError(  # Not using DeprecationWarning to hard block the run before triggering.
-                        "`local_storage` option is deprecated over cluster stability concerns."
-                        "Please use `volume` for storage space."
+                        "`local_storage` option is deprecated over cluster stability concerns. "
+                        "Please use `volume` for storage request."
                     )
 
                 for attr_key, attr_value in deco.attributes.items():

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -47,8 +47,6 @@ def get_env_vars(env_resources: Dict[str, str]) -> List[V1EnvVar]:
 
 kubernetes_vars = get_env_vars(
     {
-        "LOCAL_STORAGE": "requests.ephemeral-storage",
-        "LOCAL_STORAGE_LIMIT": "limits.ephemeral-storage",
         "CPU": "requests.cpu",
         "CPU_LIMIT": "limits.cpu",
         "MEMORY": "requests.memory",
@@ -134,7 +132,6 @@ class ResourcesFlow(FlowSpec):
 
     @accelerator(type=None)  # AIP-6604 DCR: Allow @accelerator(type=None)
     @resources(
-        local_storage="242",
         cpu="0.6",
         memory="1G",
     )
@@ -154,8 +151,6 @@ class ResourcesFlow(FlowSpec):
         assert "resourcesflow" in os.environ.get("MY_POD_NAME")
         assert os.environ.get("CPU") == "600"
         assert os.environ.get("CPU_LIMIT") == "600"
-        assert os.environ.get("LOCAL_STORAGE") == "242000000"
-        assert os.environ.get("LOCAL_STORAGE_LIMIT") == "242000000"
         assert os.environ.get("MEMORY") == "1000000000"
         assert os.environ.get("MEMORY_LIMIT") == "1000000000"
 

--- a/metaflow/plugins/kfp/tests/flows/toleration_and_affinity_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/toleration_and_affinity_flow.py
@@ -4,7 +4,6 @@ from metaflow import FlowSpec, accelerator, resources, step
 class TolerationAndAffinityFlow(FlowSpec):
     @accelerator(type="nvidia-tesla-v100")
     @resources(
-        local_storage="242",
         cpu="0.6",
         memory="2G",
     )

--- a/metaflow/plugins/resources_decorator.py
+++ b/metaflow/plugins/resources_decorator.py
@@ -55,17 +55,6 @@ class ResourcesDecorator(StepDecorator):
         Not for KFP
         AWS Batch: The value for the size (in MiB) of the /dev/shm volume for this step.
             This parameter maps to the --shm-size option to docker run .
-    local_storage: Union[int, str]
-        Not for AWS Batch.
-        KFP: Local ephemeral storage required.
-            Defaults None - relying on Kubernetes defaults.
-            **Note:** If you need to increase local ephemeral storage,
-            then we recommend requesting storage which creates a volume instead.
-            This is local disk storage per step and lost after the step.
-            Default unit is MB. See notes above for more units.
-    local_storage_limit: Union[int, str]
-        Not for AWS Batch.
-        KFP: Local ephemeral storage limit.
     volume: Union[int, str]
         Not for AWS Batch.
         KFP: Attaches a volume which by default is not accessible to subsequent steps.
@@ -97,8 +86,9 @@ class ResourcesDecorator(StepDecorator):
         "shared_memory": None,
         # Only KFP supported attributes
         "gpu_vendor": None,
-        "local_storage": None,
         "volume": None,
         "volume_mode": "ReadWriteOnce",
         "volume_dir": "/opt/metaflow_volume",
+        # Deprecated - kept only to show a meaningful error message
+        "local_storage": None,
     }


### PR DESCRIPTION
Removing code for local_storage configuration. Add exception for user who attempts to use it.

User will see the following at compile time if upgraded to this version:
```
Deploying ResourcesFlow to Kubeflow Pipelines...
    Internal error
Traceback (most recent call last):
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/cli.py", line 1163, in main
    start(auto_envvar_prefix="METAFLOW", obj=state)
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/_vendor/click/core.py", line 829, in __call__
    return self.main(args, kwargs)
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/_vendor/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/_vendor/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/_vendor/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/_vendor/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, ctx.params)
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/_vendor/click/core.py", line 610, in invoke
    return callback(args, kwargs)
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/_vendor/click/decorators.py", line 33, in new_func
    return f(get_current_context().obj, args, kwargs)
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/plugins/kfp/kfp_cli.py", line 311, in run
    run_pipeline_result = flow.create_run_on_kfp(run_name, flow_parameters)
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/plugins/kfp/kfp.py", line 197, in create_run_on_kfp
    pipeline_func, _ = self.create_kfp_pipeline_from_flow_graph()
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/plugins/kfp/kfp.py", line 650, in create_kfp_pipeline_from_flow_graph
    ] = self._create_kfp_components_from_graph()
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/plugins/kfp/kfp.py", line 406, in _create_kfp_components_from_graph
    step_name_to_kfp_component[step_name] = build_kfp_component(node, task_id)
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/plugins/kfp/kfp.py", line 369, in build_kfp_component
    resource_requirements = self._get_resource_requirements(node)
  File "/Users/yunw/.pyenv/versions/3.9.11/lib/python3.9/site-packages/metaflow/plugins/kfp/kfp.py", line 275, in _get_resource_requirements
    raise ValueError(  # Not using DeprecationWarning to hard block the run before triggering.
ValueError: `local_storage` option is deprecated over cluster stability concerns. Please use `volume` for storage request.
```