### PR TITLE
AIP-8718 Allow disabling default cards; Allow card render failures

### DIFF
--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -317,7 +317,7 @@ class KubeflowPipelines(object):
         ).items():
             workflow["metadata"]["labels"][key] = value
 
-        KubeflowPipelines._add_archive_section_to_cards_artifacts(workflow)
+        KubeflowPipelines._update_cards_artifact_configs(workflow)
 
         if self._exit_handler_created:
             # replace entrypoint content with the exit handler handler content
@@ -422,7 +422,7 @@ class KubeflowPipelines(object):
         return workflow
 
     @staticmethod
-    def _add_archive_section_to_cards_artifacts(workflow: dict):
+    def _update_cards_artifact_configs(workflow: dict):
         # Add "archive" none section to "-cards" artifacts because by default
         # they are tarred and hence not viewable in the Argo UI
         for template in workflow["spec"]["templates"]:
@@ -430,6 +430,7 @@ class KubeflowPipelines(object):
                 for artifact in template["outputs"]["artifacts"]:
                     if "-card" in artifact["name"]:
                         artifact["archive"] = {"none": {}}
+                        artifact["optional"] = True
 
     @staticmethod
     def _config_map(workflow_name: str, max_run_concurrency: int):

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -1476,14 +1476,11 @@ class KubeflowPipelines(object):
             None if node.name == "start" else {"flow_parameters_json": "None"}
         )
 
+        card_decos = [deco for deco in node.decorators if deco.name == "card"]
         file_outputs: Dict[str, str] = {
-            "card": "/tmp/outputs/cards/card.html",
+            f"card{i}": f"/tmp/outputs/cards/card{i}.html"
+            for i in range(len(card_decos))
         }
-        i = 1  # the default card would be i == 0
-        for deco in node.decorators:
-            if deco.name == "card":
-                file_outputs[f"card{i}"] = f"/tmp/outputs/cards/card{i}.html"
-                i = i + 1
 
         if node.type == "foreach":
             file_outputs["foreach_splits"] = "/tmp/outputs/foreach_splits/data"

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -173,7 +173,7 @@ class KubeflowPipelines(object):
         notify_on_success=None,
         sqs_url_on_error=None,
         sqs_role_arn_on_error=None,
-        add_default_cards=False,
+        add_default_card=False,
         **kwargs,
     ):
         """
@@ -205,7 +205,7 @@ class KubeflowPipelines(object):
         self.notify_on_success = notify_on_success
         self.sqs_url_on_error = sqs_url_on_error
         self.sqs_role_arn_on_error = sqs_role_arn_on_error
-        self.add_default_cards = add_default_cards
+        self.add_default_card = add_default_card
         self._client = None
         self._exit_handler_created = False
 
@@ -1451,8 +1451,8 @@ class KubeflowPipelines(object):
             metaflow_execution_cmd += " --is_split_index"
         if node.type == "join":
             metaflow_execution_cmd += " --is-join-step"
-        if self.add_default_cards:
-            metaflow_execution_cmd += " --add-default-cards"
+        if self.add_default_card:
+            metaflow_execution_cmd += " --add-default-card"
 
         metaflow_execution_cmd += ' --preceding_component_outputs_dict "'
         for key in preceding_component_outputs_dict:

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -1410,6 +1410,8 @@ class KubeflowPipelines(object):
         preceding_component_inputs: List[str],
         preceding_component_outputs_dict: Dict[str, dsl.PipelineParam],
     ) -> ContainerOp:
+        card_decos = [deco for deco in node.decorators if deco.name == "card"]
+
         # TODO (hariharans): https://zbrt.atl.zillow.net/browse/AIP-5406
         #   (Title: Clean up output formatting of workflow and pod specs in container op)
         # double json.dumps() to ensure we have the correct quotation marks
@@ -1453,6 +1455,8 @@ class KubeflowPipelines(object):
             metaflow_execution_cmd += " --is-join-step"
         if self.add_default_card:
             metaflow_execution_cmd += " --add-default-card"
+        if not card_decos:
+            metaflow_execution_cmd += " --skip-card-artifacts"
 
         metaflow_execution_cmd += ' --preceding_component_outputs_dict "'
         for key in preceding_component_outputs_dict:
@@ -1480,7 +1484,6 @@ class KubeflowPipelines(object):
             None if node.name == "start" else {"flow_parameters_json": "None"}
         )
 
-        card_decos = [deco for deco in node.decorators if deco.name == "card"]
         file_outputs: Dict[str, str] = {
             f"card-{i}": f"/tmp/outputs/cards/card-{i}.html"
             for i in range(len(card_decos))

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -173,6 +173,7 @@ class KubeflowPipelines(object):
         notify_on_success=None,
         sqs_url_on_error=None,
         sqs_role_arn_on_error=None,
+        add_default_cards=False,
         **kwargs,
     ):
         """
@@ -204,6 +205,7 @@ class KubeflowPipelines(object):
         self.notify_on_success = notify_on_success
         self.sqs_url_on_error = sqs_url_on_error
         self.sqs_role_arn_on_error = sqs_role_arn_on_error
+        self.add_default_cards = add_default_cards
         self._client = None
         self._exit_handler_created = False
 
@@ -1449,6 +1451,8 @@ class KubeflowPipelines(object):
             metaflow_execution_cmd += " --is_split_index"
         if node.type == "join":
             metaflow_execution_cmd += " --is-join-step"
+        if self.add_default_cards:
+            metaflow_execution_cmd += " --add-default-cards"
 
         metaflow_execution_cmd += ' --preceding_component_outputs_dict "'
         for key in preceding_component_outputs_dict:

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -1482,7 +1482,7 @@ class KubeflowPipelines(object):
 
         card_decos = [deco for deco in node.decorators if deco.name == "card"]
         file_outputs: Dict[str, str] = {
-            f"card{i}": f"/tmp/outputs/cards/card{i}.html"
+            f"card-{i}": f"/tmp/outputs/cards/card-{i}.html"
             for i in range(len(card_decos))
         }
 

--- a/metaflow/plugins/aip/aip_cli.py
+++ b/metaflow/plugins/aip/aip_cli.py
@@ -264,6 +264,7 @@ def common_create_run_options(default_yaml_kind: str):
             "--add-default-card",
             "add_default_card",
             default=from_conf("METAFLOW_AIP_ADD_DEFAULT_CARD", default=True),
+            type=bool,
             help="Whether to add default card to all workflow steps",
             show_default=True,
         )

--- a/metaflow/plugins/aip/aip_cli.py
+++ b/metaflow/plugins/aip/aip_cli.py
@@ -260,6 +260,13 @@ def common_create_run_options(default_yaml_kind: str):
             "If not set, the default iam role associated with the pod will be used",
             show_default=True,
         )
+        @click.option(
+            "--add-default-cards",
+            "add_default_cards",
+            default=True,
+            help="Whether to add default card to all workflow steps",
+            show_default=True,
+        )
         @functools.wraps(func)
         def wrapper_common_options(*args, **kwargs):
             return func(*args, **kwargs)
@@ -323,6 +330,7 @@ def run(
     sqs_role_arn_on_error=None,
     argo_wait=False,
     wait_for_completion_timeout=None,
+    add_default_cards=True,
     **kwargs,
 ):
     """
@@ -353,6 +361,7 @@ def run(
         notify_on_success=notify_on_success,
         sqs_url_on_error=sqs_url_on_error,
         sqs_role_arn_on_error=sqs_role_arn_on_error,
+        add_default_cards=True,
     )
 
     if yaml_only:
@@ -516,6 +525,7 @@ def create(
     recurring_run_enable=None,
     recurring_run_cron=None,
     recurring_run_concurrency=None,
+    add_default_cards=True,
     **kwargs,
 ):
     """
@@ -549,6 +559,7 @@ def create(
         notify_on_success=notify_on_success,
         sqs_url_on_error=sqs_url_on_error,
         sqs_role_arn_on_error=sqs_role_arn_on_error,
+        add_default_cards=True,
     )
 
     if yaml_only:
@@ -669,6 +680,7 @@ def make_flow(
     notify_on_success,
     sqs_url_on_error,
     sqs_role_arn_on_error,
+    add_default_cards=True,
 ):
     """
     Analogous to step_functions_cli.py
@@ -682,6 +694,9 @@ def make_flow(
 
     # Attach AIP decorator to the flow
     decorators._attach_decorators(obj.flow, [AIPInternalDecorator.name])
+    if add_default_cards:
+        decorators._attach_decorators(obj.flow, ["card:id=default"])
+
     decorators._init_step_decorators(
         obj.flow, obj.graph, obj.environment, obj.flow_datastore, obj.logger
     )

--- a/metaflow/plugins/aip/aip_cli.py
+++ b/metaflow/plugins/aip/aip_cli.py
@@ -261,9 +261,9 @@ def common_create_run_options(default_yaml_kind: str):
             show_default=True,
         )
         @click.option(
-            "--add-default-cards",
-            "add_default_cards",
-            default=from_conf("METAFLOW_AIP_ADD_DEFAULT_CARDS", default=True),
+            "--add-default-card",
+            "add_default_card",
+            default=from_conf("METAFLOW_AIP_ADD_DEFAULT_CARD", default=True),
             help="Whether to add default card to all workflow steps",
             show_default=True,
         )
@@ -330,7 +330,7 @@ def run(
     sqs_role_arn_on_error=None,
     argo_wait=False,
     wait_for_completion_timeout=None,
-    add_default_cards=True,
+    add_default_card=True,
     **kwargs,
 ):
     """
@@ -361,7 +361,7 @@ def run(
         notify_on_success=notify_on_success,
         sqs_url_on_error=sqs_url_on_error,
         sqs_role_arn_on_error=sqs_role_arn_on_error,
-        add_default_cards=add_default_cards,
+        add_default_card=add_default_card,
     )
 
     if yaml_only:
@@ -525,7 +525,7 @@ def create(
     recurring_run_enable=None,
     recurring_run_cron=None,
     recurring_run_concurrency=None,
-    add_default_cards=True,
+    add_default_card=True,
     **kwargs,
 ):
     """
@@ -559,7 +559,7 @@ def create(
         notify_on_success=notify_on_success,
         sqs_url_on_error=sqs_url_on_error,
         sqs_role_arn_on_error=sqs_role_arn_on_error,
-        add_default_cards=add_default_cards,
+        add_default_card=add_default_card,
     )
 
     if yaml_only:
@@ -680,7 +680,7 @@ def make_flow(
     notify_on_success,
     sqs_url_on_error,
     sqs_role_arn_on_error,
-    add_default_cards,
+    add_default_card,
 ):
     """
     Analogous to step_functions_cli.py
@@ -694,7 +694,7 @@ def make_flow(
 
     # Attach AIP decorator to the flow
     decorators._attach_decorators(obj.flow, [AIPInternalDecorator.name])
-    if add_default_cards:
+    if add_default_card:
         decorators._attach_decorators(obj.flow, ["card:id=default"])
 
     decorators._init_step_decorators(
@@ -740,5 +740,5 @@ def make_flow(
         notify_on_success=notify_on_success,
         sqs_url_on_error=sqs_url_on_error,
         sqs_role_arn_on_error=sqs_role_arn_on_error,
-        add_default_cards=add_default_cards,
+        add_default_card=add_default_card,
     )

--- a/metaflow/plugins/aip/aip_cli.py
+++ b/metaflow/plugins/aip/aip_cli.py
@@ -740,4 +740,5 @@ def make_flow(
         notify_on_success=notify_on_success,
         sqs_url_on_error=sqs_url_on_error,
         sqs_role_arn_on_error=sqs_role_arn_on_error,
+        add_default_cards=add_default_cards,
     )

--- a/metaflow/plugins/aip/aip_cli.py
+++ b/metaflow/plugins/aip/aip_cli.py
@@ -263,7 +263,7 @@ def common_create_run_options(default_yaml_kind: str):
         @click.option(
             "--add-default-cards",
             "add_default_cards",
-            default=True,
+            default=from_conf("METAFLOW_AIP_ADD_DEFAULT_CARDS", default=True),
             help="Whether to add default card to all workflow steps",
             show_default=True,
         )

--- a/metaflow/plugins/aip/aip_cli.py
+++ b/metaflow/plugins/aip/aip_cli.py
@@ -361,7 +361,7 @@ def run(
         notify_on_success=notify_on_success,
         sqs_url_on_error=sqs_url_on_error,
         sqs_role_arn_on_error=sqs_role_arn_on_error,
-        add_default_cards=True,
+        add_default_cards=add_default_cards,
     )
 
     if yaml_only:
@@ -559,7 +559,7 @@ def create(
         notify_on_success=notify_on_success,
         sqs_url_on_error=sqs_url_on_error,
         sqs_role_arn_on_error=sqs_role_arn_on_error,
-        add_default_cards=True,
+        add_default_cards=add_default_cards,
     )
 
     if yaml_only:
@@ -680,7 +680,7 @@ def make_flow(
     notify_on_success,
     sqs_url_on_error,
     sqs_role_arn_on_error,
-    add_default_cards=True,
+    add_default_cards,
 ):
     """
     Analogous to step_functions_cli.py

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -37,10 +37,9 @@ def _write_card_artifacts(
     run_id: str,
 ):
     """
-    Add card artifacts to step outputs. This function depends on Metaflow backend.
-
-    Cards are still available to view through Metaflow UI or Metaflow CLI even if this function fails.
-    Therefore, all exceptions are caught and logged, instead of raised.
+    Pull card artifacts from datastore and add them to the Argo artifact output path.
+    Cards should already be uploaded to the datastore as part of the @card decorator.
+    No exception is thrown: cards are available to view through Metaflow UI or CLI even if this function fails.
     """
 
     task_id_template: str = f"{task_id}.{passed_in_split_indexes}".strip(".")

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -52,8 +52,9 @@ def _write_card_artifacts(
         try:
             with open(file_name, "w") as card_file:
                 card_file.write(card.get())
-        except Exception as e:
-            logging.exception(f"Failed to write card {i} of type {card.type}: {e}")
+        except Exception:
+            logging.error(f"Failed to write card {i} of type {card.type}")
+            raise
         i = i + 1
 
 

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -454,7 +454,7 @@ def aip_metaflow_step(
             f.write(str(values[idx]))
 
     # Write card manifest (html) to Argo output artifact path.
-    if skip_card_artifacts:
+    if not skip_card_artifacts:
         _write_card_artifacts(
             flow_name,
             step_name,

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -51,7 +51,7 @@ def _write_card_artifacts(
             with open(file_name, "w") as card_file:
                 card_file.write(card.get())
         except Exception:
-            logging.error(f"Failed to write card {index} of type {card.type}")
+            logging.exception(f"Failed to write card {index} of type {card.type}")
             raise
 
 
@@ -445,7 +445,7 @@ def aip_metaflow_step(
         )
     except Exception as e:
         # Workflow should still succeed even if cards fail to render
-        logging.error(f"Failed to write card artifacts: {e}")
+        logging.exception(f"Failed to write card artifacts: {e}")
 
 
 if __name__ == "__main__":

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -46,7 +46,7 @@ def _write_card_artifacts(
 
     pathlib.Path("/tmp/outputs/cards/").mkdir(parents=True, exist_ok=True)
     for index, card in enumerate(sorted_cards):
-        file_name = f"/tmp/outputs/cards/card{index}.html"
+        file_name = f"/tmp/outputs/cards/card-{index}.html"
         try:
             with open(file_name, "w") as card_file:
                 card_file.write(card.get())

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -69,6 +69,7 @@ def _step_cli(
     max_user_code_retries: int,
     workflow_name: str,
     script_name: str,
+    add_default_card: bool,
 ) -> str:
     """
     Analogous to step_functions.py
@@ -166,6 +167,7 @@ def _step_cli(
 
     step: List[str] = [
         "--with=aip",
+        "--with 'card:id=default'" if add_default_card else "",
         "step",
         step_name,
         "--run-id %s" % run_id,
@@ -275,6 +277,7 @@ def _command(
 @click.option("--workflow_name")
 @click.option("--is-interruptible/--not-interruptible", default=False)
 @click.option("--is-join-step", is_flag=True, default=False)
+@click.option("--add-default-cards", is_flag=True, default=False)
 def aip_metaflow_step(
     volume_dir: str,
     environment: str,
@@ -300,6 +303,7 @@ def aip_metaflow_step(
     workflow_name: str,
     is_interruptible: bool,
     is_join_step: bool,
+    add_default_cards: bool,
 ) -> None:
     """
     (1) Renders and runs the Metaflow package_commands and Metaflow step
@@ -331,6 +335,7 @@ def aip_metaflow_step(
         user_code_retries,
         workflow_name,
         script_name,
+        add_default_cards,
     )
 
     # expose passed KFP passed in arguments as environment variables to

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -49,8 +49,11 @@ def _write_card_artifacts(
     for card in sorted_cards:
         iter_name = "" if i == 0 else i
         file_name = f"/tmp/outputs/cards/card{iter_name}.html"
-        with open(file_name, "w") as card_file:
-            card_file.write(card.get())
+        try:
+            with open(file_name, "w") as card_file:
+                card_file.write(card.get())
+        except Exception as e:
+            logging.exception(f"Failed to write card {i} of type {card.type}: {e}")
         i = i + 1
 
 
@@ -435,14 +438,18 @@ def aip_metaflow_step(
         with open(output_file, "w") as f:
             f.write(str(values[idx]))
 
-    # get card and write to output file
-    _write_card_artifacts(
-        flow_name,
-        step_name,
-        task_id,
-        passed_in_split_indexes,
-        metaflow_run_id,
-    )
+    # Get card and write to output file
+    try:
+        _write_card_artifacts(
+            flow_name,
+            step_name,
+            task_id,
+            passed_in_split_indexes,
+            metaflow_run_id,
+        )
+    except Exception as e:
+        # Workflow should still succeed even if cards fail to render
+        logging.error(f"Failed to write card artifacts: {e}")
 
 
 if __name__ == "__main__":

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -277,7 +277,7 @@ def _command(
 @click.option("--workflow_name")
 @click.option("--is-interruptible/--not-interruptible", default=False)
 @click.option("--is-join-step", is_flag=True, default=False)
-@click.option("--add-default-cards", is_flag=True, default=False)
+@click.option("--add-default-card", is_flag=True, default=False)
 def aip_metaflow_step(
     volume_dir: str,
     environment: str,
@@ -303,7 +303,7 @@ def aip_metaflow_step(
     workflow_name: str,
     is_interruptible: bool,
     is_join_step: bool,
-    add_default_cards: bool,
+    add_default_card: bool,
 ) -> None:
     """
     (1) Renders and runs the Metaflow package_commands and Metaflow step
@@ -335,7 +335,7 @@ def aip_metaflow_step(
         user_code_retries,
         workflow_name,
         script_name,
-        add_default_cards,
+        add_default_card,
     )
 
     # expose passed KFP passed in arguments as environment variables to

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -44,18 +44,15 @@ def _write_card_artifacts(
         cards, key=lambda card: (card.type != "default", cards.index(card))
     )
 
-    i = 0
     pathlib.Path("/tmp/outputs/cards/").mkdir(parents=True, exist_ok=True)
-    for card in sorted_cards:
-        iter_name = "" if i == 0 else i
-        file_name = f"/tmp/outputs/cards/card{iter_name}.html"
+    for index, card in enumerate(sorted_cards):
+        file_name = f"/tmp/outputs/cards/card{index}.html"
         try:
             with open(file_name, "w") as card_file:
                 card_file.write(card.get())
         except Exception:
-            logging.error(f"Failed to write card {i} of type {card.type}")
+            logging.error(f"Failed to write card {index} of type {card.type}")
             raise
-        i = i + 1
 
 
 def _step_cli(


### PR DESCRIPTION
Changes:
- Default cards are still added by default to all steps, but user has option to disable it is by passing `--add-default-cards false`.
  - TODO: this option needs to be propagated to CICD
- Card rendering errors are ignored.

Tests:
- Regression test: https://argo-server.int.stage-k8s.zg-aip.net/argo-ui/workflows/aip-example-dev/metadataflow-z9mmd
- Removing the cards by setting `METAFLOW_AIP_ADD_DEFAULT_CARD="false"`: https://argo-server.int.stage-k8s.zg-aip.net/argo-ui/workflows/aip-example-dev/metadataflow-ssphx

Closes [AIP-8718](https://zillowgroup.atlassian.net/browse/AIP-8718)