### PR TITLE
ci: add environment declarations for scoped CI variables

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,6 +157,8 @@ test:sandbox:
   extends:
     - .devex_sandbox_eks
     - .test
+  environment:
+    name: sandbox
   variables:
     ARGO_RUN_URL_PREFIX: "https://argo-server.int.sandbox-k8s.zg-aip.net/"
     METAFLOW_RUN_URL_PREFIX: "https://metaflow.int.sandbox-k8s.zg-aip.net"
@@ -171,6 +173,8 @@ test:internal:
   extends: 
     - .devex_internal_eks
     - .test
+  environment:
+    name: internal
   variables:
     ARGO_RUN_URL_PREFIX: "https://argo-server.int.dev-k8s.zg-aip.net/"
     METAFLOW_RUN_URL_PREFIX: "https://metaflow.int.dev-k8s.zg-aip.net"
@@ -184,6 +188,8 @@ test:nonprod:
   extends: 
     - .devex_nonprod_eks
     - .test
+  environment:
+    name: nonprod
   variables:
     ARGO_RUN_URL_PREFIX: "https://argo-server.int.stage-k8s.zg-aip.net/"
     METAFLOW_RUN_URL_PREFIX: "https://metaflow.int.stage-k8s.zg-aip.net"
@@ -197,6 +203,8 @@ test:prod:
   extends: 
   - .devex_prod_eks
   - .test
+  environment:
+    name: prod
   variables:
     ARGO_RUN_URL_PREFIX: "https://argo-server.int.prod-k8s.zg-aip.net/"
     METAFLOW_RUN_URL_PREFIX: "https://metaflow.int.prod-k8s.zg-aip.net"


### PR DESCRIPTION
## Summary
Add `environment:` declarations to CI test jobs to enable environment-scoped variable configuration in GitLab CI/CD.

## Changes
- Add `environment: name: <env>` to test jobs: sandbox, internal, nonprod, prod

## Why
This allows CI/CD variables (like datastore paths and service URLs) to be configured per-environment in GitLab settings, rather than using a single value for all environments. Each test environment can now have its own configuration.

## Impact
- No change to test behavior
- No change to job execution
- Purely CI/CD configuration metadata

## Testing
- Existing tests continue to work unchanged
- Environment-scoped variables will be picked up once configured in GitLab CI/CD settings