### PR TITLE
AIP-7275 Save capacity-type, host, instance-type to MF metadata

### DIFF
--- a/metaflow/plugins/kfp/interruptible_decorator.py
+++ b/metaflow/plugins/kfp/interruptible_decorator.py
@@ -1,4 +1,18 @@
+import os
+from typing import Optional
+
+import requests
 from metaflow.decorators import StepDecorator
+from metaflow.metadata.metadata import MetaDatum
+
+
+def _get_ec2_metadata(path: str) -> Optional[str]:
+    response = requests.get(f"http://169.254.169.254/latest/meta-data/{path}")
+    if response.ok:
+        return response.text
+    else:
+        print(f"Error: {response.status_code}")
+        return None
 
 
 class interruptibleDecorator(StepDecorator):
@@ -22,3 +36,32 @@ class interruptibleDecorator(StepDecorator):
     """
 
     name = "interruptible"
+
+    def task_pre_step(
+        self,
+        step_name,
+        task_datastore,
+        metadata,
+        run_id,
+        task_id,
+        flow,
+        graph,
+        retry_count,
+        max_user_code_retries,
+        ubf_context,
+        inputs,
+    ):
+        # Determine whether this is running on Argo, and hence on AWS
+        if os.environ.get("MF_ARGO_WORKFLOW_NAME"):
+            meta = {
+                "capacity-type": _get_ec2_metadata(
+                    "instance-life-cycle"
+                ),  # returns: {on-demand, spot}
+                "hostname": _get_ec2_metadata("hostname"),
+                "instance-type": _get_ec2_metadata("instance-type"),
+            }
+
+            entries = [
+                MetaDatum(field=k, value=v, type=k, tags=[]) for k, v in meta.items()
+            ]
+            metadata.register_metadata(run_id, step_name, task_id, entries)

--- a/metaflow/plugins/kfp/interruptible_decorator.py
+++ b/metaflow/plugins/kfp/interruptible_decorator.py
@@ -8,11 +8,7 @@ from metaflow.metadata.metadata import MetaDatum
 
 def _get_ec2_metadata(path: str) -> Optional[str]:
     response = requests.get(f"http://169.254.169.254/latest/meta-data/{path}")
-    if response.ok:
-        return response.text
-    else:
-        print(f"Error: {response.status_code}")
-        return None
+    return response.text
 
 
 class interruptibleDecorator(StepDecorator):


### PR DESCRIPTION
Save capacity-type, hostname, instance-type per step within the @interruptible decorator. Enables the ability to query for all steps marked @interruptible and whether they ran on spot, and on what nodename and instance-type.

Example task metadata:
https://metaflow.int.stage-k8s.zg-aip.net/P3HelloFlow/kfp-482b3ae6-2ac1-4e56-a0b3-c35f75b69c54/start/kfp1?direction=desc&group=false&order=startTime&section=taskinfo

![image](https://user-images.githubusercontent.com/4167032/229868279-f5eed0e4-1b25-43ce-9eac-18bdf1b9cbf6.png)
