### PR TITLE
AIP-7726 add default cards

### DIFF
--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -925,7 +925,7 @@ class KubeflowPipelines(object):
 
     def _set_container_labels(self, container_op: ContainerOp):
         # TODO(talebz): A Metaflow plugin framework to customize tags, labels, etc.
-        container_op.add_pod_label("aip.zillowgroup.net/aip-pod-default", "true")
+        container_op.add_pod_label("aip.zillowgroup.net/aip-wfsdk-pod", "true")
 
         # https://github.com/argoproj/argo-workflows/issues/4525
         # all argo workflows need istio-injection disabled, else the workflow hangs.

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -292,8 +292,8 @@ class KubeflowPipelines(object):
 
     @staticmethod
     def _add_archive_section_to_cards_artifacts(workflow: dict):
-        print("in _add_archive_section_to_cards_artifacts")
-        # for any "-cards" artifacts add "archive" section with "none" value
+        # Add "archive" none section to "-cards" artifacts because by default
+        # they are tarred and hence not viewable in the Argo UI
         for template in workflow["spec"]["templates"]:
             print("first template")
             if "outputs" in template and "artifacts" in template["outputs"]:

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -286,7 +286,22 @@ class KubeflowPipelines(object):
         for key, value in self._get_flow_labels().items():
             workflow["metadata"]["labels"][key] = value
 
+        KubeflowPipelines._add_archive_section_to_cards_artifacts(workflow)
+
         return workflow
+
+    @staticmethod
+    def _add_archive_section_to_cards_artifacts(workflow: dict):
+        print("in _add_archive_section_to_cards_artifacts")
+        # for any "-cards" artifacts add "archive" section with "none" value
+        for template in workflow["spec"]["templates"]:
+            print("first template")
+            if "outputs" in template and "artifacts" in template["outputs"]:
+                for artifact in template["outputs"]["artifacts"]:
+                    print(f"artifact: {artifact}")
+                    if "-cards" in artifact["name"]:
+                        print(f"adding archive none")
+                        artifact["archive"] = {"none": {}}
 
     @staticmethod
     def _config_map(workflow_name: str, max_run_concurrency: int):
@@ -1364,7 +1379,9 @@ class KubeflowPipelines(object):
             None if node.name == "start" else {"flow_parameters_json": "None"}
         )
 
-        file_outputs: Dict[str, str] = {}
+        file_outputs: Dict[str, str] = {
+            "cards_default": "/tmp/outputs/cards/default_card.html",
+        }
         if node.type == "foreach":
             file_outputs["foreach_splits"] = "/tmp/outputs/foreach_splits/data"
         for preceding_component_input in preceding_component_inputs:

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -432,7 +432,6 @@ def aip_metaflow_step(
         step_name,
         task_id,
         metaflow_run_id,
-        environment,
         script_name,
     )
     cmd: str = card_cli.format(run_id=metaflow_run_id)

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -166,7 +166,7 @@ def _step_cli(
 
     step: List[str] = [
         "--with=aip",
-        "--with=card",
+        "--with 'card:id=default'",
         "step",
         step_name,
         "--run-id %s" % run_id,

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -27,6 +27,34 @@ from metaflow.plugins.aip.aip_constants import (
 from ... import R
 
 
+def _get_cards_cli(
+    step_name: str,
+    task_id: str,
+    run_id: str,
+    script_name: str,
+) -> str:
+    cmds: List[str] = []
+    executable: str = "python3" if R.use_r() else "python"
+    entrypoint = [executable, script_name]
+
+    top_level: List[str] = [
+        "--quiet",
+        "--datastore=s3",
+        "--no-pylint",
+    ]
+
+    cards: List[str] = [
+        "card",
+        "get",
+        f"{run_id}/{step_name}/{task_id}",
+        "--type default",
+    ]
+
+    cmds.append(" ".join(entrypoint + top_level + cards))
+    cards_cli_string = " && ".join(cmds)
+    return cards_cli_string
+
+
 def _step_cli(
     step_name: str,
     task_id: str,
@@ -138,6 +166,7 @@ def _step_cli(
 
     step: List[str] = [
         "--with=aip",
+        "--with=card",
         "step",
         step_name,
         "--run-id %s" % run_id,
@@ -397,6 +426,29 @@ def aip_metaflow_step(
         pathlib.Path(output_path).mkdir(parents=True, exist_ok=True)
         with open(output_file, "w") as f:
             f.write(str(values[idx]))
+
+    # get card and write to output file
+    card_cli: str = _get_cards_cli(
+        step_name,
+        task_id,
+        metaflow_run_id,
+        environment,
+        script_name,
+    )
+    cmd: str = card_cli.format(run_id=metaflow_run_id)
+    cmd = f"{cmd} > /tmp/outputs/cards/default_card.html"
+
+    pathlib.Path("/tmp/outputs/cards/").mkdir(parents=True, exist_ok=True)
+    with Popen(
+        cmd, shell=True, universal_newlines=True, executable="/bin/bash", env=env
+    ) as process:
+        pass
+
+    if process.returncode != 0:
+        logging.info(f"---- Following command returned: {process.returncode}")
+        logging.info(cmd.replace(" && ", "\n"))
+        logging.info("----")
+        raise Exception("Returned: %s" % process.returncode)
 
 
 if __name__ == "__main__":

--- a/metaflow/plugins/aip/tests/flows/resources_flow.py
+++ b/metaflow/plugins/aip/tests/flows/resources_flow.py
@@ -84,7 +84,7 @@ for annotation, env_name in annotations.items():
     )
 
 labels = {
-    "aip.zillowgroup.net/aip-pod-default": "KF_POD_DEFAULT",
+    "aip.zillowgroup.net/aip-wfsdk-pod": "AIP_WFSDK_POD",
     "tags.ledger.zgtools.net/ai-flow-name": "AI_FLOW_NAME",
     "tags.ledger.zgtools.net/ai-step-name": "AI_STEP_NAME",
     "tags.ledger.zgtools.net/ai-experiment-name": "AI_EXPERIMENT_NAME",
@@ -162,7 +162,7 @@ class ResourcesFlow(FlowSpec):
         assert os.environ.get("MF_TAG_TEST_T1") == "true"
         assert os.environ.get("MF_SYS_TAG_TEST_T1") == "sys_tag_value"
 
-        assert os.environ.get("KF_POD_DEFAULT") == "true"
+        assert os.environ.get("AIP_WFSDK_POD") == "true"
 
         assert os.environ.get("AI_FLOW_NAME") == current.flow_name
         assert os.environ.get("AI_STEP_NAME") == current.step_name

--- a/metaflow/plugins/aip/tests/run_integration_tests.py
+++ b/metaflow/plugins/aip/tests/run_integration_tests.py
@@ -324,7 +324,7 @@ def test_kfp_pod_default() -> None:
     for step in flow_yaml["spec"]["templates"]:
         if step.get("container"):
             assert (
-                step["metadata"]["labels"]["aip.zillowgroup.net/aip-pod-default"]
+                step["metadata"]["labels"]["aip.zillowgroup.net/aip-wfsdk-pod"]
                 == "true"
             )
 

--- a/metaflow/tutorials/11-notebook-card/nbflow.ipynb
+++ b/metaflow/tutorials/11-notebook-card/nbflow.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7f158449",
+   "metadata": {},
+   "source": [
+    "# Running Notebooks Programatically In Metaflow\n",
+    "\n",
+    "When you use the `@card(type='notebook'...)` parameter in Metaflow, Metaflow will inject the following variables into your notebook via [Papermill]():\n",
+    "\n",
+    "- `run_id`\n",
+    "- `step_name`\n",
+    "- `task_id`\n",
+    "- `flow_name`\n",
+    "\n",
+    "These variables allow you to get data from your flow, so your notebook can render them.  This is especially useful for visualizing data or making reports based on the output(s) of your flow.\n",
+    "\n",
+    "To enable this, you must parameterize your notebook by adding the proper cell tags as [described here](https://papermill.readthedocs.io/en/latest/usage-parameterize.html#designate-parameters-for-a-cell).  The next cell in this notebook is tagged such that `Papermill` can inject these variables from the flow. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48bafc1b",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "run_id, task_id, flow_name, step_name = None, None, None, None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61f1c647",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Results for run_id={run_id} step_name={step_name} task_id={task_id} flow_name={flow_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4c9240a",
+   "metadata": {},
+   "source": [
+    "### You can use the `flow_name`, `step_name`, `run_id` and `task_id` to get data from your flow:\n",
+    "\n",
+    "For example you can retrieve the value of the variable `data_for_notebook` from the `start` step like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2999cbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from metaflow import Step\n",
+    "step = Step(f'{flow_name}/{run_id}/{step_name}') # the variable is located in the start step\n",
+    "\n",
+    "print(f\"{step.task.data.data_for_notebook=}\") # the name of the variable is \"data_for_notebook\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a371051b",
+   "metadata": {},
+   "source": [
+    "Furthermore, you can access a task like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8248bb1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from metaflow import Task\n",
+    "task = Task(f'{flow_name}/{run_id}/{step_name}/{task_id}')\n",
+    "\n",
+    "print(f\"{task.data.data_for_notebook=}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/metaflow/tutorials/11-notebook-card/nbflow.py
+++ b/metaflow/tutorials/11-notebook-card/nbflow.py
@@ -1,0 +1,70 @@
+from metaflow import step, FlowSpec, Parameter, card, current
+from metaflow.cards import Table, Markdown
+
+import functools
+
+
+def pip(libraries):
+    def decorator(function):
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            import subprocess
+            import sys
+
+            for library, version in libraries.items():
+                print("Pip Install:", library, version)
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "--quiet",
+                        library + "==" + version,
+                    ]
+                )
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+class NBFlow(FlowSpec):
+    """
+    you can as follows:
+        METAFLOW_DEFAULT_PACKAGE_SUFFIXES='.py,.yaml,.ipynb' python nbflow.py aip run
+
+    Then even use the CLI to get a card
+        python nbflow.py --metadata=service --datastore=s3 --no-pylint card get argo-nbflow-xj9x5/start/start-1 --type default > /tmp/default_card.html
+        python nbflow.py --metadata=service --datastore=s3 --no-pylint card get argo-nbflow-xj9x5/start/start-1 --type notebook > /tmp/notebook_card.html
+
+    """
+
+    exclude_nb_input = Parameter("exclude_nb_input", default=True, type=bool)
+
+    @pip(libraries={"metaflow-card-notebook": "1.0.7"})
+    @card(type="notebook")
+    @step
+    def start(self):
+        self.data_for_notebook = "I Will Print Myself From A Notebook"
+        self.nb_options_dict = dict(
+            input_path="nbflow.ipynb", exclude_input=self.exclude_nb_input
+        )
+        self.next(self.hello)
+
+    @step
+    def hello(self):
+        self.data = "world"
+        self.next(self.end)
+
+    @card(type="blank")
+    @step
+    def end(self):
+        current.card.append(Markdown("# Here’s a table"))
+        current.card.append(Table([["first", "second"], [1, 2]]))
+        print("The End")
+
+
+if __name__ == "__main__":
+    NBFlow()


### PR DESCRIPTION
The reason is to add default cards in WFSDK as part of the push,
* see example 
   * https://argo-server.int.stage-k8s.zg-aip.net/argo-ui/archived-workflows/aip-playground-dev/447be931-ca09-470c-a6e4-b23a76ca9baf
   * click on default_card.html, it'll be blank but then click on on download DOWNLOAD_CARD.HTML and inspect source to see the HTML and error.  You could download the HTML then load it locally and the Metaflow card would correctly render.
   * https://metaflow.int.stage-k8s.zg-aip.net/NBFlow/argo-nbflow-svhd9/start/start-1?group=true&order=startTime&direction=asc

However we need to update ARGO_ARTIFACT_CONTENT_SECURITY_POLICY
* https://github.com/argoproj/argo-workflows/issues/9121
* https://github.com/argoproj/argo-workflows/blob/master/server/artifacts/artifact_server.go#L462-L464