### PR TITLE
AIP-9716: Pin pytest-cov to version 6.2.1 metaflow to fix AIP integration test failures

### DIFF
--- a/metaflow/plugins/aip/Dockerfile
+++ b/metaflow/plugins/aip/Dockerfile
@@ -42,7 +42,7 @@ ENV POETRY_VIRTUALENVS_CREATE=False
 
 RUN pip install --upgrade --force-reinstall \
     -i https://artifactory.zgtools.net/artifactory/api/pypi/analytics-python/simple \
-    awscli click requests boto3 pytest pytest-xdist zillow-kfp kfp-server-api
+    awscli click requests boto3 pytest pytest-xdist pytest-cov==6.2.1 zillow-kfp kfp-server-api
 
 # Create Z_USER with UID=1000 and in the 'users' group
 ARG Z_USER="zservice"

--- a/metaflow/plugins/aip/Dockerfile
+++ b/metaflow/plugins/aip/Dockerfile
@@ -42,7 +42,7 @@ ENV POETRY_VIRTUALENVS_CREATE=False
 
 RUN pip install --upgrade --force-reinstall \
     -i https://artifactory.zgtools.net/artifactory/api/pypi/analytics-python/simple \
-    awscli click requests boto3 pytest pytest-xdist pytest-cov==6.2.1 zillow-kfp kfp-server-api
+    awscli click requests boto3 pytest==8.4.2 pytest-xdist==3.8.0 pytest-cov==6.2.1 zillow-kfp kfp-server-api
 
 # Create Z_USER with UID=1000 and in the 'users' group
 ARG Z_USER="zservice"

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
     tests_require=["coverage"],
     extras_require={
         # Use an extras here as there is no "extras_tests_require" functionality :(
-        "aip-tests": ["pytest", "pytest-xdist", "pytest-cov", "subprocess-tee"],
+        "aip-tests": ["pytest", "pytest-xdist", "pytest-cov==6.2.1", "subprocess-tee"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
     tests_require=["coverage"],
     extras_require={
         # Use an extras here as there is no "extras_tests_require" functionality :(
-        "aip-tests": ["pytest", "pytest-xdist", "pytest-cov==6.2.1", "subprocess-tee"],
+        "aip-tests": ["pytest==8.4.2", "pytest-xdist==3.8.0", "pytest-cov==6.2.1", "subprocess-tee"],
     },
 )


### PR DESCRIPTION
### Problem
AIP integration tests were failing due to pytest coverage errors caused by [pytest-cov version 7.0.0](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/sdks/zillow-metaflow/-/jobs/72261159#L146) introducing breaking changes. The last working version was [pytest-cov 6.2.1](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/sdks/zillow-metaflow/-/jobs/71521001#L504).

### Changes Made
Updated `metaflow/plugins/aip/Dockerfile` line 45: Added `pytest-cov==6.2.1` to pip install command