### PR TITLE
AIP-8704 add deploy default behavior

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ variables:
   # Run on the Internal cluster only on commit.
   # We run the tests via the integration test framework for Non-Prod/Prod.
   DEPLOY_INTERNAL: "true"
+  DEPLOY_REVIEW: "false"
   DEPLOY_STAGE: "false"
   DEPLOY_PROD: "false"
   DEPLOY_SANDBOX: "false"


### PR DESCRIPTION
Because of this [MR to the ci-cd-template repo](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template/-/merge_requests/232), setting `DEPLOY_SANDBOX` to true no longer gates `deploy:review` (or `deploy:dev` or `deploy:stage` or `deploy:prod`). Since `DEPLOY_REVIEW` [defaults to true](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template/-/blob/main/paved/aip/pipelines.yml#L17), I am adding the line `DEPLOY_REVIEW: false` so that you continue to get the same behavior you got prior to the MR to the ci-cd-template repo.