### PR TITLE
AIP-7772 re-disable nested foreach tests

### DIFF
--- a/metaflow/plugins/aip/tests/run_integration_tests.py
+++ b/metaflow/plugins/aip/tests/run_integration_tests.py
@@ -51,12 +51,10 @@ non_standard_test_flows = [
 
 disabled_test_flows = [
     "aip_flow.py",  # kfp_preceding_component feature has been deprecated.
-    # "flow_triggering_flow.py",
-    # TODO(talebz) AIP-6717 re-enable for compilation changes or when cluster can handle
-    # "foreach_linear_foreach.py",
-    # "foreach_linear_split.py",
-    # "foreach_split_linear.py",
-    # "nested_foreach_with_branching.py",
+    "foreach_linear_foreach.py",
+    "foreach_linear_split.py",
+    "foreach_split_linear.py",
+    "nested_foreach_with_branching.py",
 ]
 
 

--- a/metaflow/tutorials/00-helloworld/helloworld.py
+++ b/metaflow/tutorials/00-helloworld/helloworld.py
@@ -1,4 +1,4 @@
-from metaflow import FlowSpec, step, resources
+from metaflow import FlowSpec, step
 
 
 class HelloFlow(FlowSpec):
@@ -9,7 +9,6 @@ class HelloFlow(FlowSpec):
 
     """
 
-    @resources(cpu="500")  # this is intentional to cause a k8s failure
     @step
     def start(self):
         """

--- a/metaflow/tutorials/00-helloworld/helloworld.py
+++ b/metaflow/tutorials/00-helloworld/helloworld.py
@@ -1,4 +1,4 @@
-from metaflow import FlowSpec, step
+from metaflow import FlowSpec, step, resources
 
 
 class HelloFlow(FlowSpec):
@@ -9,6 +9,7 @@ class HelloFlow(FlowSpec):
 
     """
 
+    @resources(cpu="500")  # this is intentional to cause a k8s failure
     @step
     def start(self):
         """


### PR DESCRIPTION
Now that `feature/kfp-argo` is merged to `feature/aip`, we no longer need the nested foreach integration tests to run on every commit.  They are costly (with dozens of pods), and could bring DevEx clusters because they are fast and short lived steps.