### PR TITLE
AIP-10276 : Backward compatibility to generate Argo URL based on Argo WF Controller version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,7 @@ stages:
         -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN 
         -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION 
         -e ARGO_RUN_URL_PREFIX=$ARGO_RUN_URL_PREFIX
+        -e ARGO_UI_ROUTE_MODE=$ARGO_UI_ROUTE_MODE
         -e METAFLOW_RUN_URL_PREFIX=$METAFLOW_RUN_URL_PREFIX 
         -e METAFLOW_KUBERNETES_NAMESPACE=$METAFLOW_KUBERNETES_NAMESPACE 
         -e METAFLOW_DATASTORE_SYSROOT_S3=$METAFLOW_DATASTORE_SYSROOT_S3 
@@ -161,6 +162,7 @@ test:sandbox:
     name: sandbox
   variables:
     ARGO_RUN_URL_PREFIX: "https://argo-server.int.sandbox-k8s.zg-aip.net/"
+    ARGO_UI_ROUTE_MODE: "auto"
     METAFLOW_RUN_URL_PREFIX: "https://metaflow.int.sandbox-k8s.zg-aip.net"
     METAFLOW_KUBERNETES_NAMESPACE: "metaflow-integration-testing-sandbox"
   rules:
@@ -177,6 +179,7 @@ test:internal:
     name: internal
   variables:
     ARGO_RUN_URL_PREFIX: "https://argo-server.int.dev-k8s.zg-aip.net/"
+    ARGO_UI_ROUTE_MODE: "auto"
     METAFLOW_RUN_URL_PREFIX: "https://metaflow.int.dev-k8s.zg-aip.net"
     METAFLOW_KUBERNETES_NAMESPACE: "metaflow-integration-testing-internal"
   rules:
@@ -192,6 +195,7 @@ test:nonprod:
     name: nonprod
   variables:
     ARGO_RUN_URL_PREFIX: "https://argo-server.int.stage-k8s.zg-aip.net/"
+    ARGO_UI_ROUTE_MODE: "auto"
     METAFLOW_RUN_URL_PREFIX: "https://metaflow.int.stage-k8s.zg-aip.net"
     METAFLOW_KUBERNETES_NAMESPACE: "metaflow-integration-testing-stage"
   rules:
@@ -207,6 +211,7 @@ test:prod:
     name: prod
   variables:
     ARGO_RUN_URL_PREFIX: "https://argo-server.int.prod-k8s.zg-aip.net/"
+    ARGO_UI_ROUTE_MODE: "auto"
     METAFLOW_RUN_URL_PREFIX: "https://metaflow.int.prod-k8s.zg-aip.net"
     METAFLOW_KUBERNETES_NAMESPACE: "metaflow-integration-testing-prod"
   rules:

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -148,10 +148,16 @@ if DEFAULT_CONTAINER_REGISTRY and DEFAULT_CONTAINER_IMAGE:
 else:
     AIP_DEFAULT_CONTAINER_IMAGE = "ghcr.io/zillow/metaflow/metaflow-zillow:2.2"
 AIP_TTL_SECONDS_AFTER_FINISHED = from_conf("AIP_TTL_SECONDS_AFTER_FINISHED", None)
-# Note: `ARGO_RUN_URL_PREFIX` is the URL prefix for ARGO runs on your ARGO cluster. The prefix includes
-# all parts of the URL except the run_id at the end which we append once the run is created.
-# For eg, this would look like: "https://<your-kf-cluster-url>/argo-ui/workflows/
+# ARGO_RUN_URL_PREFIX should contain only the Argo host/root, e.g.
+# https://argo-server.int.stage-k8s.zg-aip.net
+# Route suffixes are appended by get_argo_url() based on ARGO_UI_ROUTE_MODE.
 ARGO_RUN_URL_PREFIX = from_conf("ARGO_RUN_URL_PREFIX", "").rstrip("/")
+# ARGO_UI_ROUTE_MODE selects Argo UI URL shape:
+#   "legacy"  -> /argo-ui/workflows/...?uid=...
+#   "modern"  -> /workflows/...
+#   "auto"    -> probe Argo UI <base href> (fallback: legacy)
+# Defaults to "auto" so clusters can pick the correct route without hardcoding.
+ARGO_UI_ROUTE_MODE = from_conf("ARGO_UI_ROUTE_MODE", "auto")
 METAFLOW_RUN_URL_PREFIX = from_conf("METAFLOW_RUN_URL_PREFIX", "").rstrip("/")
 AIP_MAX_PARALLELISM = int(from_conf("AIP_MAX_PARALLELISM", 10))
 AIP_MAX_RUN_CONCURRENCY = int(from_conf("AIP_MAX_RUN_CONCURRENCY", 10))

--- a/metaflow/plugins/aip/__init__.py
+++ b/metaflow/plugins/aip/__init__.py
@@ -7,6 +7,7 @@ from .argo_utils import (
     get_argo_url,
     get_metaflow_url,
     get_metaflow_run_id,
+    resolve_argo_ui_route_mode,
 )
 
 from .exit_handler_decorator import (

--- a/metaflow/plugins/aip/aip.py
+++ b/metaflow/plugins/aip/aip.py
@@ -37,6 +37,7 @@ from kubernetes.client import (
 
 from metaflow.decorators import FlowDecorator, flow_decorators
 from metaflow.metaflow_config import (
+    ARGO_RUN_URL_PREFIX,
     DATASTORE_SYSROOT_S3,
     AIP_TTL_SECONDS_AFTER_FINISHED,
     AIP_PVC_CREATE_RETRY_COUNT,
@@ -58,6 +59,7 @@ from metaflow.plugins.aip.aip_constants import (
 from metaflow.plugins.aip.aip_decorator import AIPException
 from .accelerator_decorator import AcceleratorDecorator
 from .argo_client import ArgoClient
+from .argo_utils import resolve_argo_ui_route_mode
 from .interruptible_decorator import interruptibleDecorator
 from .aip_foreach_splits import graph_to_task_ids
 from ..aws.batch.batch_decorator import BatchDecorator
@@ -1220,6 +1222,12 @@ class KubeflowPipelines(object):
                     METAFLOW_DATASTORE_SYSROOT_S3=DATASTORE_SYSROOT_S3,
                     METAFLOW_USER=METAFLOW_USER,
                 )
+                # Bake Argo URL settings at create-time so step pods don't HTTP-probe
+                # the Argo UI (unreliable/slow in-cluster and caused FlowTriggeringFlow
+                # end-step timeouts).
+                if ARGO_RUN_URL_PREFIX:
+                    metaflow_configs["ARGO_RUN_URL_PREFIX"] = ARGO_RUN_URL_PREFIX
+                metaflow_configs["ARGO_UI_ROUTE_MODE"] = resolve_argo_ui_route_mode()
 
                 metaflow_step_op: ContainerOp = self._create_metaflow_step_op(
                     node,
@@ -1594,6 +1602,8 @@ class KubeflowPipelines(object):
             ]
             if from_conf(key)
         }
+        # Resolve once at create-time so exit-handler pods reuse the same route mode.
+        env_variables["ARGO_UI_ROUTE_MODE"] = resolve_argo_ui_route_mode()
 
         if self.sqs_role_arn_on_error:
             env_variables["METAFLOW_SQS_ROLE_ARN_ON_ERROR"] = self.sqs_role_arn_on_error
@@ -1625,6 +1635,8 @@ class KubeflowPipelines(object):
             ]
             if from_conf(key)
         }
+        # Resolve once at create-time so exit-handler pods reuse the same route mode.
+        env_variables["ARGO_UI_ROUTE_MODE"] = resolve_argo_ui_route_mode()
 
         if self.notify_on_error:
             env_variables["METAFLOW_NOTIFY_ON_ERROR"] = self.notify_on_error
@@ -1658,6 +1670,8 @@ class KubeflowPipelines(object):
             ]
             if from_conf(key)
         }
+        # Resolve once at create-time so exit-handler pods reuse the same route mode.
+        env_variables["ARGO_UI_ROUTE_MODE"] = resolve_argo_ui_route_mode()
 
         return self._get_user_defined_exit_handler_op(
             udf_handler,

--- a/metaflow/plugins/aip/aip_exit_handler.py
+++ b/metaflow/plugins/aip/aip_exit_handler.py
@@ -47,6 +47,12 @@ def exit_handler(
 
     env_variables: Dict[str, str] = json.loads(env_variables_json)
 
+    # Apply create-time Argo URL settings so get_argo_url() uses the resolved route mode.
+    for key in ("ARGO_RUN_URL_PREFIX", "ARGO_UI_ROUTE_MODE"):
+        value = env_variables.get(key)
+        if value:
+            os.environ[key] = value
+
     def get_env(name, default=None) -> str:
         return env_variables.get(name, os.environ.get(name, default=default))
 

--- a/metaflow/plugins/aip/aip_udf_exit_handler.py
+++ b/metaflow/plugins/aip/aip_udf_exit_handler.py
@@ -39,6 +39,12 @@ def invoke_user_defined_exit_handler(
 
     env_variables: Dict[str, str] = json.loads(env_variables_json)
 
+    # Apply create-time Argo URL settings so get_argo_url() uses the resolved route mode.
+    for key in ("ARGO_RUN_URL_PREFIX", "ARGO_UI_ROUTE_MODE"):
+        value = env_variables.get(key)
+        if value:
+            os.environ[key] = value
+
     def get_env(name, default=None) -> str:
         return env_variables.get(name, os.environ.get(name, default=default))
 

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -1,10 +1,15 @@
 import math
+import os
+import re
+import sys
 import time
 import datetime
 from typing import Optional, Union, Dict, Any, Tuple, Callable
+from urllib.request import urlopen
 
 from metaflow.metaflow_config import (
     ARGO_RUN_URL_PREFIX,
+    ARGO_UI_ROUTE_MODE,
     METAFLOW_RUN_URL_PREFIX,
     KUBERNETES_NAMESPACE,
 )
@@ -14,6 +19,15 @@ from metaflow.plugins.aip.aip_utils import _get_aip_logger
 
 
 logger = _get_aip_logger()
+
+# Cached route mode after first resolution (explicit or detected).
+_resolved_argo_ui_route_mode: Optional[str] = None
+
+
+def _log_argo_route(message: str) -> None:
+    """Log to logger and stderr so messages show up in CI (Metaflow echo uses stderr)."""
+    logger.info(message)
+    print(f"[argo_ui_route] {message}", file=sys.stderr, flush=True)
 
 
 class ArgoHelper:
@@ -339,13 +353,86 @@ def get_metaflow_run_id(argo_run_uid: str):
     )
 
 
+def _detect_argo_ui_route_via_base_href() -> Optional[str]:
+    """
+    Probe Argo UI index HTML for <base href="...">.
+
+    No cluster RBAC required — only needs network access to ARGO_RUN_URL_PREFIX.
+    Returns "legacy" when href contains argo-ui, otherwise "modern".
+    """
+    base = os.environ.get("ARGO_RUN_URL_PREFIX", ARGO_RUN_URL_PREFIX).rstrip("/")
+    if not base:
+        return None
+    try:
+        with urlopen(base + "/", timeout=5) as resp:
+            html = resp.read(2048).decode("utf-8", errors="replace")
+    except Exception as exc:
+        _log_argo_route(f"Argo UI base-href probe failed for {base}/: {exc}")
+        return None
+
+    match = re.search(r'<base\s+href="([^"]+)"', html, flags=re.IGNORECASE)
+    if not match:
+        _log_argo_route("Argo UI HTML had no <base href>; cannot infer route mode")
+        return None
+
+    href = match.group(1).strip()
+    _log_argo_route(f"Argo UI <base href>={href!r}")
+    if "argo-ui" in href:
+        return "legacy"
+    # Typical modern root base href is "/" .
+    return "modern"
+
+
+def resolve_argo_ui_route_mode() -> str:
+    """
+    Resolve Argo UI route mode.
+
+    Precedence:
+      1. Explicit ARGO_UI_ROUTE_MODE=legacy|modern
+      2. ARGO_UI_ROUTE_MODE=auto (default): probe Argo UI <base href>
+      3. Fallback to legacy when detection fails
+    """
+    global _resolved_argo_ui_route_mode
+    if _resolved_argo_ui_route_mode is not None:
+        return _resolved_argo_ui_route_mode
+
+    configured = (
+        os.environ.get("ARGO_UI_ROUTE_MODE", ARGO_UI_ROUTE_MODE) or "auto"
+    ).strip().lower()
+
+    if configured in ("legacy", "modern"):
+        _log_argo_route(f"Using explicit ARGO_UI_ROUTE_MODE={configured}")
+        _resolved_argo_ui_route_mode = configured
+        return _resolved_argo_ui_route_mode
+
+    _log_argo_route("ARGO_UI_ROUTE_MODE=auto; probing Argo UI <base href>")
+    href_mode = _detect_argo_ui_route_via_base_href()
+    if href_mode in ("legacy", "modern"):
+        _log_argo_route(f"Using ARGO_UI_ROUTE_MODE={href_mode} from <base href>")
+        _resolved_argo_ui_route_mode = href_mode
+        return _resolved_argo_ui_route_mode
+
+    _log_argo_route(
+        "ARGO_UI_ROUTE_MODE=auto but base-href detection failed; defaulting to legacy"
+    )
+    _resolved_argo_ui_route_mode = "legacy"
+    return _resolved_argo_ui_route_mode
+
+
 def get_argo_url(
     argo_run_id: str,
     kubernetes_namespace: str,
     argo_workflow_uid: str,
 ):
-    argo_ui_url = f"{ARGO_RUN_URL_PREFIX}/workflows/{kubernetes_namespace}/{argo_run_id}?uid={argo_workflow_uid}"
-    return argo_ui_url
+    route_mode = resolve_argo_ui_route_mode()
+    base = os.environ.get("ARGO_RUN_URL_PREFIX", ARGO_RUN_URL_PREFIX).rstrip("/")
+
+    if route_mode == "modern":
+        return f"{base}/workflows/{kubernetes_namespace}/{argo_run_id}?uid={argo_workflow_uid}"
+
+    return (
+        f"{base}/argo-ui/workflows/{kubernetes_namespace}/{argo_run_id}?uid={argo_workflow_uid}"
+    )
 
 
 def get_metaflow_url(flow_name: str, argo_run_id: str):

--- a/metaflow/plugins/aip/argo_utils.py
+++ b/metaflow/plugins/aip/argo_utils.py
@@ -344,7 +344,7 @@ def get_argo_url(
     kubernetes_namespace: str,
     argo_workflow_uid: str,
 ):
-    argo_ui_url = f"{ARGO_RUN_URL_PREFIX}/argo-ui/workflows/{kubernetes_namespace}/{argo_run_id}?uid={argo_workflow_uid}"
+    argo_ui_url = f"{ARGO_RUN_URL_PREFIX}/workflows/{kubernetes_namespace}/{argo_run_id}?uid={argo_workflow_uid}"
     return argo_ui_url
 
 

--- a/metaflow/plugins/aip/tests/flows/flow_triggering_flow.py
+++ b/metaflow/plugins/aip/tests/flows/flow_triggering_flow.py
@@ -146,9 +146,17 @@ class FlowTriggeringFlow(FlowSpec):
                 },
             )
             logger.info(f"{run_id=}, {run_uid=}")
-            logger.info(
-                f"{get_argo_url(run_id, self.kubernetes_namespace, run_uid)=}"
-            )
+            argo_url = get_argo_url(run_id, self.kubernetes_namespace, run_uid)
+            logger.info(f"{argo_url=}")
+
+            # Assert URL shape from the generated URL (create-time route mode is
+            # baked into step env; avoid a second live Argo UI probe in-pod).
+            if "/argo-ui/" in argo_url:
+                assert "/argo-ui/workflows/" in argo_url
+                assert f"?uid={run_uid}" in argo_url
+            else:
+                assert "/workflows/" in argo_url
+                assert "?uid=" not in argo_url
 
             logger.info("Testing timeout exception for wait_for_kfp_run_completion")
             try:


### PR DESCRIPTION
## Summary
### Adds backward-compatible Argo workflow URL generation for both legacy and modern Argo UI route shapes ([AIP-10276](https://zillowgroup.atlassian.net/browse/AIP-10276), related to [AIP-10272](https://zillowgroup.atlassian.net/browse/AIP-10272)).

get_argo_url() now supports two URL formats via ARGO_UI_ROUTE_MODE:
- legacy → {host}/argo-ui/workflows/{ns}/{run_id}?uid={uid}
- modern → {host}/workflows/{ns}/{run_id}

ARGO_UI_ROUTE_MODE=auto (default) probes the Argo UI HTML <base href> on ARGO_RUN_URL_PREFIX:
- /argo-ui/ → legacy
- / (or other non-argo-ui href) → modern
- probe failure → safe fallback to legacy

Explicit legacy / modern still override auto-detection.
- Create-time resolved mode + ARGO_RUN_URL_PREFIX are baked into step metaflow_configs and exit-handler env so runtime pods do not need to re-probe the Argo UI.
- Callers (aip_cli.py, exit handlers) stay unchanged — they already use get_argo_url().

#### Testing 
- Added same changes in [feature branch](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/sdks/zillow-metaflow/-/compare/feature%2Faip...abhijeets%2FAIP-10276?from_project_id=20575) of zillow-metaflow gitlab repository and tested URL generation in Integration tests review job
- Tested with newer Argo version 3.7.15 and [integration tests](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/sdks/zillow-metaflow/-/jobs/111886779#L473) are passed with correct Argo URL.
- Tested with older Argo version 3.4.16 and [integration test](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/sdks/zillow-metaflow/-/jobs/111890330#L230) has generated proper Argo URL.

#### Why this change is needed?
The Argo server was migrated so that the workflow UI is now served directly at
`https://<argo-server-host>/workflows/...` — the legacy `/argo-ui/` path segment
no longer exists. The CI variables in `.gitlab-ci.yml` were already updated to
point `ARGO_RUN_URL_PREFIX` at the bare host (e.g.
`https://argo-server.int.sandbox-k8s.zg-aip.net/`), so `get_argo_url()` was
producing broken links of the form
