### PR TITLE
Bump version to 1.3.x

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ include:
 variables:
   PY_LIBRARY_NAME: "zillow-metaflow"
   MAJOR_VERSION: "1"
-  MINOR_VERSION: "2"
+  MINOR_VERSION: "3"
   METAFLOW_VERSION_PATH: "setup.py"
   IMAGE_REPOSITORY_TAG_PATH: 'image_tag_file.txt'
   IMAGE_REPOSITORY_TAG_PATH_KFP_STEP: 'image_tag_file_kfp_step.txt'


### PR DESCRIPTION
Bumping minor version given two deprecation PRs:
- https://github.com/zillow/metaflow/pull/211
- https://github.com/zillow/metaflow/pull/198