### PR TITLE
AIP-9471 - Remove pkg_resources

### DIFF
--- a/kfp/v2/google/client/client.py
+++ b/kfp/v2/google/client/client.py
@@ -15,8 +15,7 @@
 
 import datetime
 import json
-# TODO: remove pkg_resources
-import pkg_resources
+from importlib.resources import files
 import re
 import subprocess
 import warnings
@@ -188,11 +187,9 @@ class AIPlatformClient(object):
         self._region = region
         self._parent = _PARENT_PATTERN.format(project_id, region)
 
-        # TODO: remove pkg_resources
-        discovery_doc_path = pkg_resources.resource_filename(
-            'kfp.v2.google.client',
+        
+        discovery_doc_path = files('kfp.v2.google.client').joinpath(
             'discovery/aiplatform_public_google_rest_v1beta1.json')
-
         with open(discovery_doc_path) as f:
             discovery_doc = f.read()
 

--- a/kfp/v2/google/client/client.py
+++ b/kfp/v2/google/client/client.py
@@ -190,6 +190,7 @@ class AIPlatformClient(object):
         
         discovery_doc_path = files('kfp.v2.google.client').joinpath(
             'discovery/aiplatform_public_google_rest_v1beta1.json')
+
         with open(discovery_doc_path) as f:
             discovery_doc = f.read()
 

--- a/kfp/v2/google/client/client.py
+++ b/kfp/v2/google/client/client.py
@@ -15,6 +15,7 @@
 
 import datetime
 import json
+# TODO: remove pkg_resources
 import pkg_resources
 import re
 import subprocess
@@ -187,6 +188,7 @@ class AIPlatformClient(object):
         self._region = region
         self._parent = _PARENT_PATTERN.format(project_id, region)
 
+        # TODO: remove pkg_resources
         discovery_doc_path = pkg_resources.resource_filename(
             'kfp.v2.google.client',
             'discovery/aiplatform_public_google_rest_v1beta1.json')

--- a/kfp/v2/google/client/client.py
+++ b/kfp/v2/google/client/client.py
@@ -15,7 +15,10 @@
 
 import datetime
 import json
-from importlib.resources import files
+try:
+    import pkg_resources
+except:
+    print("pkg_resources not found; upgrade to importlib.resources instead")
 import re
 import subprocess
 import warnings
@@ -187,9 +190,14 @@ class AIPlatformClient(object):
         self._region = region
         self._parent = _PARENT_PATTERN.format(project_id, region)
 
-        
-        discovery_doc_path = files('kfp.v2.google.client').joinpath(
-            'discovery/aiplatform_public_google_rest_v1beta1.json')
+
+        try:
+            discovery_doc_path = pkg_resources.resource_filename(
+                'kfp.v2.google.client',
+                'discovery/aiplatform_public_google_rest_v1beta1.json') 
+        except:
+            print("pkg_resources not found; upgrade to importlib.resources instead.")
+            raise
 
         with open(discovery_doc_path) as f:
             discovery_doc = f.read()

--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -191,7 +191,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("metaflow")
-except:
+except PackageNotFoundError:
     # this happens on remote environments since the job package
     # does not have a version
     __version__ = None

--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -187,6 +187,7 @@ for _n in [
         pass
 del globals()["_n"]
 
+# TODO: remove pkg_resources
 import pkg_resources
 
 try:

--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -187,10 +187,9 @@ for _n in [
         pass
 del globals()["_n"]
 
-
+from importlib.metadata import version
 
 try:
-    from importlib.metadata import version
     __version__ = version("metaflow")
 except:
     # this happens on remote environments since the job package

--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -187,11 +187,14 @@ for _n in [
         pass
 del globals()["_n"]
 
-from importlib.metadata import PackageNotFoundError, version
+
 
 try:
+    print("BEFORE __init__.py: from importlib.metadata import version")
+    from importlib.metadata import version
+    print("AFTER __init__.py: from importlib.metadata import version")
     __version__ = version("metaflow")
-except PackageNotFoundError:
+except:
     # this happens on remote environments since the job package
     # does not have a version
     __version__ = None

--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -187,11 +187,10 @@ for _n in [
         pass
 del globals()["_n"]
 
-# TODO: remove pkg_resources
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = pkg_resources.get_distribution("metaflow").version
+    __version__ = version("metaflow")
 except:
     # this happens on remote environments since the job package
     # does not have a version

--- a/metaflow/__init__.py
+++ b/metaflow/__init__.py
@@ -190,9 +190,7 @@ del globals()["_n"]
 
 
 try:
-    print("BEFORE __init__.py: from importlib.metadata import version")
     from importlib.metadata import version
-    print("AFTER __init__.py: from importlib.metadata import version")
     __version__ = version("metaflow")
 except:
     # this happens on remote environments since the job package

--- a/metaflow/_vendor/click/decorators.py
+++ b/metaflow/_vendor/click/decorators.py
@@ -281,18 +281,20 @@ def version_option(version=None, *param_decls, **attrs):
             ver = version
             if ver is None:
                 try:
-                    # TODO: remove pkg_resources
-                    import pkg_resources
+                    from importlib.metadata import distributions
                 except ImportError:
                     pass
                 else:
-                    # TODO: remove pkg_resources
-                    for dist in pkg_resources.working_set:
-                        scripts = dist.get_entry_map().get("console_scripts") or {}
-                        for _, entry_point in iteritems(scripts):
-                            if entry_point.module_name == module:
-                                ver = dist.version
-                                break
+                    for dist in distributions():
+                        for entry_point in dist.entry_points:
+                            if entry_point.group == "console_scripts":
+                                # entry_point.value is in format "module.submodule:function"
+                                module_part = entry_point.value.split(':')[0]
+                                if module_part == module:
+                                    ver = dist.version
+                                    break
+                        if ver is not None:
+                            break
                 if ver is None:
                     raise RuntimeError("Could not determine version")
             echo(message % {"prog": prog, "version": ver}, color=ctx.color)

--- a/metaflow/_vendor/click/decorators.py
+++ b/metaflow/_vendor/click/decorators.py
@@ -281,10 +281,12 @@ def version_option(version=None, *param_decls, **attrs):
             ver = version
             if ver is None:
                 try:
+                    # TODO: remove pkg_resources
                     import pkg_resources
                 except ImportError:
                     pass
                 else:
+                    # TODO: remove pkg_resources
                     for dist in pkg_resources.working_set:
                         scripts = dist.get_entry_map().get("console_scripts") or {}
                         for _, entry_point in iteritems(scripts):

--- a/metaflow/_vendor/click/decorators.py
+++ b/metaflow/_vendor/click/decorators.py
@@ -283,7 +283,8 @@ def version_option(version=None, *param_decls, **attrs):
                 try:
                     import pkg_resources
                 except ImportError:
-                    pass
+                    print("pkg_resources not found; upgrade to importlib.resources instead")
+                    raise
                 else:
                     for dist in pkg_resources.working_set:
                         scripts = dist.get_entry_map().get("console_scripts") or {}
@@ -292,7 +293,7 @@ def version_option(version=None, *param_decls, **attrs):
                                 ver = dist.version
                                 break
                 if ver is None:
-                    raise RuntimeError("Could not determine version; pkg_resources not found; upgrade to importlib.resources instead")
+                    raise RuntimeError("Could not determine version")
             echo(message % {"prog": prog, "version": ver}, color=ctx.color)
             ctx.exit()
 

--- a/metaflow/_vendor/click/decorators.py
+++ b/metaflow/_vendor/click/decorators.py
@@ -281,22 +281,18 @@ def version_option(version=None, *param_decls, **attrs):
             ver = version
             if ver is None:
                 try:
-                    print("BEFORE decorators.py: from importlib.metadata import distributions")
-                    from importlib.metadata import distributions
-                    print("AFTER decorators.py: from importlib.metadata import distributions")
+                    import pkg_resources
                 except ImportError:
+                    print("pkg_resources not found; upgrade to importlib.resources instead")
+                    raise
                     pass
                 else:
-                    for dist in distributions():
-                        for entry_point in dist.entry_points:
-                            if entry_point.group == "console_scripts":
-                                # entry_point.value is in format "module.submodule:function"
-                                module_part = entry_point.value.split(':')[0]
-                                if module_part == module:
-                                    ver = dist.version
-                                    break
-                        if ver is not None:
-                            break
+                    for dist in pkg_resources.working_set:
+                        scripts = dist.get_entry_map().get("console_scripts") or {}
+                        for _, entry_point in iteritems(scripts):
+                            if entry_point.module_name == module:
+                                ver = dist.version
+                                break
                 if ver is None:
                     raise RuntimeError("Could not determine version")
             echo(message % {"prog": prog, "version": ver}, color=ctx.color)

--- a/metaflow/_vendor/click/decorators.py
+++ b/metaflow/_vendor/click/decorators.py
@@ -283,8 +283,6 @@ def version_option(version=None, *param_decls, **attrs):
                 try:
                     import pkg_resources
                 except ImportError:
-                    print("pkg_resources not found; upgrade to importlib.resources instead")
-                    raise
                     pass
                 else:
                     for dist in pkg_resources.working_set:
@@ -294,7 +292,7 @@ def version_option(version=None, *param_decls, **attrs):
                                 ver = dist.version
                                 break
                 if ver is None:
-                    raise RuntimeError("Could not determine version")
+                    raise RuntimeError("Could not determine version; pkg_resources not found; upgrade to importlib.resources instead")
             echo(message % {"prog": prog, "version": ver}, color=ctx.color)
             ctx.exit()
 

--- a/metaflow/_vendor/click/decorators.py
+++ b/metaflow/_vendor/click/decorators.py
@@ -281,7 +281,9 @@ def version_option(version=None, *param_decls, **attrs):
             ver = version
             if ver is None:
                 try:
+                    print("BEFORE decorators.py: from importlib.metadata import distributions")
                     from importlib.metadata import distributions
+                    print("AFTER decorators.py: from importlib.metadata import distributions")
                 except ImportError:
                     pass
                 else:

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -4,9 +4,7 @@ import os
 import sys
 import types
 
-print("BEFORE metaflow_config.py: from importlib.metadata import version")
 from importlib.metadata import version
-print("AFTER metaflow_config.py: from importlib.metadata import version")
 
 from metaflow.exception import MetaflowException
 

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -4,7 +4,9 @@ import os
 import sys
 import types
 
+print("BEFORE metaflow_config.py: from importlib.metadata import version")
 from importlib.metadata import version
+print("AFTER metaflow_config.py: from importlib.metadata import version")
 
 from metaflow.exception import MetaflowException
 

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -305,7 +305,6 @@ logger = logging.getLogger()
 logger.addFilter(Filter())
 
 
-# TODO: remove pkg_resources
 def get_version(pkg):
     return version(pkg)
 

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -4,6 +4,7 @@ import os
 import sys
 import types
 
+# TODO: remove pkg_resources
 import pkg_resources
 
 from metaflow.exception import MetaflowException
@@ -305,6 +306,7 @@ logger = logging.getLogger()
 logger.addFilter(Filter())
 
 
+# TODO: remove pkg_resources
 def get_version(pkg):
     return pkg_resources.get_distribution(pkg).version
 

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -4,8 +4,7 @@ import os
 import sys
 import types
 
-# TODO: remove pkg_resources
-import pkg_resources
+from importlib.metadata import version
 
 from metaflow.exception import MetaflowException
 
@@ -308,7 +307,7 @@ logger.addFilter(Filter())
 
 # TODO: remove pkg_resources
 def get_version(pkg):
-    return pkg_resources.get_distribution(pkg).version
+    return version(pkg)
 
 
 # PINNED_CONDA_LIBS are the libraries that metaflow depends on for execution


### PR DESCRIPTION
Remove pkg_resources because it is deprecated and is causing issues.

I confirmed that the lines of code/functions that formerly had `import pkg_resources` in `metaflow/metaflow_config.py` and `metaflow/__init__.py` are being reached, and that they are no longer causing the pkg_resources warning. 

See [this workflow](https://argo-server.int.sandbox-k8s.zg-aip.net/argo-ui/archived-workflows/zap-aip-synthetic-tests-sandbox/a9d0adaf-2ad3-446f-9853-eedefc5d498f)'s output, which contains [since-deleted print statements](https://github.com/zillow/metaflow/pull/321/commits/7379e05fb0f49eb38825b0ebaaaa9b6b2d4c4d4f):

```
BEFORE metaflow_config.py: from importlib.metadata import version
AFTER metaflow_config.py: from importlib.metadata import version
BEFORE metaflow_config.py: from importlib.metadata import version
AFTER metaflow_config.py: from importlib.metadata import version
BEFORE __init__.py: from importlib.metadata import version
AFTER __init__.py: from importlib.metadata import version
BEFORE __init__.py: from importlib.metadata import version
AFTER __init__.py: from importlib.metadata import version
```

I also tested the latest version of metaflow in [this commit](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/synthetic-tests/aip-synthetic-tests/-/merge_requests/62/diffs?commit_id=72dd2b6295eaadf1c2f7e1e4f9afd6c32dee31fb) to the synthetic tests.
