### PR TITLE
AIP-9738:  Update deprecated dependencies to suport Python 3.12

### DIFF
--- a/kfp/components/_components.py
+++ b/kfp/components/_components.py
@@ -547,8 +547,16 @@ def _resolve_command_line_and_paths(
         elif isinstance(arg, IfPlaceholder):
             arg = arg.if_structure
             condition_result = expand_command_part(arg.condition)
-            from distutils.util import strtobool
-            condition_result_bool = condition_result and strtobool(
+            # Replacement for distutils.util.strtobool (removed in Python 3.12)
+            def _strtobool(val):
+                val_lower = str(val).lower()
+                if val_lower in ('y', 'yes', 't', 'true', 'on', '1'):
+                    return True
+                elif val_lower in ('n', 'no', 'f', 'false', 'off', '0'):
+                    return False
+                else:
+                    raise ValueError(f"invalid truth value {val!r}")
+            condition_result_bool = condition_result and _strtobool(
                 condition_result
             )  #Python gotcha: bool('False') == True; Need to use strtobool; Also need to handle None and []
             result_node = arg.then_value if condition_result_bool else arg.else_value

--- a/kfp/components/_data_passing.py
+++ b/kfp/components/_data_passing.py
@@ -69,8 +69,14 @@ def _serialize_bool(bool_value: bool) -> str:
 
 
 def _deserialize_bool(s) -> bool:
-    from distutils.util import strtobool
-    return strtobool(s) == 1
+    # Replacement for distutils.util.strtobool (removed in Python 3.12)
+    s_lower = str(s).lower()
+    if s_lower in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    elif s_lower in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {s!r}")
 
 
 _bool_deserializer_definitions = inspect.getsource(_deserialize_bool)

--- a/kfp/components/_python_op.py
+++ b/kfp/components/_python_op.py
@@ -1114,9 +1114,9 @@ def _module_is_builtin_or_standard(module_name: str) -> bool:
     import sys
     if module_name in sys.builtin_module_names:
         return True
-    import distutils.sysconfig as sysconfig
+    import sysconfig
     import os
-    std_lib_dir = sysconfig.get_python_lib(standard_lib=True)
+    std_lib_dir = sysconfig.get_path("stdlib")
     module_name_parts = module_name.split('.')
     expected_module_path = os.path.join(std_lib_dir, *module_name_parts)
     return os.path.exists(expected_module_path) or os.path.exists(

--- a/kfp/components/type_annotation_utils.py
+++ b/kfp/components/type_annotation_utils.py
@@ -58,7 +58,7 @@ def get_short_type_name(type_name: str) -> str:
     Returns:
       The short form type name or the original name if pattern doesn't match.
     """
-    match = re.match('(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
+    match = re.match(r'(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
     if match:
         return match.group('type')
     else:

--- a/kfp/dsl/_ops_group.py
+++ b/kfp/dsl/_ops_group.py
@@ -69,7 +69,7 @@ class OpsGroup(object):
         if name is None:
             return None
         name_pattern = '^' + (group_type + '-' + name + '-').replace(
-            '_', '-') + '[\d]+$'
+            '_', '-') + r'[\d]+$'
         for ops_group_already_in_pipeline in _pipeline.Pipeline.get_default_pipeline(
         ).groups:
             import re

--- a/kfp/v2/components/types/type_annotations.py
+++ b/kfp/v2/components/types/type_annotations.py
@@ -149,7 +149,7 @@ def get_short_type_name(type_name: str) -> str:
     Returns:
       The short form type name or the original name if pattern doesn't match.
     """
-    match = re.match('(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
+    match = re.match(r'(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
     if match:
         return match.group('type')
     else:

--- a/metaflow/R.py
+++ b/metaflow/R.py
@@ -1,5 +1,5 @@
 import os
-import imp
+import importlib.util
 from tempfile import NamedTemporaryFile
 
 from .util import to_bytes
@@ -100,7 +100,9 @@ def run(
     full_cmdline[0] = os.path.basename(full_cmdline[0])
     with NamedTemporaryFile(prefix="metaflowR.", delete=False) as tmp:
         tmp.write(to_bytes(flow_script))
-    module = imp.load_source("metaflowR", tmp.name)
+    spec = importlib.util.spec_from_file_location("metaflowR", tmp.name)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
     flow = module.FLOW(use_cli=False)
 
     from . import exception

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -121,7 +121,7 @@ class Decorator(object):
             name, attrspec = top
             attrs = dict(
                 map(lambda x: x.strip(), a.split("="))
-                for a in re.split(""",(?=[\s\w]+=)""", attrspec.strip("\"'"))
+                for a in re.split(r""",(?=[\s\w]+=)""", attrspec.strip("\"'"))
             )
             return cls(attributes=attrs)
 

--- a/metaflow/metadata/util.py
+++ b/metaflow/metadata/util.py
@@ -1,8 +1,7 @@
 from io import BytesIO
 import os
+import shutil
 import tarfile
-
-from distutils.dir_util import copy_tree
 
 from metaflow import util
 from metaflow.datastore.local_storage import LocalStorage
@@ -28,8 +27,8 @@ def sync_local_metadata_from_datastore(metadata_local_dir, task_ds):
     with util.TempDir() as td:
         with tarfile.open(fileobj=BytesIO(tarball), mode="r:gz") as tar:
             tar.extractall(td)
-        copy_tree(
+        shutil.copytree(
             os.path.join(td, metadata_local_dir),
             LocalStorage.get_datastore_root_from_config(echo_none),
-            update=True,
+            dirs_exist_ok=True,
         )

--- a/metaflow/mflog/mflog.py
+++ b/metaflow/mflog/mflog.py
@@ -9,7 +9,7 @@ from metaflow.util import to_bytes, to_fileobj, to_unicode
 
 VERSION = b"0"
 
-RE = b"(\[!)?" b"\[MFLOG\|" b"(0)\|" b"(.+?)Z\|" b"(.+?)\|" b"(.+?)\]" b"(.*)"
+RE = rb"(\[!)?" rb"\[MFLOG\|" rb"(0)\|" rb"(.+?)Z\|" rb"(.+?)\|" rb"(.+?)\]" rb"(.*)"
 
 # the RE groups defined above must match the MFLogline fields below
 # except utc_timestamp, which is filled in by the parser based on utc_tstamp_str

--- a/metaflow/plugins/aws/batch/batch_cli.py
+++ b/metaflow/plugins/aws/batch/batch_cli.py
@@ -4,8 +4,6 @@ import sys
 import time
 import traceback
 
-from distutils.dir_util import copy_tree
-
 from metaflow import util
 from metaflow import R
 from metaflow.exception import CommandException, METAFLOW_EXIT_DISALLOW_RETRY

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -3,7 +3,7 @@ from metaflow._vendor import click
 from hashlib import sha1
 import json
 import re
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from metaflow import current, decorators, parameters, JSONType
 from metaflow.metaflow_config import SFN_STATE_MACHINE_PREFIX
@@ -184,7 +184,7 @@ def check_metadata_service_version(obj):
     version = metadata.version()
     if version == "local":
         return
-    elif version is not None and LooseVersion(version) >= LooseVersion("2.0.2"):
+    elif version is not None and Version(version) >= Version("2.0.2"):
         # Metaflow metadata service needs to be at least at version 2.0.2
         return
     else:

--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -15,7 +15,7 @@ from metaflow.util import get_username, to_bytes, to_unicode
 from .step_functions import StepFunctions
 from .production_token import load_token, store_token, new_token
 
-VALID_NAME = re.compile("[^a-zA-Z0-9_\-\.]")
+VALID_NAME = re.compile(r"[^a-zA-Z0-9_\-\.]")
 
 
 class IncorrectProductionToken(MetaflowException):

--- a/metaflow/plugins/conda/conda.py
+++ b/metaflow/plugins/conda/conda.py
@@ -3,7 +3,7 @@ import os
 import json
 import subprocess
 import time
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from metaflow.exception import MetaflowException
 from metaflow.metaflow_config import CONDA_DEPENDENCY_RESOLVER
@@ -40,7 +40,7 @@ class Conda(object):
         # Check for a minimum version for conda when conda or mamba is used
         # for dependency resolution.
         if dependency_solver == "conda" or dependency_solver == "mamba":
-            if LooseVersion(self._info()["conda_version"]) < LooseVersion("4.6.0"):
+            if Version(self._info()["conda_version"]) < Version("4.6.0"):
                 msg = "Conda version 4.6.0 or newer is required."
                 if dependency_solver == "mamba":
                     msg += " Visit https://mamba.readthedocs.io/en/latest/installation.html for installation instructions."

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -2,7 +2,7 @@ import os
 import requests
 import time
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from metaflow.exception import MetaflowException
 from metaflow.metaflow_config import (
@@ -105,7 +105,7 @@ class ServiceMetadataProvider(MetadataProvider):
             # single run heartbeat or a single task heartbeat can be started
             raise Exception("heartbeat already started")
         # start sidecar
-        if self.version() is None or LooseVersion(self.version()) < LooseVersion(
+        if self.version() is None or Version(self.version()) < Version(
             "2.0.4"
         ):
             # if old version of the service is running
@@ -175,9 +175,9 @@ class ServiceMetadataProvider(MetadataProvider):
         if attempt is not None:
             if cls._supports_attempt_gets is None:
                 version = cls._version(None)
-                cls._supports_attempt_gets = version is not None and LooseVersion(
+                cls._supports_attempt_gets = version is not None and Version(
                     version
-                ) >= LooseVersion("2.0.6")
+                ) >= Version("2.0.6")
             if not cls._supports_attempt_gets:
                 raise ServiceException(
                     "Getting specific attempts of Tasks or Artifacts requires "

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "requests",
         "boto3",
         "pylint",
+        "packaging",  # required for Python 3.12 (replaces distutils.version)
         # required for KFP
         "Deprecated>=1.2.7,<2",
         "docstring-parser>=0.7.3,<1",


### PR DESCRIPTION
Fixed all deprecation when running under Python 3.12 base image to make sure metaflow package is installable and importable in Python 3.12 environments.