### PR TITLE
AIP-9999: Auxiliary changes for CVE fixes

### DIFF
--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -130,13 +130,15 @@ def _step_cli(
         sys.stderr.write("[aip_metaflow_step] cwd=%r\n" % os.getcwd())
         sys.stderr.flush()
 
-        # Export user-defined parameters into runtime environment
-        param_file = "parameters.sh"
+        # Export user-defined parameters into runtime environment.
+        # Use /tmp so the file is always writable regardless of cwd (avoids permission errors
+        # when cwd is a project dir that may be root-owned in the image or mounted read-only).
+        param_file = "/tmp/parameters.sh"
         # TODO: move to AIP plugin
         export_params = (
             "python -m "
             "metaflow.plugins.aip.set_batch_environment "
-            "parameters --output_file %s && . `pwd`/%s" % (param_file, param_file)
+            "parameters --output_file %s && . %s" % (param_file, param_file)
         )
         params: List[str] = entrypoint + [
             "--quiet",

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import pathlib
+import sys
 import time
 from subprocess import Popen
 from typing import Dict, List
@@ -124,6 +125,10 @@ def _step_cli(
     if step_name == "start":
         # We need a separate unique ID for the special _parameters task
         task_id_params = "1-params"
+
+        # Debug: cwd when building the parameters command (remove after resolving parameters.sh permission issue)
+        sys.stderr.write("[aip_metaflow_step] cwd=%r\n" % os.getcwd())
+        sys.stderr.flush()
 
         # Export user-defined parameters into runtime environment
         param_file = "parameters.sh"

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -126,10 +126,6 @@ def _step_cli(
         # We need a separate unique ID for the special _parameters task
         task_id_params = "1-params"
 
-        # Debug: cwd when building the parameters command (remove after resolving parameters.sh permission issue)
-        sys.stderr.write("[aip_metaflow_step] cwd=%r\n" % os.getcwd())
-        sys.stderr.flush()
-
         # Export user-defined parameters into runtime environment.
         # Use /tmp so the file is always writable regardless of cwd (avoids permission errors
         # when cwd is a project dir that may be root-owned in the image or mounted read-only).

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pathlib
 import time
+import uuid
 from subprocess import Popen
 from typing import Dict, List
 
@@ -128,7 +129,9 @@ def _step_cli(
         # Export user-defined parameters into runtime environment.
         # Use /tmp so the file is always writable regardless of cwd (avoids permission errors
         # when cwd is a project dir that may be root-owned in the image or mounted read-only).
-        param_file = "/tmp/parameters.sh"
+        # Use run_id + UUID so the path is unique across runs and steps (avoids conflicts when
+        # multiple workflows run on the same host, e.g. a notebook instance).
+        param_file = f"/tmp/parameters-{run_id}-{uuid.uuid4().hex}.sh"
         # TODO: move to AIP plugin
         export_params = (
             "python -m "

--- a/metaflow/plugins/aip/aip_metaflow_step.py
+++ b/metaflow/plugins/aip/aip_metaflow_step.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import pathlib
-import sys
 import time
 from subprocess import Popen
 from typing import Dict, List

--- a/metaflow/plugins/aip/aip_step_init.py
+++ b/metaflow/plugins/aip/aip_step_init.py
@@ -61,7 +61,7 @@ def save_step_environment_variables(
         with open(STEP_ENVIRONMENT_VARIABLES, "w") as file:
             for key, value in environment_exports.items():
                 file.write(f"export {key}={value}\n")
-        os.chmod(STEP_ENVIRONMENT_VARIABLES, 644)
+        os.chmod(STEP_ENVIRONMENT_VARIABLES, 0o644)
 
 
 def _compute_input_paths(

--- a/metaflow/plugins/aip/set_batch_environment.py
+++ b/metaflow/plugins/aip/set_batch_environment.py
@@ -26,7 +26,7 @@ def parameters(output_file: str):
             dumps = json.dumps(params[k])
             value = f"'{dumps}'" if isinstance(params[k], dict) else dumps
             f.write(f"export METAFLOW_INIT_{normalized_name}={value}\n")
-    os.chmod(output_file, 509)
+    os.chmod(output_file, 0o755)
 
 
 if __name__ == "__main__":

--- a/metaflow/plugins/aip/set_batch_environment.py
+++ b/metaflow/plugins/aip/set_batch_environment.py
@@ -1,7 +1,5 @@
 import json
 import os
-import stat
-import sys
 
 from metaflow._vendor import click
 
@@ -19,27 +17,6 @@ def parameters(output_file: str):
     input_parameters = {param["name"]: param["value"] for param in metaflow_parameters}
     params = json.loads(os.environ.get("METAFLOW_DEFAULT_PARAMETERS", "{}"))
     params.update(input_parameters)
-    # Debug: where we're writing and whether it's writable (remove after resolving parameters.sh permission issue)
-    _cwd = os.getcwd()
-    _abs = os.path.abspath(output_file)
-    _dir = os.path.dirname(_abs)
-    try:
-        _uid, _gid = os.getuid(), os.getgid()
-    except AttributeError:
-        _uid = _gid = None  # Windows
-    _dir_exists = os.path.exists(_dir)
-    _dir_writable = os.access(_dir, os.W_OK)
-    sys.stderr.write(
-        "[set_batch_environment] cwd=%r output_file=%r abspath=%r dir_exists=%s dir_writable=%s process_uid=%s process_gid=%s\n"
-        % (_cwd, output_file, _abs, _dir_exists, _dir_writable, _uid, _gid)
-    )
-    if _dir_exists:
-        _dir_stat = os.stat(_dir)
-        sys.stderr.write(
-            "[set_batch_environment] dir %r mode=%s (oct: %s) uid=%s gid=%s\n"
-            % (_dir, _dir_stat.st_mode, oct(stat.S_IMODE(_dir_stat.st_mode)), _dir_stat.st_uid, _dir_stat.st_gid)
-        )
-    sys.stderr.flush()
     with open(output_file, "w") as f:
         for k in params:
             # Replace `-` with `_` is parameter names since `-` isn't an

--- a/metaflow/plugins/aip/set_batch_environment.py
+++ b/metaflow/plugins/aip/set_batch_environment.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 from metaflow._vendor import click
 
@@ -17,6 +18,15 @@ def parameters(output_file: str):
     input_parameters = {param["name"]: param["value"] for param in metaflow_parameters}
     params = json.loads(os.environ.get("METAFLOW_DEFAULT_PARAMETERS", "{}"))
     params.update(input_parameters)
+    # Debug: where we're writing and whether it's writable (remove after resolving parameters.sh permission issue)
+    _cwd = os.getcwd()
+    _abs = os.path.abspath(output_file)
+    _dir = os.path.dirname(_abs)
+    sys.stderr.write(
+        "[set_batch_environment] cwd=%r output_file=%r abspath=%r dir_exists=%s dir_writable=%s\n"
+        % (_cwd, output_file, _abs, os.path.exists(_dir), os.access(_dir, os.W_OK))
+    )
+    sys.stderr.flush()
     with open(output_file, "w") as f:
         for k in params:
             # Replace `-` with `_` is parameter names since `-` isn't an

--- a/metaflow/plugins/aip/set_batch_environment.py
+++ b/metaflow/plugins/aip/set_batch_environment.py
@@ -1,5 +1,6 @@
 import json
 import os
+import stat
 import sys
 
 from metaflow._vendor import click
@@ -22,10 +23,22 @@ def parameters(output_file: str):
     _cwd = os.getcwd()
     _abs = os.path.abspath(output_file)
     _dir = os.path.dirname(_abs)
+    try:
+        _uid, _gid = os.getuid(), os.getgid()
+    except AttributeError:
+        _uid = _gid = None  # Windows
+    _dir_exists = os.path.exists(_dir)
+    _dir_writable = os.access(_dir, os.W_OK)
     sys.stderr.write(
-        "[set_batch_environment] cwd=%r output_file=%r abspath=%r dir_exists=%s dir_writable=%s\n"
-        % (_cwd, output_file, _abs, os.path.exists(_dir), os.access(_dir, os.W_OK))
+        "[set_batch_environment] cwd=%r output_file=%r abspath=%r dir_exists=%s dir_writable=%s process_uid=%s process_gid=%s\n"
+        % (_cwd, output_file, _abs, _dir_exists, _dir_writable, _uid, _gid)
     )
+    if _dir_exists:
+        _dir_stat = os.stat(_dir)
+        sys.stderr.write(
+            "[set_batch_environment] dir %r mode=%s (oct: %s) uid=%s gid=%s\n"
+            % (_dir, _dir_stat.st_mode, oct(stat.S_IMODE(_dir_stat.st_mode)), _dir_stat.st_uid, _dir_stat.st_gid)
+        )
     sys.stderr.flush()
     with open(output_file, "w") as f:
         for k in params:

--- a/metaflow/plugins/aws/aws_utils.py
+++ b/metaflow/plugins/aws/aws_utils.py
@@ -4,7 +4,7 @@ from metaflow.exception import MetaflowException
 
 
 def get_docker_registry(image_uri):
-    """
+    r"""
     Explanation:
         (.+?(?:[:.].+?)\/)? - [GROUP 0] REGISTRY
             .+?                 - A registry must start with at least one character


### PR DESCRIPTION
### Summary
While working on the CVE fixes for CICD v7, I had to make a few changes this repository as well.

### Changes
* Octal literals
Without octal literals, the unix permissions are not set correctly. This causes issues while running flows are CVE fixes, i.e. running with non-root users, such as `/bin/bash: line 1: /tmp/step-environment-variables.sh: Permission denied`.

* Use `/tmp` for `parameters.sh`
Earlier `parameters.sh` was created inside the project directory under `/opt/zillow` and sometimes the process may not have the write permissions, resulting in the following error:
```
  File "/opt/zillow/.venv/lib/python3.12/site-packages/metaflow/plugins/aip/set_batch_environment.py", line 20, in parameters
    with open(output_file, "w") as f:
         ^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: 'parameters.sh'
```
Therefore, the fix is to create `parameters.sh` in a directory which is always writable - `/tmp` is an ideal location.

### Testing
Tested with  a v6 repository [aip-workflow-example](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/integration-tests/aip-workflow-example/-/pipelines/13080192) and a v7 repository [aip-toleration-integration-test](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/integration-tests/aip-toleration-integration-test/-/pipelines/13079249) to ensure the change works in both.