### PR TITLE
AIP-8595 truncate volume name

### DIFF
--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -999,9 +999,7 @@ class KubeflowPipelines(object):
         )
         self._set_container_labels(resource)
 
-        volume = PipelineVolume(
-            name=f"{volume_name}-volume", pvc=resource.outputs["name"]
-        )
+        volume = PipelineVolume(name=f"{volume_name}", pvc=resource.outputs["name"])
         return (resource, volume)
 
     @staticmethod

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -957,7 +957,9 @@ class KubeflowPipelines(object):
         size: str,
         volume_type: Optional[str],
     ) -> Tuple[ResourceOp, PipelineVolume]:
-        volume_name = "{{pod.name}}"
+        # AIP-8595(talebz): to avoid volume name "must be no more than 63 characters error"
+        # truncate from the beginning (the suffix has more entropy)
+        volume_name = "{{=sprig.trunc(-63, pod.name)}}"
         attribute_outputs = {"size": "{.status.capacity.storage}"}
         requested_resources = V1ResourceRequirements(requests={"storage": size})
 

--- a/metaflow/plugins/aip/tests/flows/resources_flow.py
+++ b/metaflow/plugins/aip/tests/flows/resources_flow.py
@@ -125,7 +125,8 @@ class TestTypeClass(click.ParamType):
         return "Dataset"
 
 
-class ResourcesFlow(FlowSpec):
+# AIP-8595(talebz): To validate that volume names are truncated to 63 characters
+class ResourcesFlowLooooooooooooooooooooooongNaaaaaaaaaaaaaaaaaaaaame(FlowSpec):
     json_param: Dict = Parameter(
         "json_param", default=default_dict, type=TestTypeClass()
     )
@@ -216,4 +217,4 @@ class ResourcesFlow(FlowSpec):
 
 
 if __name__ == "__main__":
-    ResourcesFlow()
+    ResourcesFlowLooooooooooooooooooooooongNaaaaaaaaaaaaaaaaaaaaame()


### PR DESCRIPTION
To avoid the error:

> ``` Pod "mopro-inference-saiwingy-fix-fea-53392f16-r2v7m-1527204495" is invalid: [spec.volumes[3].name: Invalid value: "mopro-inference-saiwingy-fix-fea-53392f16-r2v7m-1527204495-volume": must be no more than 63 characters, spec.containers[0].volumeMounts[1].name: Not found: "mopro-inference-saiwingy-fix-fea-53392f16-r2v7m-1527204495-volume", spec.containers[1].volumeMounts[0].name: Not found: "mopro-inference-saiwingy-fix-fea-53392f16-r2v7m-1527204495-volume"]```