### PR TITLE
Pin min zillow-kfp version to speed up version resolution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     tests_require=["coverage"],
     extras_require={
-        "kfp": ["zillow-kfp", "kfp-server-api"],
+        "kfp": ["zillow-kfp>=1.8.0", "kfp-server-api"],
         # Use an extras here as there is no "extras_tests_require" functionality :(
         "kfp-tests": ["pytest", "pytest-xdist", "pytest-cov", "subprocess-tee"],
     },

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     tests_require=["coverage"],
     extras_require={
-        "kfp": ["zillow-kfp>=1.8.0", "kfp-server-api"],
+        "kfp": ["zillow-kfp>=1.0.80", "kfp-server-api"],
         # Use an extras here as there is no "extras_tests_require" functionality :(
         "kfp-tests": ["pytest", "pytest-xdist", "pytest-cov", "subprocess-tee"],
     },


### PR DESCRIPTION
zillow-kfp spawns quite a few other dependencies. Adding a lower bound help poetry resolve dependencies in projects depending on zillow-metaflow.

Let me know if you feel this is not a good approach.