### PR TITLE
AIP-6493 zodiac_owner label & tag

### DIFF
--- a/metaflow/metadata/metadata.py
+++ b/metaflow/metadata/metadata.py
@@ -516,8 +516,9 @@ class MetadataProvider(object):
             "k8s_namespace": os.environ.get("MF_POD_NAMESPACE"),
             "zodiac_service": os.environ.get("ZODIAC_SERVICE"),
             "zodiac_team": os.environ.get("ZODIAC_TEAM"),
+            "zodiac_owner": os.environ.get("ZODIAC_OWNER"),
         }
-        for key in ["k8s_namespace", "zodiac_service", "zodiac_team"]:
+        for key in ["k8s_namespace", "zodiac_service", "zodiac_team", "zodiac_owner"]:
             if kfp_tags[key]:
                 tags.append(f"{key}:{kfp_tags[key]}")
         return tags

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -646,7 +646,7 @@ class KubeflowPipelines(object):
         # - In the context of a Zillow NB self.username == METAFLOW_USER (user_alias)
         #   and KFP_USER_DOMAIN == "zillowgroup.com"
         # - In the context of Metaflow integration tests self.username == USER=$GITLAB_USER_EMAIL
-        user_email = self.username  
+        user_email = self.username
         if KFP_USER_DOMAIN:
             user_email += f"@{KFP_USER_DOMAIN}"
         container_op.add_pod_label("zodiac.zillowgroup.net/owner", user_email)

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -642,6 +642,15 @@ class KubeflowPipelines(object):
                 "tags.ledger.zgtools.net/ai-experiment-name", self.experiment
             )
 
+        # - In context of Zillow CICD self.username == "cicd_compile"
+        # - In the context of a Zillow NB self.username == METAFLOW_USER (user_alias)
+        #   and KFP_USER_DOMAIN == "zillowgroup.com"
+        # - In the context of Metaflow integration tests self.username == USER=$GITLAB_USER_EMAIL
+        user_email = self.username  
+        if KFP_USER_DOMAIN:
+            user_email += f"@{KFP_USER_DOMAIN}"
+        container_op.add_pod_label("zodiac.zillowgroup.net/owner", user_email)
+
     def create_kfp_pipeline_from_flow_graph(self) -> Tuple[Callable, PipelineConf]:
         """
         Returns a KFP DSL Pipeline function by walking the Metaflow Graph
@@ -663,6 +672,7 @@ class KubeflowPipelines(object):
                     "MF_ARGO_WORKFLOW_NAME": "metadata.labels['workflows.argoproj.io/workflow']",
                     "ZODIAC_SERVICE": "metadata.labels['zodiac.zillowgroup.net/service']",
                     "ZODIAC_TEAM": "metadata.labels['zodiac.zillowgroup.net/team']",
+                    "ZODIAC_OWNER": "metadata.labels['zodiac.zillowgroup.net/owner']",
                 }
                 for name, resource in env_vars.items():
                     op.container.add_env_variable(

--- a/metaflow/plugins/kfp/tests/flows/metadata_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/metadata_flow.py
@@ -38,6 +38,7 @@ class MetadataFlow(FlowSpec):
         assert "metaflow_test" in start_step_tags
         assert f"zodiac_service:{os.environ['ZODIAC_SERVICE']}" in start_step_tags
         assert f"zodiac_team:{os.environ['ZODIAC_TEAM']}" in start_step_tags
+        assert f"zodiac_owner:{os.environ['ZODIAC_OWNER']}" in start_step_tags
         assert f"k8s_namespace:{os.environ['MF_POD_NAMESPACE']}" in start_step_tags
 
         print("MetadataFlow is all done.")

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -82,7 +82,7 @@ labels = {
     "tags.ledger.zgtools.net/ai-flow-name": "AI_FLOW_NAME",
     "tags.ledger.zgtools.net/ai-step-name": "AI_STEP_NAME",
     "tags.ledger.zgtools.net/ai-experiment-name": "AI_EXPERIMENT_NAME",
-    "zodiac.zillowgroup.net/owner": "ZODIAC_OWNER"
+    "zodiac.zillowgroup.net/owner": "ZODIAC_OWNER",
 }
 for label, env_name in labels.items():
     kubernetes_vars.append(

--- a/metaflow/plugins/kfp/tests/flows/resources_flow.py
+++ b/metaflow/plugins/kfp/tests/flows/resources_flow.py
@@ -82,6 +82,7 @@ labels = {
     "tags.ledger.zgtools.net/ai-flow-name": "AI_FLOW_NAME",
     "tags.ledger.zgtools.net/ai-step-name": "AI_STEP_NAME",
     "tags.ledger.zgtools.net/ai-experiment-name": "AI_EXPERIMENT_NAME",
+    "zodiac.zillowgroup.net/owner": "ZODIAC_OWNER"
 }
 for label, env_name in labels.items():
     kubernetes_vars.append(
@@ -162,6 +163,8 @@ class ResourcesFlow(FlowSpec):
         assert os.environ.get("AI_FLOW_NAME") == current.flow_name
         assert os.environ.get("AI_STEP_NAME") == current.step_name
         assert os.environ.get("AI_EXPERIMENT_NAME") == "metaflow_test"
+
+        assert os.environ.get("ZODIAC_OWNER")
 
         self.items = [1, 2]
         self.next(self.foreach_step, foreach="items")


### PR DESCRIPTION
- [x] set `zodiac.zillowgroup.net/owner` to current user in the NB scenario
- [x] set  `zodiac_owner` Metaflow tag to be consistent with `zodiac_service` and `zodiac_team` tags
- [x] set `ZODIAC_OWNER` pod env variable to be able to set above Metaflow tag