### PR TITLE
AIP-8434 resilient_flow.py fix

### DIFF
--- a/metaflow/plugins/aip/tests/flows/resilient_flow.py
+++ b/metaflow/plugins/aip/tests/flows/resilient_flow.py
@@ -47,6 +47,10 @@ class ResilientFlow(FlowSpec):
             validate_checkpoint_dir(checkpoint_paths.checkpoint_dir)
             assert checkpoint_paths.previous_checkpoint_path is None
 
+            # sleep to allow time for argo-wf-controller to know that this
+            # pod has started, this is related to the DEFAULT_REQUEUE_TIME=1m
+            time.sleep(60)
+
             # delete and terminate myself!!
             command = (
                 f"./kubectl delete pod {os.environ.get('POD_NAME')} "


### PR DESCRIPTION
- WFSDK resilient_flow.py to handle DEFAULT_REQUEUE_TIME=1m
- The manner in which resilient_flow.py tests resiliency is by a hard kubectl pod delete immediately when the start step begins.  This does not allow the argo-wf-controller time (1m) to even know that the pod has started, and hence attempts to start the step again and again.