### PR TITLE
AIP-7511 exit_handler DAG - Part 1

### DIFF
--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -334,16 +334,16 @@ class KubeflowPipelines(object):
             exit_handler_template["name"] = "exit-handler"
             workflow["spec"]["onExit"] = "exit-handler"
 
+            # initialize
+            exit_handler_template["dag"] = {"tasks": []}
             if self.sqs_url_on_error:
-                exit_handler_template["dag"] = {
-                    "tasks": [
-                        {
-                            "name": "sqs-exit-handler",
-                            "template": "sqs-exit-handler",
-                            "when": "{{workflow.status}} != 'Succeeded'",
-                        },
-                    ]
-                }
+                exit_handler_template["dag"]["tasks"].append(
+                    {
+                        "name": "sqs-exit-handler",
+                        "template": "sqs-exit-handler",
+                        "when": "{{workflow.status}} != 'Succeeded'",
+                    }
+                )
 
             if self.notify:
                 notify_task = {

--- a/metaflow/plugins/aip/aip_exit_handler.py
+++ b/metaflow/plugins/aip/aip_exit_handler.py
@@ -12,8 +12,8 @@ _logger = logging.getLogger(__name__)
 @click.option("--run_id")
 @click.option("--env_variables_json")
 @click.option("--flow_parameters_json")
-@click.option("--run_email_notify", is_flag=True)
-@click.option("--run_sqs_on_error", is_flag=True)
+@click.option("--run_email_notify", is_flag=True, default=False)
+@click.option("--run_sqs_on_error", is_flag=True, default=False)
 def exit_handler(
     flow_name: str,
     status: str,
@@ -48,7 +48,6 @@ def exit_handler(
         return env_variables.get(name, os.environ.get(name, default=default))
 
     def email_notify(send_to):
-        import posixpath
         import smtplib
         from email.mime.multipart import MIMEMultipart
         from email.mime.text import MIMEText
@@ -137,11 +136,11 @@ def exit_handler(
             _logger.error(err)
             raise err
 
+    print(f"Flow completed with status={status}")
     if run_email_notify:
         notify_on_error = get_env("METAFLOW_NOTIFY_ON_ERROR")
         notify_on_success = get_env("METAFLOW_NOTIFY_ON_SUCCESS")
 
-        print(f"Flow completed with status={status}")
         if notify_on_error and status == "Failed":
             email_notify(notify_on_error)
         elif notify_on_success and status == "Succeeded":


### PR DESCRIPTION
- split AIP email notify & SQS DLQ into separate Argo steps within the exit_handler DAG
- cleanup the Argo entrypoint to be the Argo flow DAG, not exit-handler.

## before
![image](https://github.com/zillow/metaflow/assets/4167032/be199019-3e0e-4966-b5a0-6ccb28abb283)

## after
![image](https://github.com/zillow/metaflow/assets/4167032/216c84bc-6efc-4473-a337-42b8487791db)

## exit_handler dag
```yaml
    - name: exit-handler
      dag:
        tasks:
          - name: sqs-exit-handler
            template: sqs-exit-handler
            arguments: {}
            dependencies:
              - notify-email-exit-handler
          - name: notify-email-exit-handler
            template: notify-email-exit-handler
            arguments: {}
```

## Coming Part 2
Part 2 will create another step in the exit-handler dag to invoke the user provided Flow `@exit_handler(user_defined_function)`