### PR TITLE
Argo: Remove service account; Use static workflow name

### DIFF
--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -231,19 +231,16 @@ class KubeflowPipelines(object):
         if output_format == "kfp":
             pass  # KFP pipeline yaml is created by default
         elif output_format == "argo-workflow":
-            workflow["spec"]["serviceAccountName"] = (
-                KUBERNETES_SERVICE_ACCOUNT or "default-editor"
+            workflow["metadata"]["name"] = (
+                workflow["metadata"].pop("generateName").rstrip("-")
             )
-            workflow["metadata"]["generateName"] = None
-            workflow["metadata"]["name"] = self.name
         elif output_format == "argo-workflow-template":
-            workflow["spec"]["serviceAccountName"] = (
-                KUBERNETES_SERVICE_ACCOUNT or "default-editor"
-            )
             workflow["kind"] = "WorkflowTemplate"
-            workflow["metadata"]["generateName"] = None
-            workflow["metadata"]["name"] = self.name
-            workflow["status"] = None
+            workflow["metadata"]["name"] = (
+                workflow["metadata"].pop("generateName").rstrip("-")
+            )
+            workflow["metadata"].pop("generateName", None)
+            workflow.pop("status", None)
         else:
             raise NotImplementedError(f"Unsupported output format {output_format}.")
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -231,16 +231,23 @@ class KubeflowPipelines(object):
         if output_format == "kfp":
             pass  # KFP pipeline yaml is created by default
         elif output_format == "argo-workflow":
-            workflow["metadata"]["name"] = (
-                workflow["metadata"].pop("generateName").rstrip("-")
-            )
+            # Output of KFP compiler already has workflow["kind"] = "Workflow".
+
+            # Keep generateName - Argo Workflow is usually used in single run.
+
+            # Service account is added through webhooks.
+            workflow["spec"].pop("serviceAccountName", None)
+
         elif output_format == "argo-workflow-template":
             workflow["kind"] = "WorkflowTemplate"
+
+            # Use static name to make referencing easier.
             workflow["metadata"]["name"] = (
                 workflow["metadata"].pop("generateName").rstrip("-")
             )
-            workflow["metadata"].pop("generateName", None)
-            workflow.pop("status", None)
+
+            # Service account is added through webhooks.
+            workflow["spec"].pop("serviceAccountName", None)
         else:
             raise NotImplementedError(f"Unsupported output format {output_format}.")
 

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -242,6 +242,9 @@ class KubeflowPipelines(object):
             workflow["kind"] = "WorkflowTemplate"
 
             # Use static name to make referencing easier.
+            # Note the name has to follow k8s format.
+            # self.name is typically CamelCase as it's python class name.
+            # generateName contains a sanitized version of self.name from kfp.compiler
             workflow["metadata"]["name"] = (
                 workflow["metadata"].pop("generateName").rstrip("-")
             )

--- a/metaflow/plugins/kfp/kfp.py
+++ b/metaflow/plugins/kfp/kfp.py
@@ -234,11 +234,15 @@ class KubeflowPipelines(object):
             workflow["spec"]["serviceAccountName"] = (
                 KUBERNETES_SERVICE_ACCOUNT or "default-editor"
             )
+            workflow["metadata"]["generateName"] = None
+            workflow["metadata"]["name"] = self.name
         elif output_format == "argo-workflow-template":
             workflow["spec"]["serviceAccountName"] = (
                 KUBERNETES_SERVICE_ACCOUNT or "default-editor"
             )
             workflow["kind"] = "WorkflowTemplate"
+            workflow["metadata"]["generateName"] = None
+            workflow["metadata"]["name"] = self.name
             workflow["status"] = None
         else:
             raise NotImplementedError(f"Unsupported output format {output_format}.")


### PR DESCRIPTION
Remove service account as it will be added by the webhook. 
Use static workflow `name` instead of `generateName`.