### PR TITLE
AIP-7393 Add Flow labels to Workflow for ArgoUI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,17 @@ on:
   push:
     branches:
     - master
-    - feature/aip
+    - feature/kfp
     - feature/aip
   pull_request:
     branches:
     - master
+    - feature/kfp
     - feature/aip
     - feature/aip-argo
     - tz/AIP-7299-argo-submit  # TODO(talebz) remove before merging
+    - feature/kfp-argo
+    - tz/AIP-7385-aip-plugin
   workflow_call:
   
 jobs:

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -954,7 +954,7 @@ class KubeflowPipelines(object):
             # This is done to support user-supplied Zodiac service per AIP Notebook.
             # Please see comments on how and why ZILLOW_ZODIAC_SERVICE label for more.
             container_op.add_pod_annotation(
-                "logging.zgtools.net/topic",
+                "logging.zgtools.net/index",
                 f"log.fluentd-z1.{ZILLOW_ZODIAC_SERVICE}.dev",
             )
 

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -295,12 +295,9 @@ class KubeflowPipelines(object):
         # Add "archive" none section to "-cards" artifacts because by default
         # they are tarred and hence not viewable in the Argo UI
         for template in workflow["spec"]["templates"]:
-            print("first template")
             if "outputs" in template and "artifacts" in template["outputs"]:
                 for artifact in template["outputs"]["artifacts"]:
-                    print(f"artifact: {artifact}")
                     if "-cards" in artifact["name"]:
-                        print(f"adding archive none")
                         artifact["archive"] = {"none": {}}
 
     @staticmethod

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -865,12 +865,12 @@ class KubeflowPipelines(object):
 
     def _get_flow_labels(self) -> Dict[str, str]:
         # function return variable
-        ret: Dict[str, str] = {}
+        ret_flow_labels: Dict[str, str] = {}
 
         prefix = "metaflow.org"
-        ret[f"{prefix}/flow_name"] = self.name
+        ret_flow_labels[f"{prefix}/flow_name"] = self.name
         if self.experiment:
-            ret[f"{prefix}/experiment"] = self.experiment
+            ret_flow_labels[f"{prefix}/experiment"] = self.experiment
 
         all_tags = list()
         all_tags += self.tags if self.tags else []
@@ -888,7 +888,7 @@ class KubeflowPipelines(object):
                 raise ValueError(
                     f"Tag name {annotation_name} must be no more than 63 characters"
                 )
-            ret[annotation_name] = annotation_value
+            ret_flow_labels[annotation_name] = annotation_value
 
         # - In context of Zillow CICD self.username == "cicd_compile"
         # - In the context of a Zillow NB self.username == METAFLOW_USER (user_alias)
@@ -896,18 +896,17 @@ class KubeflowPipelines(object):
         owner = self.username
         if "@" in owner:
             owner = owner.split("@")[0]
-        ret["zodiac.zillowgroup.net/owner"] = owner
+        ret_flow_labels["zodiac.zillowgroup.net/owner"] = owner
 
-        # Add in Zodiac service and team labels to the aip pods if the environment variable is
-        # present in the notebook (individual profile notebooks only) and set them. These labels
-        # are not being added by poddefaults as they were removed. Workflows launched in project
-        # profiles still get these labels added via poddefaults. Also adds in logging topic
-        # annotation as this value is specific to zodiac service as well.
+        # If the Zodiac environment variable is present in the notebook (individual profile notebooks only),
+        # the Zodiac service and team labels are added to the AIP pods and set. These labels are not added
+        # by the AIP webhook to support user-supplied Zodiac service per AIP Notebook. Workflows launched
+        # in project CICD profiles will still have these labels added via the AIP webhook.
         if ZILLOW_ZODIAC_SERVICE and ZILLOW_ZODIAC_TEAM:
-            ret["zodiac.zillowgroup.net/service"] = ZILLOW_ZODIAC_SERVICE
-            ret["zodiac.zillowgroup.net/team"] = ZILLOW_ZODIAC_TEAM
+            ret_flow_labels["zodiac.zillowgroup.net/service"] = ZILLOW_ZODIAC_SERVICE
+            ret_flow_labels["zodiac.zillowgroup.net/team"] = ZILLOW_ZODIAC_TEAM
 
-        return ret
+        return ret_flow_labels
 
     def _set_container_labels(self, container_op: ContainerOp):
         # TODO(talebz): A Metaflow plugin framework to customize tags, labels, etc.
@@ -935,12 +934,10 @@ class KubeflowPipelines(object):
                 "tags.ledger.zgtools.net/ai-experiment-name", self.experiment
             )
 
-        # Add in Zodiac service and team labels to the aip pods if the environment variable is
-        # present in the notebook (individual profile notebooks only) and set them. These labels
-        # are not being added by poddefaults as they were removed. Workflows launched in project
-        # profiles still get these labels added via poddefaults. Also adds in logging topic
-        # annotation as this value is specific to zodiac service as well.
         if ZILLOW_ZODIAC_SERVICE and ZILLOW_ZODIAC_TEAM:
+            # Add a logging topic annotation specific to the Zodiac service.
+            # This is done to support user-supplied Zodiac service per AIP Notebook.
+            # Please see comments on how and why ZILLOW_ZODIAC_SERVICE label for more.
             container_op.add_pod_annotation(
                 "logging.zgtools.net/topic",
                 f"log.fluentd-z1.{ZILLOW_ZODIAC_SERVICE}.dev",

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -286,7 +286,22 @@ class KubeflowPipelines(object):
         for key, value in self._get_flow_labels().items():
             workflow["metadata"]["labels"][key] = value
 
+        KubeflowPipelines._add_archive_section_to_cards_artifacts(workflow)
+
         return workflow
+
+    @staticmethod
+    def _add_archive_section_to_cards_artifacts(workflow: dict):
+        # Add "archive" none section to "-cards" artifacts because by default
+        # they are tarred and hence not viewable in the Argo UI
+        for template in workflow["spec"]["templates"]:
+            print("first template")
+            if "outputs" in template and "artifacts" in template["outputs"]:
+                for artifact in template["outputs"]["artifacts"]:
+                    print(f"artifact: {artifact}")
+                    if "-cards" in artifact["name"]:
+                        print(f"adding archive none")
+                        artifact["archive"] = {"none": {}}
 
     @staticmethod
     def _config_map(workflow_name: str, max_run_concurrency: int):
@@ -910,7 +925,7 @@ class KubeflowPipelines(object):
 
     def _set_container_labels(self, container_op: ContainerOp):
         # TODO(talebz): A Metaflow plugin framework to customize tags, labels, etc.
-        container_op.add_pod_label("aip.zillowgroup.net/aip-pod-default", "true")
+        container_op.add_pod_label("aip.zillowgroup.net/aip-wfsdk-pod", "true")
 
         # https://github.com/argoproj/argo-workflows/issues/4525
         # all argo workflows need istio-injection disabled, else the workflow hangs.
@@ -1364,7 +1379,9 @@ class KubeflowPipelines(object):
             None if node.name == "start" else {"flow_parameters_json": "None"}
         )
 
-        file_outputs: Dict[str, str] = {}
+        file_outputs: Dict[str, str] = {
+            "cards_default": "/tmp/outputs/cards/default_card.html",
+        }
         if node.type == "foreach":
             file_outputs["foreach_splits"] = "/tmp/outputs/foreach_splits/data"
         for preceding_component_input in preceding_component_inputs:

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -282,6 +282,10 @@ class KubeflowPipelines(object):
                 }
             }
 
+        # add Flow labels as Workflow labels to be searchable in the Argo UI
+        for key, value in self._get_flow_labels().items():
+            workflow["metadata"]["labels"][key] = value
+
         return workflow
 
     @staticmethod
@@ -859,20 +863,15 @@ class KubeflowPipelines(object):
         )
         return (resource, volume)
 
-    def _set_container_labels(self, container_op: ContainerOp):
-        # TODO(talebz): A Metaflow plugin framework to customize tags, labels, etc.
-        container_op.add_pod_label("aip.zillowgroup.net/aip-pod-default", "true")
-
-        # https://github.com/argoproj/argo-workflows/issues/4525
-        # all argo workflows need istio-injection disabled, else the workflow hangs.
-        container_op.add_pod_label("sidecar.istio.io/inject", "false")
+    def _get_flow_labels(self) -> Dict[str, str]:
+        # function return variable
+        ret: Dict[str, str] = {}
 
         prefix = "metaflow.org"
-        container_op.add_pod_annotation(f"{prefix}/flow_name", self.name)
-        container_op.add_pod_annotation(f"{prefix}/step", container_op.name)
-        container_op.add_pod_annotation(f"{prefix}/run_id", METAFLOW_RUN_ID)
+        ret[f"{prefix}/flow_name"] = self.name
         if self.experiment:
-            container_op.add_pod_annotation(f"{prefix}/experiment", self.experiment)
+            ret[f"{prefix}/experiment"] = self.experiment
+
         all_tags = list()
         all_tags += self.tags if self.tags else []
         all_tags += self.sys_tags if self.sys_tags else []
@@ -889,7 +888,42 @@ class KubeflowPipelines(object):
                 raise ValueError(
                     f"Tag name {annotation_name} must be no more than 63 characters"
                 )
-            container_op.add_pod_annotation(annotation_name, annotation_value)
+            ret[annotation_name] = annotation_value
+
+        # - In context of Zillow CICD self.username == "cicd_compile"
+        # - In the context of a Zillow NB self.username == METAFLOW_USER (user_alias)
+        # - In the context of Metaflow integration tests self.username == USER=$GITLAB_USER_EMAIL
+        owner = self.username
+        if "@" in owner:
+            owner = owner.split("@")[0]
+        ret["zodiac.zillowgroup.net/owner"] = owner
+
+        # Add in Zodiac service and team labels to the aip pods if the environment variable is
+        # present in the notebook (individual profile notebooks only) and set them. These labels
+        # are not being added by poddefaults as they were removed. Workflows launched in project
+        # profiles still get these labels added via poddefaults. Also adds in logging topic
+        # annotation as this value is specific to zodiac service as well.
+        if ZILLOW_ZODIAC_SERVICE and ZILLOW_ZODIAC_TEAM:
+            ret["zodiac.zillowgroup.net/service"] = ZILLOW_ZODIAC_SERVICE
+            ret["zodiac.zillowgroup.net/team"] = ZILLOW_ZODIAC_TEAM
+
+        return ret
+
+    def _set_container_labels(self, container_op: ContainerOp):
+        # TODO(talebz): A Metaflow plugin framework to customize tags, labels, etc.
+        container_op.add_pod_label("aip.zillowgroup.net/aip-pod-default", "true")
+
+        # https://github.com/argoproj/argo-workflows/issues/4525
+        # all argo workflows need istio-injection disabled, else the workflow hangs.
+        container_op.add_pod_label("sidecar.istio.io/inject", "false")
+
+        # add Flow labels as container labels
+        for key, value in self._get_flow_labels().items():
+            container_op.add_pod_label(key, value)
+
+        prefix = "metaflow.org"
+        container_op.add_pod_annotation(f"{prefix}/step", container_op.name)
+        container_op.add_pod_annotation(f"{prefix}/run_id", METAFLOW_RUN_ID)
 
         # tags.ledger.zgtools.net/* pod labels required for the ZGCP Costs Ledger
         container_op.add_pod_label("tags.ledger.zgtools.net/ai-flow-name", self.name)
@@ -901,26 +935,12 @@ class KubeflowPipelines(object):
                 "tags.ledger.zgtools.net/ai-experiment-name", self.experiment
             )
 
-        # - In context of Zillow CICD self.username == "cicd_compile"
-        # - In the context of a Zillow NB self.username == METAFLOW_USER (user_alias)
-        # - In the context of Metaflow integration tests self.username == USER=$GITLAB_USER_EMAIL
-        owner = self.username
-        if "@" in owner:
-            owner = owner.split("@")[0]
-        container_op.add_pod_label("zodiac.zillowgroup.net/owner", owner)
-
         # Add in Zodiac service and team labels to the aip pods if the environment variable is
         # present in the notebook (individual profile notebooks only) and set them. These labels
         # are not being added by poddefaults as they were removed. Workflows launched in project
         # profiles still get these labels added via poddefaults. Also adds in logging topic
         # annotation as this value is specific to zodiac service as well.
         if ZILLOW_ZODIAC_SERVICE and ZILLOW_ZODIAC_TEAM:
-            container_op.add_pod_label(
-                "zodiac.zillowgroup.net/service", ZILLOW_ZODIAC_SERVICE
-            )
-            container_op.add_pod_label(
-                "zodiac.zillowgroup.net/team", ZILLOW_ZODIAC_TEAM
-            )
             container_op.add_pod_annotation(
                 "logging.zgtools.net/topic",
                 f"log.fluentd-z1.{ZILLOW_ZODIAC_SERVICE}.dev",

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -27,6 +27,34 @@ from metaflow.plugins.aip.aip_constants import (
 from ... import R
 
 
+def _get_cards_cli(
+    step_name: str,
+    task_id: str,
+    run_id: str,
+    script_name: str,
+) -> str:
+    cmds: List[str] = []
+    executable: str = "python3" if R.use_r() else "python"
+    entrypoint = [executable, script_name]
+
+    top_level: List[str] = [
+        "--quiet",
+        "--datastore=s3",
+        "--no-pylint",
+    ]
+
+    cards: List[str] = [
+        "card",
+        "get",
+        f"{run_id}/{step_name}/{task_id}",
+        "--type default",
+    ]
+
+    cmds.append(" ".join(entrypoint + top_level + cards))
+    cards_cli_string = " && ".join(cmds)
+    return cards_cli_string
+
+
 def _step_cli(
     step_name: str,
     task_id: str,
@@ -138,6 +166,7 @@ def _step_cli(
 
     step: List[str] = [
         "--with=aip",
+        "--with 'card:id=default'",
         "step",
         step_name,
         "--run-id %s" % run_id,
@@ -397,6 +426,28 @@ def aip_metaflow_step(
         pathlib.Path(output_path).mkdir(parents=True, exist_ok=True)
         with open(output_file, "w") as f:
             f.write(str(values[idx]))
+
+    # get card and write to output file
+    card_cli: str = _get_cards_cli(
+        step_name,
+        task_id,
+        metaflow_run_id,
+        script_name,
+    )
+    cmd: str = card_cli.format(run_id=metaflow_run_id)
+    cmd = f"{cmd} > /tmp/outputs/cards/default_card.html"
+
+    pathlib.Path("/tmp/outputs/cards/").mkdir(parents=True, exist_ok=True)
+    with Popen(
+        cmd, shell=True, universal_newlines=True, executable="/bin/bash", env=env
+    ) as process:
+        pass
+
+    if process.returncode != 0:
+        logging.info(f"---- Following command returned: {process.returncode}")
+        logging.info(cmd.replace(" && ", "\n"))
+        logging.info("----")
+        raise Exception("Returned: %s" % process.returncode)
 
 
 if __name__ == "__main__":

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -30,6 +30,7 @@ from ... import R
 def _get_cards_cli(
     step_name: str,
     task_id: str,
+    passed_in_split_indexes: str,
     run_id: str,
     script_name: str,
 ) -> str:
@@ -43,12 +44,18 @@ def _get_cards_cli(
         "--no-pylint",
     ]
 
+    task_id_template: str = f"{task_id}.{passed_in_split_indexes}".strip(".")
+    run_pathspec = f"{run_id}/{step_name}/{task_id_template}"
+
     cards: List[str] = [
         "card",
         "get",
-        f"{run_id}/{step_name}/{task_id}",
-        "--type default",
+        run_pathspec,
+        "--id default",  # the default card id is also default
     ]
+
+    # load environment variables set in STEP_ENVIRONMENT_VARIABLES
+    cmds.append(f". {STEP_ENVIRONMENT_VARIABLES}")
 
     cmds.append(" ".join(entrypoint + top_level + cards))
     cards_cli_string = " && ".join(cmds)
@@ -431,6 +438,7 @@ def aip_metaflow_step(
     card_cli: str = _get_cards_cli(
         step_name,
         task_id,
+        passed_in_split_indexes,
         metaflow_run_id,
         script_name,
     )

--- a/metaflow/plugins/aip/tests/flows/resources_flow.py
+++ b/metaflow/plugins/aip/tests/flows/resources_flow.py
@@ -84,7 +84,7 @@ for annotation, env_name in annotations.items():
     )
 
 labels = {
-    "aip.zillowgroup.net/aip-pod-default": "KF_POD_DEFAULT",
+    "aip.zillowgroup.net/aip-wfsdk-pod": "AIP_WFSDK_POD",
     "tags.ledger.zgtools.net/ai-flow-name": "AI_FLOW_NAME",
     "tags.ledger.zgtools.net/ai-step-name": "AI_STEP_NAME",
     "tags.ledger.zgtools.net/ai-experiment-name": "AI_EXPERIMENT_NAME",
@@ -162,7 +162,7 @@ class ResourcesFlow(FlowSpec):
         assert os.environ.get("MF_TAG_TEST_T1") == "true"
         assert os.environ.get("MF_SYS_TAG_TEST_T1") == "sys_tag_value"
 
-        assert os.environ.get("KF_POD_DEFAULT") == "true"
+        assert os.environ.get("AIP_WFSDK_POD") == "true"
 
         assert os.environ.get("AI_FLOW_NAME") == current.flow_name
         assert os.environ.get("AI_STEP_NAME") == current.step_name

--- a/metaflow/plugins/aip/tests/flows/resources_flow.py
+++ b/metaflow/plugins/aip/tests/flows/resources_flow.py
@@ -63,13 +63,8 @@ kubernetes_vars.append(
 )
 
 annotations = {
-    "metaflow.org/flow_name": "MF_NAME",
     "metaflow.org/step": "MF_STEP",
     "metaflow.org/run_id": "MF_RUN_ID",
-    "metaflow.org/experiment": "MF_EXPERIMENT",
-    "metaflow.org/tag_metaflow_test": "MF_TAG_METAFLOW_TEST",
-    "metaflow.org/tag_test_t1": "MF_TAG_TEST_T1",
-    "metaflow.org/tag_test_sys_t1": "MF_SYS_TAG_TEST_T1",
 }
 for annotation, env_name in annotations.items():
     kubernetes_vars.append(
@@ -84,6 +79,11 @@ for annotation, env_name in annotations.items():
     )
 
 labels = {
+    "metaflow.org/flow_name": "MF_NAME",
+    "metaflow.org/experiment": "MF_EXPERIMENT",
+    "metaflow.org/tag_metaflow_test": "MF_TAG_METAFLOW_TEST",
+    "metaflow.org/tag_test_t1": "MF_TAG_TEST_T1",
+    "metaflow.org/tag_test_sys_t1": "MF_SYS_TAG_TEST_T1",
     "aip.zillowgroup.net/aip-wfsdk-pod": "AIP_WFSDK_POD",
     "tags.ledger.zgtools.net/ai-flow-name": "AI_FLOW_NAME",
     "tags.ledger.zgtools.net/ai-step-name": "AI_STEP_NAME",

--- a/metaflow/plugins/aip/tests/run_integration_tests.py
+++ b/metaflow/plugins/aip/tests/run_integration_tests.py
@@ -324,7 +324,7 @@ def test_kfp_pod_default() -> None:
     for step in flow_yaml["spec"]["templates"]:
         if step.get("container"):
             assert (
-                step["metadata"]["labels"]["aip.zillowgroup.net/aip-pod-default"]
+                step["metadata"]["labels"]["aip.zillowgroup.net/aip-wfsdk-pod"]
                 == "true"
             )
 

--- a/metaflow/tutorials/11-notebook-card/nbflow.ipynb
+++ b/metaflow/tutorials/11-notebook-card/nbflow.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7f158449",
+   "metadata": {},
+   "source": [
+    "# Running Notebooks Programatically In Metaflow\n",
+    "\n",
+    "When you use the `@card(type='notebook'...)` parameter in Metaflow, Metaflow will inject the following variables into your notebook via [Papermill]():\n",
+    "\n",
+    "- `run_id`\n",
+    "- `step_name`\n",
+    "- `task_id`\n",
+    "- `flow_name`\n",
+    "\n",
+    "These variables allow you to get data from your flow, so your notebook can render them.  This is especially useful for visualizing data or making reports based on the output(s) of your flow.\n",
+    "\n",
+    "To enable this, you must parameterize your notebook by adding the proper cell tags as [described here](https://papermill.readthedocs.io/en/latest/usage-parameterize.html#designate-parameters-for-a-cell).  The next cell in this notebook is tagged such that `Papermill` can inject these variables from the flow. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48bafc1b",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "run_id, task_id, flow_name, step_name = None, None, None, None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61f1c647",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Results for run_id={run_id} step_name={step_name} task_id={task_id} flow_name={flow_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4c9240a",
+   "metadata": {},
+   "source": [
+    "### You can use the `flow_name`, `step_name`, `run_id` and `task_id` to get data from your flow:\n",
+    "\n",
+    "For example you can retrieve the value of the variable `data_for_notebook` from the `start` step like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2999cbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from metaflow import Step\n",
+    "step = Step(f'{flow_name}/{run_id}/{step_name}') # the variable is located in the start step\n",
+    "\n",
+    "print(f\"{step.task.data.data_for_notebook=}\") # the name of the variable is \"data_for_notebook\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a371051b",
+   "metadata": {},
+   "source": [
+    "Furthermore, you can access a task like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8248bb1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from metaflow import Task\n",
+    "task = Task(f'{flow_name}/{run_id}/{step_name}/{task_id}')\n",
+    "\n",
+    "print(f\"{task.data.data_for_notebook=}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/metaflow/tutorials/11-notebook-card/nbflow.py
+++ b/metaflow/tutorials/11-notebook-card/nbflow.py
@@ -1,0 +1,70 @@
+from metaflow import step, FlowSpec, Parameter, card, current
+from metaflow.cards import Table, Markdown
+
+import functools
+
+
+def pip(libraries):
+    def decorator(function):
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            import subprocess
+            import sys
+
+            for library, version in libraries.items():
+                print("Pip Install:", library, version)
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "--quiet",
+                        library + "==" + version,
+                    ]
+                )
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+class NBFlow(FlowSpec):
+    """
+    you can as follows:
+        METAFLOW_DEFAULT_PACKAGE_SUFFIXES='.py,.yaml,.ipynb' python nbflow.py aip run
+
+    Then even use the CLI to get a card
+        python nbflow.py --metadata=service --datastore=s3 --no-pylint card get argo-nbflow-xj9x5/start/start-1 --type default > /tmp/default_card.html
+        python nbflow.py --metadata=service --datastore=s3 --no-pylint card get argo-nbflow-xj9x5/start/start-1 --type notebook > /tmp/notebook_card.html
+
+    """
+
+    exclude_nb_input = Parameter("exclude_nb_input", default=True, type=bool)
+
+    @pip(libraries={"metaflow-card-notebook": "1.0.7"})
+    @card(type="notebook")
+    @step
+    def start(self):
+        self.data_for_notebook = "I Will Print Myself From A Notebook"
+        self.nb_options_dict = dict(
+            input_path="nbflow.ipynb", exclude_input=self.exclude_nb_input
+        )
+        self.next(self.hello)
+
+    @step
+    def hello(self):
+        self.data = "world"
+        self.next(self.end)
+
+    @card(type="blank")
+    @step
+    def end(self):
+        current.card.append(Markdown("# Here’s a table"))
+        current.card.append(Table([["first", "second"], [1, 2]]))
+        print("The End")
+
+
+if __name__ == "__main__":
+    NBFlow()


### PR DESCRIPTION
please see run with Workflow labels here:

* run: `python metaflow/tutorials/00-helloworld/helloworld.py aip run --tag t42 -e e42`
* Argo UIhttps://argo-server.int.stage-k8s.zg-aip.net/argo-ui/workflows/aip-playground-dev/helloflow-nbbdj?tab=summary
* Related Metaflow UI https://metaflow.int.stage-k8s.zg-aip.net/HelloFlow/argo-helloflow-nbbdj


```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
...
  labels:
    metaflow.org/experiment: e42
    metaflow.org/flow_name: HelloFlow
    metaflow.org/tag_e42: "true"
    metaflow.org/tag_t42: "true"
    pipelines.kubeflow.org/kfp_sdk_version: 1.0.81-1.8.10
    workflows.argoproj.io/phase: Running
    zodiac.zillowgroup.net/owner: talebz
```

and now searchable in the Argo UI labels filter

<img width="505" alt="image" src="https://github.com/zillow/metaflow/assets/4167032/f2f0db10-2ef2-4d0c-bcb2-80399f169522">


## compiled
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: helloflow-
  labels:
    pipelines.kubeflow.org/kfp_sdk_version: 1.0.81-1.8.10
    #  ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓  PLEASE SEE LABELS created by this PR ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ 
    metaflow.org/flow_name: HelloFlow
    metaflow.org/experiment: e42
    metaflow.org/tag_t42: "true"
    zodiac.zillowgroup.net/owner: talebz
spec:
  entrypoint: helloflow
  templates:
  - name: end
    # existing labels and annotations added by WFSDK, and kfp
    metadata:
      annotations: 
        metaflow.org/step: end
        metaflow.org/run_id: 'argo-{{workflow.name}}'
        pipelines.kubeflow.org/task_display_name: end, 
        pipelines.kubeflow.org/max_cache_staleness: P0D
      labels:
        pipelines.kubeflow.org/kfp_sdk_version: 1.0.81-1.8.10
        pipelines.kubeflow.org/pipeline-sdk-type: kfp
        aip.zillowgroup.net/aip-pod-default: "true"
        sidecar.istio.io/inject: "false"
        metaflow.org/flow_name: HelloFlow
        zodiac.zillowgroup.net/owner: talebz
        tags.ledger.zgtools.net/ai-flow-name: HelloFlow
        tags.ledger.zgtools.net/ai-step-name: end
        pipelines.kubeflow.org/enable_caching: "true"
 ```

## k8s cluster podspec after AIP webhook and KFP mutations
```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    karpenter.sh/do-not-evict: "true"
    kubectl.kubernetes.io/default-container: main
    kubernetes.io/limit-ranger: 'LimitRanger plugin set: ephemeral-storage request
      for container wait; ephemeral-storage limit for container wait; cpu, ephemeral-storage,
      memory request for container main; cpu, ephemeral-storage, memory limit for
      container main; ephemeral-storage request for init container init; ephemeral-storage
      limit for init container init'
    kubernetes.io/psp: eks.privileged
    logging.zgtools.net/index: ai_platform_nonprod
    logging.zgtools.net/istio-init.ignore: "true"
    logging.zgtools.net/istio-proxy.ignore: "true"
    logging.zgtools.net/queue-proxy.ignore: "true"
    logging.zgtools.net/wait.ignore: "true"
    metaflow.org/run_id: argo-helloflow-8nvp9
    metaflow.org/step: start
    pipelines.kubeflow.org/max_cache_staleness: P0D
    pipelines.kubeflow.org/task_display_name: start
    sidecar.istio.io/inject: "false"
    workflows.argoproj.io/node-id: helloflow-8nvp9-1794368775
    workflows.argoproj.io/node-name: helloflow-8nvp9.start
    zodiac.zillowgroup.net/environment: aianalytics_stage
    zodiac.zillowgroup.net/service: aip-playground
  creationTimestamp: "2023-10-12T16:58:38Z"
  labels:
    aip.zillowgroup.net/aip-pod-default: "true"
    metaflow.org/experiment: e42
    metaflow.org/flow_name: HelloFlow
    metaflow.org/tag_e42: "true"
    metaflow.org/tag_t42: "true"
    pipelines.kubeflow.org/enable_caching: "true"
    pipelines.kubeflow.org/kfp_sdk_version: 1.0.81-1.8.10
    pipelines.kubeflow.org/pipeline-sdk-type: kfp
    sidecar.istio.io/inject: "false"
    tags.ledger.zgtools.net/ai-experiment-name: e42
    tags.ledger.zgtools.net/ai-flow-name: HelloFlow
    tags.ledger.zgtools.net/ai-step-name: start
    user: aip-playground-dev
    workflows.argoproj.io/completed: "false"
    workflows.argoproj.io/workflow: helloflow-8nvp9
    zodiac.zillowgroup.net/environment: aianalytics_stage
    zodiac.zillowgroup.net/owner: talebz
    zodiac.zillowgroup.net/product: batch
    zodiac.zillowgroup.net/service: aip-playground
    zodiac.zillowgroup.net/team: ai-platform
```