### PR TITLE
AIP-8440 retry opsgenie test intermittent error

### DIFF
--- a/metaflow/plugins/aip/tests/run_integration_tests.py
+++ b/metaflow/plugins/aip/tests/run_integration_tests.py
@@ -176,7 +176,12 @@ def test_error_and_opsgenie_alert(pytestconfig) -> None:
             data=json.dumps(close_alert_data),
             headers=opsgenie_auth_headers,
         )
-        if close_alert_response.status_code == 200:
+        # Sometimes the response status code is 202, signaling
+        # the request has been accepted and is being queued for processing.
+        if (
+            close_alert_response.status_code == 200
+            or close_alert_response.status_code == 202
+        ):
             break
         time.sleep(3)
 


### PR DESCRIPTION
Hardening this test is important to avoid intermittent issues and AIP engineers retrying this test that may mask true failures.

see failure https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/sdks/zillow-metaflow/-/jobs/37777543
```
FAILED run_integration_tests.py::test_error_and_opsgenie_alert - assert (429 == 200 or 429 == 202)
 +  where 429 = <Response [429]>.status_code
 +  and   429 = <Response [429]>.status_code
```

429 is this error: [429 Too Many Requests - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429)