### PR TITLE
increase test parallelization 3->7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,7 @@ stages:
         bash -c "
           set -x &&
           cd /home/zservice/metaflow/metaflow/plugins/aip/tests &&
-          python -m pytest -s -n 3 run_integration_tests.py --image ${IMAGE_REPOSITORY_TAG} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg --pipeline-tag pipeline_iid_${CI_PIPELINE_IID}
+          python -m pytest -s -n 7 run_integration_tests.py --image ${IMAGE_REPOSITORY_TAG} --opsgenie-api-token ${OPSGENIE_API_TOKEN} --cov-config=setup.cfg --pipeline-tag pipeline_iid_${CI_PIPELINE_IID}
         "
   artifacts:
     when: always


### PR DESCRIPTION
I'm afraid that increasing DEFAULT_REQUEUE_TIME 10s to 1m has increased the time that integration tests take (~15min to ~20-25min).
This change should mitigate that by scaling out the WFSDK tests.