### PR TITLE
[minor][bugfix] Remove redundant generateName

### DIFF
--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -291,10 +291,9 @@ class KubeflowPipelines(object):
             # Note the name has to follow k8s format.
             # self.name is typically CamelCase as it's python class name.
             # generateName contains a sanitized version of self.name from aip.compiler
+            default_workflow_name = workflow["metadata"].pop("generateName").rstrip("-")
             workflow["metadata"]["name"] = (
-                sanitize_k8s_name(name)
-                if name
-                else workflow["metadata"].pop("generateName").rstrip("-")
+                sanitize_k8s_name(name) if name else default_workflow_name
             )
 
             # Service account is added through webhooks.


### PR DESCRIPTION
When creating a workflow with a specific name using `python <flow.py> create --name <name>`, the compiled workflow template manifest contains both `generateName` and `name` under metadata field. 

For example, the output template of a recent pipeline https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/integration-tests/aip-workflow-example/-/jobs/42159367 has manifest that looks like the following:
```
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  generateName: exampleflow-
  name: example-flow-95623b8e
  annotations: {}
  labels: {
    metaflow.org/flow_name: ExampleFlow,
    metaflow.org/tag_project-name: aip-workflow-example,
    metaflow.org/tag_pipeline-id: '6821369',
    metaflow.org/tag_commit-sha: 95623b8eb6146e5c33e526dfbcbc946828565541,
    zodiac.zillowgroup.net/owner: None,
    zodiac.zillowgroup.net/product: batch
  }
... (more fields below)
```
where the `name: example-flow-95623b8e` is expected (as flow name + commit sha) but the `generateName: exampleflow-` is redundant. 

Further looking into the code, it looks like when a specific `--name` is provided, the current logic prevent `generateName` from being popped out.