### PR TITLE
AIP 9153 add stop flow and terminate flow functionality

### DIFF
--- a/metaflow/plugins/aip/argo_client.py
+++ b/metaflow/plugins/aip/argo_client.py
@@ -151,7 +151,7 @@ class ArgoClient(object):
                 namespace=self._namespace,
                 plural=plural,
                 name=name,
-                body=body
+                body=body,
             )
         except client.rest.ApiException as e:
             if e.status == 404:
@@ -160,7 +160,7 @@ class ArgoClient(object):
             raise ArgoClientException(
                 json.loads(e.body)["message"] if e.body is not None else e.reason
             )
-    
+
     def delete_workflow_template(self, name: str):
         client = self._client.get()
         try:

--- a/metaflow/plugins/aip/argo_client.py
+++ b/metaflow/plugins/aip/argo_client.py
@@ -154,9 +154,6 @@ class ArgoClient(object):
                 body=body,
             )
         except client.rest.ApiException as e:
-            if e.status == 404:
-                print("Workflow not found")
-                return None
             raise ArgoClientException(
                 json.loads(e.body)["message"] if e.body is not None else e.reason
             )

--- a/metaflow/plugins/aip/argo_client.py
+++ b/metaflow/plugins/aip/argo_client.py
@@ -142,6 +142,29 @@ class ArgoClient(object):
                 json.loads(e.body)["message"] if e.body is not None else e.reason
             )
 
+    def patch_argo_object(self, name: str, plural: str, body: List):
+        
+        print(f"patching argo object:\n{self._group=}\n{self._version=}\n{self._namespace=}\n{plural=}\n{body=}")
+
+        # print("skipping the actual patching...")
+        client = self._client.get()
+        try:
+            return client.CustomObjectsApi().patch_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=self._namespace,
+                plural=plural,
+                name=name,
+                body=body
+            )
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                print("Workflow not found")
+                return None
+            raise ArgoClientException(
+                json.loads(e.body)["message"] if e.body is not None else e.reason
+            )
+    
     def delete_workflow_template(self, name: str):
         client = self._client.get()
         try:

--- a/metaflow/plugins/aip/argo_client.py
+++ b/metaflow/plugins/aip/argo_client.py
@@ -143,10 +143,6 @@ class ArgoClient(object):
             )
 
     def patch_argo_object(self, name: str, plural: str, body: List):
-        
-        print(f"patching argo object:\n{self._group=}\n{self._version=}\n{self._namespace=}\n{plural=}\n{body=}")
-
-        # print("skipping the actual patching...")
         client = self._client.get()
         try:
             return client.CustomObjectsApi().patch_namespaced_custom_object(

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -8,8 +8,6 @@ from metaflow.metaflow_config import (
     METAFLOW_RUN_URL_PREFIX,
     KUBERNETES_NAMESPACE,
 )
-
-# from metaflowTerm.metaflow.plugins.aip.argo_client import ArgoClient  # this is for development on a notebook
 from metaflow.plugins.aip.argo_client import ArgoClient
 from metaflow.plugins.aip.aip_decorator import AIPException
 from metaflow.plugins.aip.aip_utils import _get_aip_logger
@@ -37,7 +35,7 @@ class ArgoHelper:
         Stop a workflow but still run exit handlers.
 
         Args:
-            workflow_name: Name of the workflow to terminate. 
+            workflow_name: Name of the workflow to terminate.
         """
 
         logger.info(f"Terminating workflow: {workflow_name=}")
@@ -56,7 +54,7 @@ class ArgoHelper:
         Immediately stop a workflow and do not run any exit handlers.
 
         Args:
-            workflow_name: Name of the workflow to terminate. 
+            workflow_name: Name of the workflow to terminate.
         """
 
         logger.info(f"Terminating workflow: {workflow_name=}")

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -38,7 +38,7 @@ class ArgoHelper:
             workflow_name: Name of the workflow to terminate.
         """
 
-        logger.info(f"Terminating workflow: {workflow_name=}")
+        logger.info(f"Stopping workflow: {workflow_name=}")
         body = {"spec": {"shutdown": "Stop"}}
         self._client.patch_argo_object(
             name=workflow_name,

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -35,7 +35,7 @@ class ArgoHelper:
         Stop a workflow but still run exit handlers.
 
         Args:
-            workflow_name: Name of the workflow to terminate.
+            workflow_name: Name of the workflow to stop.
         """
 
         logger.info(f"Stopping workflow: {workflow_name=}")

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -8,6 +8,7 @@ from metaflow.metaflow_config import (
     METAFLOW_RUN_URL_PREFIX,
     KUBERNETES_NAMESPACE,
 )
+
 # from metaflowTerm.metaflow.plugins.aip.argo_client import ArgoClient  # this is for development on a notebook
 from metaflow.plugins.aip.argo_client import ArgoClient
 from metaflow.plugins.aip.aip_decorator import AIPException

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -29,12 +29,34 @@ class ArgoHelper:
         print(f"initiating ArgoHelper with {kubernetes_namespace=}")
         self._client = ArgoClient(namespace=kubernetes_namespace)
 
+    def stop_workflow(
+        self,
+        workflow_name: str,
+    ) -> None:
+        """
+        Stops workflow immediately, but allows exit handlers to run. 
+
+        Args:
+            workflow_name: Name of the workflow to terminate. 
+        """
+
+        logger.info(f"Terminating workflow: {workflow_name=}")
+        body = {"spec": {"shutdown": "Stop"}}
+        self._client.patch_argo_object(
+            name=workflow_name,
+            plural="workflows",
+            body=body,
+        )
+
     def terminate_workflow(
         self,
         workflow_name: str,
     ) -> None:
         """
-        TODO: add description
+        Terminates a workflow immediately. Exit handlers do not run. 
+
+        Args:
+            workflow_name: Name of the workflow to terminate. 
         """
 
         logger.info(f"Terminating workflow: {workflow_name=}")

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -8,7 +8,7 @@ from metaflow.metaflow_config import (
     METAFLOW_RUN_URL_PREFIX,
     KUBERNETES_NAMESPACE,
 )
-from metaflow.plugins.aip.argo_client import ArgoClient
+from metaflowTerm.metaflow.plugins.aip.argo_client import ArgoClient
 from metaflow.plugins.aip.aip_decorator import AIPException
 from metaflow.plugins.aip.aip_utils import _get_aip_logger
 
@@ -24,18 +24,34 @@ class ArgoHelper:
                 Required as the defaults provided in the ArgoClient is usually not what customers desire.
                 TODO: This namespace can be default to the current namespace if the script is ran within a cluster.
         """
+        print(f"initiating ArgoHelper with {kubernetes_namespace=}")
         self._client = ArgoClient(namespace=kubernetes_namespace)
+
 
     def terminate_workflow(
         self,
-        workflow_name: Optional[str] = None,
-        **kwarg,
-    ) -> Tuple[str, str]:
+        argo_run_id: str,
+    ) -> None:
         """
         TODO: add description
         """
 
-        pass
+        print(f"terminating workflow with {argo_run_id=}")
+        run_status = self._client.get_workflow_run_status(argo_run_id)
+        print(f"got {run_status=}")
+
+        body = [{"op": "replace", "path": "/spec/exampleField", "value": "updatefield"}]
+
+        print(f"{argo_run_id=}")
+        print(f"{body=}")
+        
+        api_response = self._client.patch_argo_object(
+            name=argo_run_id,
+            plural="workflows",
+            body=body,
+        )
+        print(f"{api_response=}")
+        
 
     def trigger_exact(
         self,

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -8,7 +8,8 @@ from metaflow.metaflow_config import (
     METAFLOW_RUN_URL_PREFIX,
     KUBERNETES_NAMESPACE,
 )
-from metaflowTerm.metaflow.plugins.aip.argo_client import ArgoClient
+# from metaflowTerm.metaflow.plugins.aip.argo_client import ArgoClient  # this is for development on a notebook
+from metaflow.plugins.aip.argo_client import ArgoClient
 from metaflow.plugins.aip.aip_decorator import AIPException
 from metaflow.plugins.aip.aip_utils import _get_aip_logger
 
@@ -27,31 +28,21 @@ class ArgoHelper:
         print(f"initiating ArgoHelper with {kubernetes_namespace=}")
         self._client = ArgoClient(namespace=kubernetes_namespace)
 
-
     def terminate_workflow(
         self,
-        argo_run_id: str,
+        workflow_name: str,
     ) -> None:
         """
         TODO: add description
         """
 
-        print(f"terminating workflow with {argo_run_id=}")
-        run_status = self._client.get_workflow_run_status(argo_run_id)
-        print(f"got {run_status=}")
-
-        body = [{"op": "replace", "path": "/spec/exampleField", "value": "updatefield"}]
-
-        print(f"{argo_run_id=}")
-        print(f"{body=}")
-        
-        api_response = self._client.patch_argo_object(
-            name=argo_run_id,
+        logger.info(f"Terminating workflow: {workflow_name=}")
+        body = {"spec": {"shutdown": "Terminate"}}
+        self._client.patch_argo_object(
+            name=workflow_name,
             plural="workflows",
             body=body,
         )
-        print(f"{api_response=}")
-        
 
     def trigger_exact(
         self,

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -34,7 +34,7 @@ class ArgoHelper:
         workflow_name: str,
     ) -> None:
         """
-        Stops workflow immediately, but allows exit handlers to run. 
+        Stop a workflow but still run exit handlers.
 
         Args:
             workflow_name: Name of the workflow to terminate. 
@@ -53,7 +53,7 @@ class ArgoHelper:
         workflow_name: str,
     ) -> None:
         """
-        Terminates a workflow immediately. Exit handlers do not run. 
+        Immediately stop a workflow and do not run any exit handlers.
 
         Args:
             workflow_name: Name of the workflow to terminate. 

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -30,7 +30,9 @@ class ArgoHelper:
         """
         Permanently stops workflow with status 'Failed'.
         Currently running steps do NOT finish running.
-        Exit handlers are allowed to run.
+        Exit handlers are allowed to run. This includes the `notify-email-exit-handler`, which sends an email to the
+            address specified by notifyErrorEmail in the AIPEnvironment. The address provided is often OpsGenie, where
+            an email can raise an OpsGenie alert.
 
         Args:
             workflow_name: Name of the workflow to stop.
@@ -48,7 +50,9 @@ class ArgoHelper:
         """
         Permanently stops workflow with status 'Failed'.
         Currently running steps do NOT finish running.
-        Exit handlers are NOT allowed to run.
+        Exit handlers are NOT allowed to run. This includes the `notify-email-exit-handler`, which means no email will
+            be sent, even though the workflow 'Failed'. If your alerting setup depends on exit handler emails
+            (ex OpsGenie), you will not get alerted by a terminated workflow.
 
         Args:
             workflow_name: Name of the workflow to terminate.

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -24,7 +24,7 @@ class ArgoHelper:
                 Required as the defaults provided in the ArgoClient is usually not what customers desire.
                 TODO: This namespace can be default to the current namespace if the script is ran within a cluster.
         """
-        print(f"initiating ArgoHelper with {kubernetes_namespace=}")
+        logger.info(f"initiating ArgoHelper with {kubernetes_namespace=}")
         self._client = ArgoClient(namespace=kubernetes_namespace)
 
     def stop_workflow(

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -28,7 +28,8 @@ class ArgoHelper:
 
     def stop_workflow(self, workflow_name: str) -> None:
         """
-        Permanently and immediately stops workflow with status 'Failed'. 
+        Permanently stops workflow with status 'Failed'.
+        Currently running steps do NOT finish running.
         Exit handlers are allowed to run.
 
         Args:
@@ -45,7 +46,8 @@ class ArgoHelper:
 
     def terminate_workflow(self, workflow_name: str) -> None:
         """
-        Permanently and immediately stops workflow with status 'Failed'. 
+        Permanently stops workflow with status 'Failed'.
+        Currently running steps do NOT finish running.
         Exit handlers are NOT allowed to run.
 
         Args:

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -24,12 +24,12 @@ class ArgoHelper:
                 Required as the defaults provided in the ArgoClient is usually not what customers desire.
                 TODO: This namespace can be default to the current namespace if the script is ran within a cluster.
         """
-        logger.info(f"initiating ArgoHelper for Namespace: {kubernetes_namespace}")
         self._client = ArgoClient(namespace=kubernetes_namespace)
 
     def stop_workflow(self, workflow_name: str) -> None:
         """
-        Stop a workflow but still run exit handlers.
+        Permanently and immediately stops workflow with status 'Failed'. 
+        Exit handlers are allowed to run.
 
         Args:
             workflow_name: Name of the workflow to stop.
@@ -45,7 +45,8 @@ class ArgoHelper:
 
     def terminate_workflow(self, workflow_name: str) -> None:
         """
-        Immediately stop a workflow and do not run any exit handlers.
+        Permanently and immediately stops workflow with status 'Failed'. 
+        Exit handlers are NOT allowed to run.
 
         Args:
             workflow_name: Name of the workflow to terminate.

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -24,13 +24,10 @@ class ArgoHelper:
                 Required as the defaults provided in the ArgoClient is usually not what customers desire.
                 TODO: This namespace can be default to the current namespace if the script is ran within a cluster.
         """
-        logger.info(f"initiating ArgoHelper with {kubernetes_namespace=}")
+        logger.info(f"initiating ArgoHelper for Namespace: {kubernetes_namespace}")
         self._client = ArgoClient(namespace=kubernetes_namespace)
 
-    def stop_workflow(
-        self,
-        workflow_name: str,
-    ) -> None:
+    def stop_workflow(self, workflow_name: str) -> None:
         """
         Stop a workflow but still run exit handlers.
 
@@ -46,10 +43,7 @@ class ArgoHelper:
             body=body,
         )
 
-    def terminate_workflow(
-        self,
-        workflow_name: str,
-    ) -> None:
+    def terminate_workflow(self, workflow_name: str) -> None:
         """
         Immediately stop a workflow and do not run any exit handlers.
 

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -26,6 +26,17 @@ class ArgoHelper:
         """
         self._client = ArgoClient(namespace=kubernetes_namespace)
 
+    def terminate_workflow(
+        self,
+        workflow_name: Optional[str] = None,
+        **kwarg,
+    ) -> Tuple[str, str]:
+        """
+        TODO: add description
+        """
+
+        pass
+
     def trigger_exact(
         self,
         template_name: Optional[str] = None,


### PR DESCRIPTION
**Background**
Version 1 of wfsdk (aka zillow-metaflow) supported terminating a workflow with a KFP plugin function [terminate_run](https://github.com/zillow/metaflow/blob/16459a7a7615d096b117928a433d0c12ba81e818/metaflow/plugins/kfp/kfp_utils.py#L274), which terminated a workflow based on its run_id. Based on a [GitLab search](https://gitlab.zgtools.net/search?group_id=181&scope=blobs&search=terminate_run), the function is only used by [Zestimate orchestrator](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-zestimates/zestimate-orchestrator/-/blob/main/zestimate_orchestrator/utils/pipeline_utils.py#L109), which is owned by the VHD team (aka Ken's team). VHD [asked for this same functionality in the Argo-based version 2 of zillow-metaflow](https://zillowgroup.slack.com/archives/C0774URNUN6/p1740594684606099?thread_ts=1740422841.010719&cid=C0774URNUN6), but none was found in the [Argo plugin](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/sdks/zillow-metaflow/-/blob/feature/aip/metaflow/plugins/aip/argo_utils.py). 

**Design**
Support terminate flows from argo plugin. Reference in argo workflows patching [here](https://github.com/argoproj/argo-workflows/blob/815b24960e80e28540ac566b29e1860958a0ff39/workflow/util/util.go#L1445) and [here](https://github.com/argoproj/argo-workflows/blob/815b24960e80e28540ac566b29e1860958a0ff39/workflow/util/util.go#L1468). patchShutdownStrategy simply needs to be emulated in wfsdk as python code with the kubernetes custom objects API.

**Notes:**

- Terminate in KFP may not be the same as terminated in argo
    - [Issue re argo stop v terminate](https://github.com/argoproj/argo-workflows/issues/4454); [MR to clarify](https://github.com/argoproj/argo-workflows/commit/cbead62215db474b450567b97fa67bfefe066323) that both end the workflow, but stop allows exit handlers to run while terminate does not.
    - We should ask VHD which behavior they prefer/expect. We can also just add both functionalities and document them.