### PR TITLE
AIP-6643: Add in log file output per test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ main.js.map
 
 .coverage
 .coverage.*
+pytest-logs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ stages:
         ${BUILT_IMAGE_FULL_PATH}
         bash -c "
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg --public-dir /home/zservice/public
+          python -m pytest -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg --public-dir /home/zservice/public
         "
   artifacts:
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ stages:
         ${BUILT_IMAGE_FULL_PATH}
         bash -c "
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg --public-dir /home/zservice/public
+          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg --public-dir /home/zservice/public
         "
   artifacts:
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ stages:
         ${BUILT_IMAGE_FULL_PATH}
         bash -c "
           cd /home/zservice/metaflow/metaflow/plugins/kfp/tests &&
-          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg
+          python -m pytest -s -n 3 run_integration_tests.py --image ${BUILT_IMAGE_FULL_PATH} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg --public-dir /home/zservice/public
         "
   artifacts:
     when: always

--- a/metaflow/plugins/kfp/kfp_cli.py
+++ b/metaflow/plugins/kfp/kfp_cli.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 import subprocess
+import logging
 
 from metaflow import JSONType, current, decorators, parameters
 from metaflow._vendor import click
@@ -225,6 +226,13 @@ def step_init(obj, run_id, step_name, passed_in_split_indexes, task_id):
     "If not set, METAFLOW_NOTIFY_ON_SUCCESS is used from Metaflow config or environment variable",
     show_default=True,
 )
+@click.option(
+    "--verbose/--no-verbose",
+    "verbose",
+    default=False,
+    help="Turns on debug logging.",
+    show_default=True,
+)
 @click.pass_obj
 def run(
     obj,
@@ -248,11 +256,17 @@ def run(
     notify_on_error=None,
     notify_on_success=None,
     argo_wait=False,
+    verbose=False,
     **kwargs,
 ):
     """
     Analogous to step_functions_cli.py
     """
+
+    if verbose:
+        # Turn on debugging for the root logger so in particular we can see logs emitted by the KFP
+        # SDK as that by default emits there.
+        logging.basicConfig(level=logging.DEBUG)
 
     def _convert_value(param: parameters.Parameter):
         v = kwargs.get(param.name)

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -11,15 +11,20 @@ def pytest_addoption(parser):
     parser.addoption(
         "--opsgenie-api-token", dest="opsgenie_api_token", action="store", default=None
     )
+    parser.addoption("--public-directory", dest="public_dir", action="store", default='')
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
-def pytest_runtest_setup(item):
+def pytest_runtest_setup(item, pytestconfig):
     """Emit a log file per test to make it easier to debug in failure scenarios.
 
     Sourced from:  https://stackoverflow.com/a/64480499
     """
     logging_plugin = item.config.pluginmanager.get_plugin("logging-plugin")
-    filename = Path('pytest-logs', f"{item._request.node.name}.log")
+    filename = Path(
+        pytestconfig.getoption('public_dir'),
+        'pytest-logs',
+        f"{item._request.node.name}.log"
+    )
     logging_plugin.set_log_path(str(filename))
     yield

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -11,7 +11,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--opsgenie-api-token", dest="opsgenie_api_token", action="store", default=None
     )
-    parser.addoption("--public-directory", dest="public_dir", action="store", default='')
+    parser.addoption("--public-dir", dest="public_dir", action="store", default='')
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -24,14 +24,18 @@ def pytest_addoption(parser):
 class StreamToLogger(TextIOBase):
     """Fake file-like stream object that redirects writes to a logger instance."""
 
-    def __init__(self, logger, level):
+    def __init__(self, logger, level, original_stream):
         self.logger = logger
         self.level = level
         self.linebuf = ""
+        self.original_stream = original_stream
 
     def write(self, buf):
         for line in buf.rstrip().splitlines():
             self.logger.log(self.level, line.rstrip())
+        else:
+            # Additionally ensure we also write back to the original stream too!
+            self.original_stream.write(buf)
 
     def flush(self):
         pass
@@ -44,14 +48,10 @@ def pytest_runtest_setup(item):
     Sourced from:  https://stackoverflow.com/a/64480499
     """
     logging_plugin = item.config.pluginmanager.get_plugin("logging-plugin")
-    filename = Path(
-        item.config.getoption('public_dir'),
-        'pytest-logs',
-        f"{item._request.node.name}.log"
-    )
+    filename = Path("pytest-logs", f"{item._request.node.name}.log")
     logging_plugin.set_log_path(str(filename))
 
     # Forward logs from stdout/stderr to the logger as well.
-    sys.stdout = StreamToLogger(logger, logging.INFO)
-    sys.stderr =  StreamToLogger(logger, logging.ERROR)
+    sys.stdout = StreamToLogger(logger, logging.INFO, sys.stdout)
+    sys.stderr =  StreamToLogger(logger, logging.INFO, sys.stderr)
     yield

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -1,5 +1,12 @@
-import pytest
+import logging
+import sys
 from pathlib import Path
+from io import TextIOBase
+import pytest
+
+
+# Use the root logger for stdout/stderr patching.
+logger = logging.getLogger()
 
 
 def pytest_addoption(parser):
@@ -12,6 +19,22 @@ def pytest_addoption(parser):
         "--opsgenie-api-token", dest="opsgenie_api_token", action="store", default=None
     )
     parser.addoption("--public-dir", dest="public_dir", action="store", default='')
+
+
+class StreamToLogger(TextIOBase):
+    """Fake file-like stream object that redirects writes to a logger instance."""
+
+    def __init__(self, logger, level):
+        self.logger = logger
+        self.level = level
+        self.linebuf = ""
+
+    def write(self, buf):
+        for line in buf.rstrip().splitlines():
+            self.logger.log(self.level, line.rstrip())
+
+    def flush(self):
+        pass
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
@@ -27,4 +50,8 @@ def pytest_runtest_setup(item):
         f"{item._request.node.name}.log"
     )
     logging_plugin.set_log_path(str(filename))
+
+    # Forward logs from stdout/stderr to the logger as well.
+    sys.stdout = StreamToLogger(logger, logging.INFO)
+    sys.stderr =  StreamToLogger(logger, logging.ERROR)
     yield

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -18,7 +18,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--opsgenie-api-token", dest="opsgenie_api_token", action="store", default=None
     )
-    parser.addoption("--public-dir", dest="public_dir", action="store", default='')
+    parser.addoption("--public-dir", dest="public_dir", action="store", default="")
 
 
 class StreamToLogger(TextIOBase):
@@ -49,9 +49,9 @@ def pytest_runtest_setup(item):
     """
     logging_plugin = item.config.pluginmanager.get_plugin("logging-plugin")
     filename = Path(
-        item.config.getoption('public_dir'),
+        item.config.getoption("public_dir"),
         "pytest-logs",
-        f"{item._request.node.name}.log"
+        f"{item._request.node.name}.log",
     )
     logging_plugin.set_log_path(str(filename))
 
@@ -59,5 +59,5 @@ def pytest_runtest_setup(item):
     if not isinstance(sys.stdout, StreamToLogger):
         sys.stdout = StreamToLogger(logger, logging.INFO, sys.stdout)
     if not isinstance(sys.stderr, StreamToLogger):
-        sys.stderr =  StreamToLogger(logger, logging.INFO, sys.stderr)
+        sys.stderr = StreamToLogger(logger, logging.INFO, sys.stderr)
     yield

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -56,6 +56,8 @@ def pytest_runtest_setup(item):
     logging_plugin.set_log_path(str(filename))
 
     # Forward logs from stdout/stderr to the logger as well.
-    sys.stdout = StreamToLogger(logger, logging.INFO, sys.stdout)
-    sys.stderr =  StreamToLogger(logger, logging.INFO, sys.stderr)
+    if not isinstance(sys.stdout, StreamToLogger):
+        sys.stdout = StreamToLogger(logger, logging.INFO, sys.stdout)
+    if not isinstance(sys.stderr, StreamToLogger):
+        sys.stderr =  StreamToLogger(logger, logging.INFO, sys.stderr)
     yield

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -1,3 +1,7 @@
+import pytest
+from pathlib import Path
+
+
 def pytest_addoption(parser):
     """
     The image on Artifactory that corresponds to the currently
@@ -7,3 +11,15 @@ def pytest_addoption(parser):
     parser.addoption(
         "--opsgenie-api-token", dest="opsgenie_api_token", action="store", default=None
     )
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_setup(item):
+    """Emit a log file per test to make it easier to debug in failure scenarios.
+
+    Sourced from:  https://stackoverflow.com/a/64480499
+    """
+    logging_plugin = item.config.pluginmanager.get_plugin("logging-plugin")
+    filename = Path('pytest-logs', f"{item._request.node.name}.log")
+    logging_plugin.set_log_path(str(filename))
+    yield

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -48,7 +48,11 @@ def pytest_runtest_setup(item):
     Sourced from:  https://stackoverflow.com/a/64480499
     """
     logging_plugin = item.config.pluginmanager.get_plugin("logging-plugin")
-    filename = Path("pytest-logs", f"{item._request.node.name}.log")
+    filename = Path(
+        item.config.getoption('public_dir'),
+        "pytest-logs",
+        f"{item._request.node.name}.log"
+    )
     logging_plugin.set_log_path(str(filename))
 
     # Forward logs from stdout/stderr to the logger as well.

--- a/metaflow/plugins/kfp/tests/conftest.py
+++ b/metaflow/plugins/kfp/tests/conftest.py
@@ -15,14 +15,14 @@ def pytest_addoption(parser):
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
-def pytest_runtest_setup(item, pytestconfig):
+def pytest_runtest_setup(item):
     """Emit a log file per test to make it easier to debug in failure scenarios.
 
     Sourced from:  https://stackoverflow.com/a/64480499
     """
     logging_plugin = item.config.pluginmanager.get_plugin("logging-plugin")
     filename = Path(
-        pytestconfig.getoption('public_dir'),
+        item.config.getoption('public_dir'),
         'pytest-logs',
         f"{item._request.node.name}.log"
     )

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -58,16 +58,23 @@ def _python():
 
 
 def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
-    file_paths: List[str] = [
-        file_name
-        for file_name in listdir(flow_dir_path)
-        if isfile(join(flow_dir_path, file_name))
-        and not file_name.startswith(".")
-        and not file_name in non_standard_test_flows
+    # TODO AIP-6643 Reinstate all the tests before merging!!!
+    return [
+        'foreach_linear_foreach.py',
+        'foreach_linear_split.py',
+        'foreach_split_linear.py',
     ]
-    return file_paths
+    # file_paths: List[str] = [
+    #     file_name
+    #     for file_name in listdir(flow_dir_path)
+    #     if isfile(join(flow_dir_path, file_name))
+    #     and not file_name.startswith(".")
+    #     and not file_name in non_standard_test_flows
+    # ]
+    # return file_paths
 
 
+@pytest.mark.skip
 def test_s3_sensor_flow(pytestconfig) -> None:
     # ensure the s3_sensor waits for some time before the key exists
     file_name: str = f"s3-sensor-file-{uuid.uuid1()}.txt"
@@ -205,7 +212,6 @@ def test_error_and_opsgenie_alert(pytestconfig) -> None:
     return
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
 def test_flows(pytestconfig, flow_file_path: str) -> None:
     full_path: str = join("flows", flow_file_path)

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -58,6 +58,8 @@ def _python():
 
 
 def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
+    # TODO AIP-6643 Revert this
+    return ['nested_foreach_with_branching.py']
     file_paths: List[str] = [
         file_name
         for file_name in listdir(flow_dir_path)
@@ -68,6 +70,7 @@ def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
     return file_paths
 
 
+@pytest.mark.skip
 def test_s3_sensor_flow(pytestconfig) -> None:
     # ensure the s3_sensor waits for some time before the key exists
     file_name: str = f"s3-sensor-file-{uuid.uuid1()}.txt"
@@ -131,6 +134,7 @@ def test_s3_sensor_flow(pytestconfig) -> None:
 
 # This test ensures that a flow fails correctly,
 # and when it fails, an OpsGenie email is sent.
+@pytest.mark.skip
 def test_error_and_opsgenie_alert(pytestconfig) -> None:
     raise_error_flow_cmd: str = (
         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
@@ -317,6 +321,7 @@ def get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path) -> Dict[str, str]:
     return flow_yaml
 
 
+@pytest.mark.skip
 def test_kubernetes_service_account_compile_only() -> None:
     service_account = "test-service-account"
     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
@@ -333,6 +338,7 @@ def test_kubernetes_service_account_compile_only() -> None:
     assert flow_yaml["spec"]["serviceAccountName"] == service_account
 
 
+@pytest.mark.skip
 def test_toleration_and_affinity_compile_only() -> None:
     step_templates: Dict[str, str] = {}
     with tempfile.TemporaryDirectory() as yaml_tmp_dir:

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -131,6 +131,7 @@ def test_s3_sensor_flow(pytestconfig) -> None:
 
 # This test ensures that a flow fails correctly,
 # and when it fails, an OpsGenie email is sent.
+@pytest.mark.skip
 def test_error_and_opsgenie_alert(pytestconfig) -> None:
     raise_error_flow_cmd: str = (
         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
@@ -204,6 +205,7 @@ def test_error_and_opsgenie_alert(pytestconfig) -> None:
     return
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("flow_file_path", obtain_flow_file_paths("flows"))
 def test_flows(pytestconfig, flow_file_path: str) -> None:
     full_path: str = join("flows", flow_file_path)
@@ -316,6 +318,7 @@ def get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path) -> Dict[str, str]:
     return flow_yaml
 
 
+@pytest.mark.skip
 def test_kubernetes_service_account_compile_only() -> None:
     service_account = "test-service-account"
     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
@@ -332,6 +335,7 @@ def test_kubernetes_service_account_compile_only() -> None:
     assert flow_yaml["spec"]["serviceAccountName"] == service_account
 
 
+@pytest.mark.skip
 def test_toleration_and_affinity_compile_only() -> None:
     step_templates: Dict[str, str] = {}
     with tempfile.TemporaryDirectory() as yaml_tmp_dir:

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -232,7 +232,8 @@ def run_cmd_with_backoff_from_platform_errors(
     # as well as output to stdout and stderr (which users can see on the Gitlab logs). We check
     # if the error message is due to a KFAM issue, and if so, we do an exponential backoff.
 
-    backoff_intervals_in_seconds: List[int] = [0, 2, 4, 8, 16, 32]
+    # TODO AIP-6643 Limit retries so we get all the logs
+    backoff_intervals_in_seconds: List[int] = [0, 2, 4] # , 8, 16, 32]
 
     platform_error_messages: List[str] = [
         "Reason: Unauthorized",

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -214,7 +214,7 @@ def test_flows(pytestconfig, flow_file_path: str) -> None:
 
     test_cmd: str = (
         f"{_python()} {full_path} --datastore=s3 --with retry kfp run "
-        f"--wait-for-completion --workflow-timeout 1800 "
+        f"--wait-for-completion --workflow-timeout 1800 --verbose "
         f"--max-parallelism 3 --experiment metaflow_test --tag test_t1 "
         f"--sys-tag test_sys_t1:sys_tag_value "
     )

--- a/metaflow/plugins/kfp/tests/run_integration_tests.py
+++ b/metaflow/plugins/kfp/tests/run_integration_tests.py
@@ -58,23 +58,16 @@ def _python():
 
 
 def obtain_flow_file_paths(flow_dir_path: str) -> List[str]:
-    # TODO AIP-6643 Reinstate all the tests before merging!!!
-    return [
-        'foreach_linear_foreach.py',
-        'foreach_linear_split.py',
-        'foreach_split_linear.py',
+    file_paths: List[str] = [
+        file_name
+        for file_name in listdir(flow_dir_path)
+        if isfile(join(flow_dir_path, file_name))
+        and not file_name.startswith(".")
+        and not file_name in non_standard_test_flows
     ]
-    # file_paths: List[str] = [
-    #     file_name
-    #     for file_name in listdir(flow_dir_path)
-    #     if isfile(join(flow_dir_path, file_name))
-    #     and not file_name.startswith(".")
-    #     and not file_name in non_standard_test_flows
-    # ]
-    # return file_paths
+    return file_paths
 
 
-@pytest.mark.skip
 def test_s3_sensor_flow(pytestconfig) -> None:
     # ensure the s3_sensor waits for some time before the key exists
     file_name: str = f"s3-sensor-file-{uuid.uuid1()}.txt"
@@ -138,7 +131,6 @@ def test_s3_sensor_flow(pytestconfig) -> None:
 
 # This test ensures that a flow fails correctly,
 # and when it fails, an OpsGenie email is sent.
-@pytest.mark.skip
 def test_error_and_opsgenie_alert(pytestconfig) -> None:
     raise_error_flow_cmd: str = (
         f"{_python()} flows/raise_error_flow.py --datastore=s3 kfp run "
@@ -324,7 +316,6 @@ def get_compiled_yaml(compile_to_yaml_cmd, yaml_file_path) -> Dict[str, str]:
     return flow_yaml
 
 
-@pytest.mark.skip
 def test_kubernetes_service_account_compile_only() -> None:
     service_account = "test-service-account"
     with tempfile.TemporaryDirectory() as yaml_tmp_dir:
@@ -341,7 +332,6 @@ def test_kubernetes_service_account_compile_only() -> None:
     assert flow_yaml["spec"]["serviceAccountName"] == service_account
 
 
-@pytest.mark.skip
 def test_toleration_and_affinity_compile_only() -> None:
     step_templates: Dict[str, str] = {}
     with tempfile.TemporaryDirectory() as yaml_tmp_dir:

--- a/metaflow/plugins/kfp/tests/setup.cfg
+++ b/metaflow/plugins/kfp/tests/setup.cfg
@@ -13,7 +13,7 @@ exclude_lines =
 
 # pytest
 [tool:pytest]
-addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --log-file-level debug --log-cli-level info --log-format "%(asctime)s %(threadName)s %(filename)s:%(lineno)d %(levelname)s - %(message)s" --log-date-format "%Y-%m-%d %H:%M:%S"
+addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --log-file-level debug --log-cli-level info --log-file-format "%(asctime)s %(threadName)s %(filename)s:%(lineno)d %(levelname)s - %(message)s" --log-file-date-format "%Y-%m-%d %H:%M:%S"
 
 
 [html]

--- a/metaflow/plugins/kfp/tests/setup.cfg
+++ b/metaflow/plugins/kfp/tests/setup.cfg
@@ -13,7 +13,7 @@ exclude_lines =
 
 # pytest
 [tool:pytest]
-addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html
+addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --log-file-level debug
 
 [html]
 directory = /home/zservice/public/coverage

--- a/metaflow/plugins/kfp/tests/setup.cfg
+++ b/metaflow/plugins/kfp/tests/setup.cfg
@@ -13,7 +13,8 @@ exclude_lines =
 
 # pytest
 [tool:pytest]
-addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --log-file-level debug --log-cli-level info
+addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --log-file-level debug --log-cli-level info --logformat "%(asctime)s %(threadName)s %(filename)s:%(lineno)d %(levelname)s - %(message)s" --log-date-format "%Y-%m-%d %H:%M:%S"
+
 
 [html]
 directory = /home/zservice/public/coverage

--- a/metaflow/plugins/kfp/tests/setup.cfg
+++ b/metaflow/plugins/kfp/tests/setup.cfg
@@ -13,7 +13,7 @@ exclude_lines =
 
 # pytest
 [tool:pytest]
-addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --public-dir /home/zservice/public
+addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html
 
 [html]
 directory = /home/zservice/public/coverage

--- a/metaflow/plugins/kfp/tests/setup.cfg
+++ b/metaflow/plugins/kfp/tests/setup.cfg
@@ -13,7 +13,7 @@ exclude_lines =
 
 # pytest
 [tool:pytest]
-addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --log-file-level debug --log-cli-level info --logformat "%(asctime)s %(threadName)s %(filename)s:%(lineno)d %(levelname)s - %(message)s" --log-date-format "%Y-%m-%d %H:%M:%S"
+addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --log-file-level debug --log-cli-level info --log-format "%(asctime)s %(threadName)s %(filename)s:%(lineno)d %(levelname)s - %(message)s" --log-date-format "%Y-%m-%d %H:%M:%S"
 
 
 [html]

--- a/metaflow/plugins/kfp/tests/setup.cfg
+++ b/metaflow/plugins/kfp/tests/setup.cfg
@@ -13,7 +13,7 @@ exclude_lines =
 
 # pytest
 [tool:pytest]
-addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --log-file-level debug
+addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --log-file-level debug --log-cli-level info
 
 [html]
 directory = /home/zservice/public/coverage

--- a/metaflow/plugins/kfp/tests/setup.cfg
+++ b/metaflow/plugins/kfp/tests/setup.cfg
@@ -13,7 +13,7 @@ exclude_lines =
 
 # pytest
 [tool:pytest]
-addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html 
+addopts = -vv --cov=/home/zservice/metaflow/metaflow/plugins/kfp --cov-report term --cov-report html --public-dir /home/zservice/public
 
 [html]
-directory = /home/zservice/public
+directory = /home/zservice/public/coverage


### PR DESCRIPTION
To do:
- [ ] Understand root cause of intermittent 403 test failures (retries do seem to work which is weird).
- [ ] Understand root cause of intermittent S3 test failures.
- [x] Add in per-test file logging output, in addition to live logs to the CLI.
    - Hopefully this will make these deeper investigations easier as logs won't be interleaved!
    - Logs go to the `public/pytest-logs` folder, to make room I've shifted the coverage HTML output from `public` to `public/coverage` to minimize conflicts.
- [ ] Re-enable all integration tests - Temporarily disabled to expedite testing!