### PR TITLE
 k8s labels zodiac owner w/o "@" alias only

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -647,8 +647,6 @@ class KubeflowPipelines(object):
         #   and KFP_USER_DOMAIN == "zillowgroup.com"
         # - In the context of Metaflow integration tests self.username == USER=$GITLAB_USER_EMAIL
         user_email = self.username
-        if KFP_USER_DOMAIN:
-            user_email += f"@{KFP_USER_DOMAIN}"
         container_op.add_pod_label("zodiac.zillowgroup.net/owner", user_email)
 
     def create_kfp_pipeline_from_flow_graph(self) -> Tuple[Callable, PipelineConf]:

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -644,7 +644,6 @@ class KubeflowPipelines(object):
 
         # - In context of Zillow CICD self.username == "cicd_compile"
         # - In the context of a Zillow NB self.username == METAFLOW_USER (user_alias)
-        #   and KFP_USER_DOMAIN == "zillowgroup.com"
         # - In the context of Metaflow integration tests self.username == USER=$GITLAB_USER_EMAIL
         user_email = self.username
         container_op.add_pod_label("zodiac.zillowgroup.net/owner", user_email)


### PR DESCRIPTION
To fix
```
This step is in Error state with this message: Pod "failureflow-qc59j-1192218406" is invalid: metadata.labels: Invalid value: "talebz@zillowgroup.com": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```