### PR TITLE
Bumping the minor version to 2.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ include:
 variables:
   PY_LIBRARY_NAME: "zillow-metaflow"
   MAJOR_VERSION: "2"
-  MINOR_VERSION: "2"
+  MINOR_VERSION: "3"
   METAFLOW_VERSION_PATH: "setup.py"
   IMAGE_REPOSITORY_TAG_PATH: 'image_tag_file.txt'
   IMAGE_REPOSITORY_TAG_PATH_AIP_STEP: 'image_tag_file_aip_step.txt'


### PR DESCRIPTION
ArgoHelper is quite some change comparing to the previous version, despite no customer adoption previously. Bumping the minor version to make this distinction. Also, we can track MRs released between now and metaflow zg-2.2 easily.