### PR TITLE
Remove Github Metaflow full suite of tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        ver: ['3.9','3.10',]
+        os: [ubuntu-latest]
+        ver: ['3.9']
 
     steps:
     - uses: actions/checkout@v2
@@ -48,6 +48,3 @@ jobs:
 
     - name: Python Code Format Check
       run: black --target-version py39 --diff --check ./metaflow/plugins/aip/*.py
-
-    - name: Execute Python tests
-      run: tox


### PR DESCRIPTION
- Remove core full suite of tests that run on Github. The ZG AIP plugin has never failed these tests, and the AIP integration tests because we don't modify Metaflow core.